### PR TITLE
[80801] Fix wrong translation

### DIFF
--- a/language/functions.xml
+++ b/language/functions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8500ca3fb8c3ef090f6469422d441f75b109e40c Maintainer: cmb Status: in progress -->
+<!-- EN-Revision: e296d2443b197fce63a9752dc6d58c0fdcf0c5cc Maintainer: cmb Status: in progress -->
 <!-- Credits: hholzgra, tom, updated to fix build by theseer -->
 <!-- r351733 and r351885 have not been translated -->
 
@@ -239,7 +239,7 @@ function takes_many_args(
     </programlisting>
    </example>
    <para>
-    As of PHP 8.0.0, passing optional arguments after mandatory arguments
+    As of PHP 8.0.0, passing mandatory arguments after optional arguments
     is deprecated. This can generally be resolved by dropping the default value.
     One exception to this rule are arguments of the form
     <code>Type $param = null</code>, where the &null; default makes the type implicitly


### PR DESCRIPTION
This PR fixes the bug report [`80801`](https://bugs.php.net/bug.php?id=80801) by applying the https://github.com/php/doc-en/pull/270 PR and updating the revision to match that commit.

Don't know German myself so don't feel confident translating anything but I can at least lend a hand will small issues like this.