### PR TITLE
renamed argument $fontfile of function imagettftext()

### DIFF
--- a/reference/image/functions/imagettfbbox.xml
+++ b/reference/image/functions/imagettfbbox.xml
@@ -17,7 +17,7 @@
    <type>array</type><methodname>imagettfbbox</methodname>
    <methodparam><type>float</type><parameter>size</parameter></methodparam>
    <methodparam><type>float</type><parameter>angle</parameter></methodparam>
-   <methodparam><type>string</type><parameter>fontfile</parameter></methodparam>
+   <methodparam><type>string</type><parameter>font_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -51,7 +51,7 @@
       </para>
      </listitem>
     </varlistentry>
-    &gd.ttf.fontfile;
+    &gd.ttf.font_filename;
     <varlistentry>
      <term><parameter>text</parameter></term>
      <listitem>

--- a/reference/image/functions/imagettftext.xml
+++ b/reference/image/functions/imagettftext.xml
@@ -18,7 +18,7 @@
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
-   <methodparam><type>string</type><parameter>fontfile</parameter></methodparam>
+   <methodparam><type>string</type><parameter>font_filename</parameter></methodparam>
    <methodparam><type>string</type><parameter>text</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -87,7 +87,7 @@
       </para>
      </listitem>
     </varlistentry>
-    &gd.ttf.fontfile;
+    &gd.ttf.font_filename;
     <varlistentry>
      <term><parameter>text</parameter></term>
      <listitem>
@@ -154,13 +154,13 @@ imagefilledrectangle($im, 0, 0, 399, 29, $white);
 // Der zu zeichnende Text
 $text = 'Testing...';
 // Bei Bedarf ist der Pfad anzupassen
-$font = 'arial.ttf';
+$font_filename = 'arial.ttf';
 
 // Füge etwas Schatten zum Text hinzu
-imagettftext($im, 20, 0, 11, 21, $grey, $font, $text);
+imagettftext($im, 20, 0, 11, 21, $grey, $font_filename, $text);
 
 // Füge den Text hinzu
-imagettftext($im, 20, 0, 10, 20, $black, $font, $text);
+imagettftext($im, 20, 0, 10, 20, $black, $font_filename, $text);
 
 // Die Verwendung von imagepng() ergibt bessere Textqualität als imagejpeg()
 imagepng($im);


### PR DESCRIPTION
Renamed argument to match implementation 

function `imagettftext()` has the argument `$font_filename` not `$fontfile`.

in english doc it's already correct