### PR TITLE
Enhancement: Build documentation on GitHub Actions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,0 +1,43 @@
+# https://docs.github.com/en/actions
+
+name: "Integrate"
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - "master"
+
+jobs:
+  build:
+    name: "Build"
+
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        language:
+          - "de"
+
+    steps:
+      - name: "Checkout php/doc-${{ matrix.language }}"
+        uses: "actions/checkout@v2"
+        with:
+          path: "${{ matrix.language }}"
+          repository: "php/doc-${{ matrix.language }}"
+
+      - name: "Checkout php/doc-en as fallback"
+        if: "matrix.language != 'en'"
+        uses: "actions/checkout@v2"
+        with:
+          path: "en"
+          repository: "php/doc-en"
+
+      - name: "Checkout php/doc-base"
+        uses: "actions/checkout@v2"
+        with:
+          path: "doc-base"
+          repository: "php/doc-base"
+
+      - name: "Build documentation for ${{ matrix.language }}"
+        run: "php8.0 doc-base/configure.php --disable-libxml-check --enable-xml-details --redirect-stderr-to-stdout --with-lang=${{ matrix.language }}"


### PR DESCRIPTION
This PR

* [x] builds the documentation on GitHub Actions

💁‍♂️ The workflow is identical to the one proposed in https://github.com/php/doc-en/pull/299 (except for the `LANGUAGE` environment variable). You can see this in action at https://github.com/localheinz/doc-de/pull/1.