### PR TITLE
Fix spelling error; remove unneeded abbreviation

### DIFF
--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -32,7 +32,7 @@
       <note>
        <para>
         Vor PHP 5.5 überprüft <function>empty</function> nur Variablen, alles
-        andere führt zu einem Parse-Error. Anders gesagt wird folgendes nich
+        andere führt zu einem Parse-Error. Anders gesagt wird folgendes nicht
         funktionieren: <command>empty(trim($name))</command>. Statt dessen
         sollte <command>trim($name) == false</command> verwendet werden.
        </para>
@@ -51,7 +51,7 @@
   &reftitle.returnvalues;
   <para>
    Gibt &false; zurück, wenn <parameter>var</parameter> existiert und einen
-   nichtleeren Wert hat, der nicht null ist, aka "falsey". Siehe <link
+   nichtleeren Wert hat, der nicht null ist, auch bekannt als "falsey". Siehe <link
    linkend="language.types.boolean.casting">Converting to boolean</link>.
    Andernfalls wird &true; zurückgegeben.
   </para>


### PR DESCRIPTION
"aka" might be known to most readers, but using it doesn't add value.