### PR TITLE
Updated to en-revision

### DIFF
--- a/reference/ssh2/book.xml
+++ b/reference/ssh2/book.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1634a886415d0ab4df195fe49d18a1c150b70758 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 68c2c871505aadf983f16113c5b077b335ce8d76 Maintainer: cmb Status: ready -->
  
 <book xml:id="book.ssh2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>Secure Shell2</title>
  <titleabbrev>SSH2</titleabbrev>
  

--- a/reference/strings/functions/addslashes.xml
+++ b/reference/strings/functions/addslashes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.addslashes" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>addslashes</refname>
@@ -38,18 +38,6 @@ eval("echo '" . addslashes($str) . "';");
 ]]>
     </programlisting>
    </informalexample>
-  </para>
-  <para>
-   Vor PHP 5.4.0 war die Direktive <link
-   linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link> standardmäßig
-   <literal>on</literal>, und diese führt im Wesentlichen
-   <function>addslashes</function> auf alle GET-, POST- und COOKIE-Daten aus.
-   <function>addslashes</function> darf nicht auf Zeichenketten angewendet werden,
-   die bereits mit <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link>
-   maskiert wurden, da die Zeichenketten sonst doppelt maskiert werden.
-   <function>get_magic_quotes_gpc</function> kann verwendet werden, um zu prüfen,
-   ob <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link> gleich
-   <literal>on</literal> ist.
   </para>
   <para>
    Die Funktion <function>addslashes</function> wird manchmal

--- a/reference/strings/functions/chunk-split.xml
+++ b/reference/strings/functions/chunk-split.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: sammywg Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.chunk-split">
  <refnamediv>
   <refname>chunk_split</refname>
@@ -87,7 +87,6 @@ $neuer_string = chunk_split(base64_encode($data));
    <simplelist>
     <member><function>str_split</function></member>
     <member><function>explode</function></member>
-    <member><function>split</function></member>
     <member><function>wordwrap</function></member>
     <member><link xlink:href="&url.rfc;2045">RFC 2045</link></member>
    </simplelist>

--- a/reference/strings/functions/localeconv.xml
+++ b/reference/strings/functions/localeconv.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: af4410a7e15898c3dbe83d6ea38246745ed9c6fb Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 715a125af5a86f0e6d6d5aa6cfa9c45257a433ac Maintainer: sammywg Status: ready -->
 
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.localeconv">
  <refnamediv>
@@ -18,6 +18,11 @@
    Gibt ein assoziatives Array zurück, das die lokalisierten Informationen
    zur Formatierung von Zahlen und Geldbeträgen enthält.
   </para>
+ </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
 
  <refsect1 role="returnvalues">

--- a/reference/strings/functions/money-format.xml
+++ b/reference/strings/functions/money-format.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cb3e68d99d80a70feafc6f9a1b5f678e4d0522af Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 715a125af5a86f0e6d6d5aa6cfa9c45257a433ac Maintainer: nobody Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.money-format">
  <refnamediv>
   <refname>money_format</refname>
@@ -262,25 +262,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  <note>
-   <para>
-    Die Funktion <function>money_format</function> ist nur definiert, wenn das
-    System strfmon unterstützt. Beispielsweise ist dies unter Windows nicht so,
-    sodass <function>money_format</function> unter Windows nicht definiert ist.
-   </para>
-  </note>
-  <note>
-   <para>
-    Die Kategorie <constant>LC_MONETARY</constant> der Locale-Einstellungen
-    hat Einfluss auf das Verhalten dieser Funktion. <function>setlocal</function>
-    ist zu verwenden, um die gewünschte Locale einzustellen bevor diese Funktion
-    verwendet wird.
-   </para>
-  </note>
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -340,6 +321,25 @@ echo money_format($fmt, 1234.56) . "\n";
   </para>
  </refsect1>
 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Die Funktion <function>money_format</function> ist nur definiert, wenn das
+    System strfmon unterstützt. Beispielsweise ist dies unter Windows nicht so,
+    sodass <function>money_format</function> unter Windows nicht definiert ist.
+   </para>
+  </note>
+  <note>
+   <para>
+    Die Kategorie <constant>LC_MONETARY</constant> der Locale-Einstellungen
+    hat Einfluss auf das Verhalten dieser Funktion. <function>setlocal</function>
+    ist zu verwenden, um die gewünschte Locale einzustellen bevor diese Funktion
+    verwendet wird.
+   </para>
+  </note>
+ </refsect1>
+ 
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/strings/functions/parse-str.xml
+++ b/reference/strings/functions/parse-str.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4a7ddddc27271967b616ad3400cfbe2a9b48212b Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 9d2b858bca85edbeebb83f05a1cd2e87cf90127d Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.parse-str" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>parse_str</refname>
@@ -157,14 +157,6 @@ echo $output['Mein_Wert']; // Etwas
     die Variable <varname>$_SERVER['QUERY_STRING']</varname> verwendet werden.
     Weitere Informationen finden sich auch im Abschnitt <link
     linkend="language.variables.external">Variablen aus externen Quellen</link>.
-   </para>
-  </note>
-  <note>
-   <para>
-    Die <link linkend="ini.magic-quotes-gpc">magic_quotes_gpc</link>-Einstellung
-    beeinflusst die Ausgabe dieser Funktion, da <function>parse_str</function>
-    dieselben Mechanismen verwendet, die PHP zum Füllen der Variablen
-    <varname>$_GET</varname>, <varname>$_POST</varname>, etc. nutzt.
    </para>
   </note>
  </refsect1>

--- a/reference/strings/functions/quotemeta.xml
+++ b/reference/strings/functions/quotemeta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.quotemeta" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>quotemeta</refname>
@@ -61,7 +61,6 @@
     <member><function>nl2br</function></member>
     <member><function>stripslashes</function></member>
     <member><function>stripcslashes</function></member>
-    <member><function>ereg</function></member>
     <member><function>preg_quote</function></member>
    </simplelist>
   </para>

--- a/reference/strings/functions/str-word-count.xml
+++ b/reference/strings/functions/str-word-count.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c73b00a6d7f799e3e5189a316efa06b7ef3c0fe6 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: d335ba69a16f4013280de8e3e71d9ba19fe3cb3c Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.str-word-count" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>str_word_count</refname>
@@ -187,7 +187,6 @@ Array
    <simplelist>
     <member><function>explode</function></member>
     <member><function>preg_split</function></member>
-    <member><function>split</function></member>
     <member><function>count_chars</function></member>
     <member><function>substr_count</function></member>
    </simplelist>

--- a/reference/strings/functions/strcasecmp.xml
+++ b/reference/strings/functions/strcasecmp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c7331ee1924e5b2937f1693190ace24eb888e0 Maintainer: sammywg Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strcasecmp">
+<!-- EN-Revision: c44475e1fafcbee203ed4935a6d5d7a01379fcdc Maintainer: sammywg Status: ready -->
+<refentry xml:id="function.strcasecmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strcasecmp</refname>
   <refpurpose>Vergleich von Zeichenketten ohne Unterscheidung
@@ -12,8 +12,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>strcasecmp</methodname>
-   <methodparam><type>string</type><parameter>str1</parameter></methodparam>
-   <methodparam><type>string</type><parameter>str2</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string2</parameter></methodparam>
   </methodsynopsis>
   <para>
    Groß- und kleinschreibungsunabhängiger Vergleich zweier Zeichenketten, der
@@ -26,7 +26,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>str1</parameter></term>
+     <term><parameter>string1</parameter></term>
      <listitem>
       <para>
        Die erste Zeichenkette.
@@ -34,7 +34,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>str2</parameter></term>
+     <term><parameter>string2</parameter></term>
      <listitem>
       <para>
        Die zweite Zeichenkette.
@@ -48,9 +48,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Ist <parameter>str1</parameter> kleiner als
-   <parameter>str2</parameter> wird ein Wert &lt; 0 zurückgegeben, ist
-   <parameter>str1</parameter> größer als <parameter>str2</parameter> ein Wert
+   Ist <parameter>string1</parameter> kleiner als
+   <parameter>string2</parameter> wird ein Wert &lt; 0 zurückgegeben, ist
+   <parameter>string1</parameter> größer als <parameter>string2</parameter> ein Wert
    &gt; 0, und bei Gleichheit gibt die Funktion 0 zurück.
   </para>
  </refsect1>
@@ -91,8 +91,6 @@ if (strcasecmp($var1, $var2) == 0) {
  </refsect1>
 
 </refentry>
-
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/strings/functions/strcmp.xml
+++ b/reference/strings/functions/strcmp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: df427d95b9b05897b41304b4f26e8d7d11939c86 Maintainer: sammywg Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strcmp">
+<!-- EN-Revision: c44475e1fafcbee203ed4935a6d5d7a01379fcdc Maintainer: sammywg Status: ready -->
+<refentry xml:id="function.strcmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strcmp</refname>
   <refpurpose>Vergleich zweier Strings (Binary safe)</refpurpose>
@@ -11,8 +11,8 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>strcmp</methodname>
-   <methodparam><type>string</type><parameter>str1</parameter></methodparam>
-   <methodparam><type>string</type><parameter>str2</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string2</parameter></methodparam>
   </methodsynopsis>
   <simpara>
    Beachten Sie, dass zwischen Groß- und Kleinschreibung
@@ -25,7 +25,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>str1</parameter></term>
+     <term><parameter>string1</parameter></term>
      <listitem>
       <para>
        Die erste Zeichenkette.
@@ -33,7 +33,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>str2</parameter></term>
+     <term><parameter>string2</parameter></term>
      <listitem>
       <para>
        Die zweite Zeichenkette.
@@ -47,9 +47,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Ist <parameter>str1</parameter> kleiner als
-   <parameter>str2</parameter> wird ein Wert &lt; 0 zurückgegeben, ist
-   <parameter>str1</parameter> größer als <parameter>str2</parameter> ein Wert
+   Ist <parameter>string1</parameter> kleiner als
+   <parameter>string2</parameter> wird ein Wert &lt; 0 zurückgegeben, ist
+   <parameter>string1</parameter> größer als <parameter>string2</parameter> ein Wert
    &gt; 0, und bei Gleichheit gibt die Funktion 0 zurück.
   </para>
  </refsect1>
@@ -89,8 +89,6 @@ if (strcmp($var1, $var2) !== 0) {
  </refsect1>
 
 </refentry>
-
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/strings/functions/strip-tags.xml
+++ b/reference/strings/functions/strip-tags.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.strip-tags" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strip_tags</refname>
@@ -52,7 +52,7 @@
       </note>
       <note>
        <para>
-        In PHP 5.3.4 und neuer werden selbst-schließende XHTML-Tags ignoriert,
+        Selbst-schließende XHTML-Tags ignoriert,
         und nur nicht-selbst-schließende Tags sollten in
         <parameter>allowed_tags</parameter> verwendet werden. Um
         beispielsweise sowohl <literal>&lt;br;&gt;</literal> als auch

--- a/reference/strings/functions/strip-tags.xml
+++ b/reference/strings/functions/strip-tags.xml
@@ -52,12 +52,11 @@
       </note>
       <note>
        <para>
-        Selbst-schließende XHTML-Tags ignoriert,
-        und nur nicht-selbst-schließende Tags sollten in
-        <parameter>allowed_tags</parameter> verwendet werden. Um
-        beispielsweise sowohl <literal>&lt;br;&gt;</literal> als auch
-        <literal>&lt;br/&gt;</literal> zu erlauben, sollte folgendes verwendet
-        werden:
+        Da selbstschließende XHTML-Tags ignoriert werden, sollten nur
+        nicht-selbstschließende Tags in <parameter>allowed_tags</parameter>
+        verwendet werden. Um beispielsweise sowohl
+        <literal>&lt;br;&gt;</literal> als auch <literal>&lt;br/&gt;</literal>
+        zu erlauben, sollte folgendes verwendet werden:
        </para>
        <informalexample>
         <programlisting role="php">

--- a/reference/strings/functions/stristr.xml
+++ b/reference/strings/functions/stristr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.stristr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>stristr</refname>
@@ -111,7 +111,7 @@
 <?php
   $email = 'USER@EXAMPLE.com';
   echo stristr($email, 'e');       // Ausgabe: ER@EXAMPLE.com
-  echo stristr($email, 'e', true); // Ab PHP 5.3.0, Ausgabe: US
+  echo stristr($email, 'e', true); // Ausgabe: US
 ?>
 ]]>
     </programlisting>

--- a/reference/strings/functions/strncasecmp.xml
+++ b/reference/strings/functions/strncasecmp.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c7331ee1924e5b2937f1693190ace24eb888e0 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: c44475e1fafcbee203ed4935a6d5d7a01379fcdc Maintainer: sammywg Status: ready -->
 <!-- splitted from ./en/functions/strings.xml, last change in rev 1.66 -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strncasecmp">
+<refentry xml:id="function.strncasecmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strncasecmp</refname>
   <refpurpose>
@@ -15,9 +15,9 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>strncasecmp</methodname>
-   <methodparam><type>string</type><parameter>str1</parameter></methodparam>
-   <methodparam><type>string</type><parameter>str2</parameter></methodparam>
-   <methodparam><type>int</type><parameter>len</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string2</parameter></methodparam>
+   <methodparam><type>int</type><parameter>length</parameter></methodparam>
   </methodsynopsis>
   <para>
    Diese Funktion ist identisch zu <function>strcasecmp</function> bis auf den
@@ -31,7 +31,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>str1</parameter></term>
+     <term><parameter>string1</parameter></term>
      <listitem>
       <para>
        Die erste Zeichenkette.
@@ -39,7 +39,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>str2</parameter></term>
+     <term><parameter>string2</parameter></term>
      <listitem>
       <para>
        Die zweite Zeichenkette.
@@ -47,7 +47,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>len</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
        Die Länge der Zeichenkette, die für den Vergleich herangezogen werden soll.
@@ -61,9 +61,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Gibt einen Wert &lt;0 zurück, wenn <parameter>str1</parameter> kürzer
-   ist als <parameter>str2</parameter>, einen Wert &gt;0, wenn
-   <parameter>str1</parameter> länger ist als <parameter>str2</parameter>,
+   Gibt einen Wert &lt;0 zurück, wenn <parameter>string1</parameter> kürzer
+   ist als <parameter>string2</parameter>, einen Wert &gt;0, wenn
+   <parameter>string1</parameter> länger ist als <parameter>string2</parameter>,
    und 0, wenn sie gleich sind.
   </para>
  </refsect1>

--- a/reference/strings/functions/strncmp.xml
+++ b/reference/strings/functions/strncmp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96c7331ee1924e5b2937f1693190ace24eb888e0 Maintainer: sammywg Status: ready -->
-<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.strncmp">
+<!-- EN-Revision: c44475e1fafcbee203ed4935a6d5d7a01379fcdc Maintainer: sammywg Status: ready -->
+<refentry xml:id="function.strncmp" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strncmp</refname>
   <refpurpose>String-Vergleich der ersten n Zeichen (Binary safe)</refpurpose>
@@ -11,9 +11,9 @@
   &reftitle.description;
   <methodsynopsis>
    <type>int</type><methodname>strncmp</methodname>
-   <methodparam><type>string</type><parameter>str1</parameter></methodparam>
-   <methodparam><type>string</type><parameter>str2</parameter></methodparam>
-   <methodparam><type>int</type><parameter>len</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string1</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string2</parameter></methodparam>
+   <methodparam><type>int</type><parameter>length</parameter></methodparam>
   </methodsynopsis>
   <para>
    Diese Funktion ist ähnlich <function>strcmp</function> mit dem Unterschied,
@@ -30,7 +30,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>str1</parameter></term>
+     <term><parameter>string1</parameter></term>
      <listitem>
       <para>
        Die erste Zeichenkette.
@@ -38,7 +38,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>str2</parameter></term>
+     <term><parameter>string2</parameter></term>
      <listitem>
       <para>
        Die zweite Zeichenkette.
@@ -46,7 +46,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>len</parameter></term>
+     <term><parameter>length</parameter></term>
      <listitem>
       <para>
        Die Anzahl der Zeichen, die für den Vergleich herangezogen werden soll.
@@ -60,9 +60,9 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Ist <parameter>str1</parameter> kleiner als
-   <parameter>str2</parameter> wird &lt; 0 zurückgegeben, ist
-   <parameter>str1</parameter> größer als <parameter>str2</parameter> &gt; 0,
+   Ist <parameter>string1</parameter> kleiner als
+   <parameter>string2</parameter> wird &lt; 0 zurückgegeben, ist
+   <parameter>string1</parameter> größer als <parameter>string2</parameter> &gt; 0,
    und bei Gleichheit gibt die Funktion 0 zurück.
    </para>
  </refsect1>
@@ -82,8 +82,6 @@
  </refsect1>
 
 </refentry>
-
-
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/reference/strings/functions/strstr.xml
+++ b/reference/strings/functions/strstr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e095023e408c8cb6378ae16bb6870343a3946919 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.strstr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>strstr</refname>
@@ -123,7 +123,7 @@ $email  = 'name@example.com';
 $domain = strstr($email, '@');
 echo $domain; // Ausgabe: @example.com
 
-$user = strstr($email, '@', true); // Ab PHP 5.3.0
+$user = strstr($email, '@', true);
 echo $user; // Ausgabe: name
 ?>
 ]]>

--- a/reference/strings/functions/substr.xml
+++ b/reference/strings/functions/substr.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3988654d1342cbd4a0195f0a6aefcb0fef5593b9 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 715a125af5a86f0e6d6d5aa6cfa9c45257a433ac Maintainer: cmb Status: ready -->
 <refentry xml:id="function.substr" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>substr</refname>
@@ -123,6 +123,22 @@ $rest = substr("abcdef", -3, -1); // gibt "de" zurück
    &return.falseforfailure; oder einen leeren String.
   </para>
  </refsect1>
+ 
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Gibt im Fehlerfall &false; zurück.
+   <example>
+    <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(substr('a', 2)); // bool(false)
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
@@ -199,7 +215,7 @@ echo "7) ".var_export(substr(1.2e3, 0, 4), true).PHP_EOL;
 ?>
 ]]>
     </programlisting>
-    &example.outputs.7;
+    &example.outputs;
     <screen>
 <![CDATA[
 1) 'pe'
@@ -211,34 +227,6 @@ echo "7) ".var_export(substr(1.2e3, 0, 4), true).PHP_EOL;
 7) '1200'
 ]]>
     </screen>
-    &example.outputs;
-    <screen>
-<![CDATA[
-1) 'pe'
-2) '54'
-3) 'gr'
-4) '1'
-5) false
-6) false
-7) '1200'
-]]>
-    </screen>
-   </example>
-  </para>
- </refsect1>
-
- <refsect1 role="errors">
-  &reftitle.errors;
-  <para>
-   Gibt im Fehlerfall &false; zurück.
-   <example>
-    <programlisting role="php">
-<![CDATA[
-<?php
-var_dump(substr('a', 2)); // bool(false)
-?>
-]]>
-    </programlisting>
    </example>
   </para>
  </refsect1>

--- a/reference/uodbc/configure.xml
+++ b/reference/uodbc/configure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 185582af21c073e367e32d46dd528e130ce3d26b Maintainer: nobody Status: ready -->
+<!-- EN-Revision: eec6a4a36bf452bf271f116e7b6b9bb09d1181c3 Maintainer: nobody Status: ready -->
 <section xml:id="odbc.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
  <para>
@@ -176,9 +176,8 @@
    </varlistentry>
   </variablelist>
  </para>
- &windows.builtin;
  <simpara>
-  Allerdings müssen Windows-Benutzer ab PHP 7.0.0
+  Windows-Benutzer müssen
   <filename>php_odbc.dll</filename> aktivieren, um diese Erweiterung zu
   verwenden.
  </simpara>

--- a/reference/uodbc/ini.xml
+++ b/reference/uodbc/ini.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6dfe0767250cdbdf509223f6bc266557b0a3fec9 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: eec6a4a36bf452bf271f116e7b6b9bb09d1181c3 Maintainer: nobody Status: ready -->
 <section xml:id="odbc.configuration" xmlns="http://docbook.org/ns/docbook">
  &reftitle.runtime;
  &extension.runtime;
@@ -75,7 +75,7 @@
       <entry><link linkend="ini.uodbc.defaultcursortype">odbc.default_cursortype</link></entry>
       <entry>"3"</entry>
       <entry>PHP_INI_ALL</entry>
-      <entry>Verfügbar von PHP 5.3.0 an</entry>
+      <entry></entry>
      </row>
     </tbody>
    </tgroup>

--- a/reference/url/constants.xml
+++ b/reference/url/constants.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: sammywg Status: ready -->
 <appendix xml:id="url.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
  <para>
   Die folgenden Konstanten sind für die Nutzung mit
-  <function>parse_url</function> vorgesehen und stehen
-  ab PHP 5.1.2 zur Verfügung.
+  <function>parse_url</function> vorgesehen.
  </para>
  <variablelist>
   <varlistentry xml:id="constant.php-url-scheme">

--- a/reference/url/functions/rawurlencode.xml
+++ b/reference/url/functions/rawurlencode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: simp Status: ready -->
+<!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: simp Status: ready -->
 <!-- Credits: sammywg -->
 <refentry xml:id="function.rawurlencode" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -47,12 +47,6 @@
    interpretiert zu werden, sowie um URLs vor dem Verstümmeln durch
    Übertragungsmedien mit Zeichenumwandlung (wie bei einigen E-Mail-Systemen)
    zu schützen.
-   <note>
-    <para>
-     Vor PHP 5.3.0 hat rawurlencode Tilden (<literal>~</literal>) gemäß
-     <link xlink:href="&url.rfc;1738">RFC 1738</link> kodiert.
-    </para>
-   </note>
   </para>
  </refsect1>
 

--- a/reference/v8js/book.xml
+++ b/reference/v8js/book.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f3264a028baa1f1675bcfc7661532ff76aaa0a67 Maintainer: raphaelm Status: ready -->
+<!-- EN-Revision: 68c2c871505aadf983f16113c5b077b335ce8d76 Maintainer: raphaelm Status: ready -->
 
 <book xml:id="book.v8js" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?phpdoc extension-membership="pecl" ?>
  <title>V8 Javascript-Engine Integration</title>
  <titleabbrev>V8js</titleabbrev>
 

--- a/reference/v8js/setup.xml
+++ b/reference/v8js/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 01c763109c30a13b87358be1eb30f58608c9747e Maintainer: raphaelm Status: ready -->
+<!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: raphaelm Status: ready -->
 
 <chapter xml:id="v8js.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -8,7 +8,7 @@
  <section xml:id="v8js.requirements">
   &reftitle.required;
   <para>
-   PHP 5.3.3+ und die V8-Bibliothek mit Headern sind an den üblichen
+   PHP und die V8-Bibliothek mit Headern sind an den üblichen
    Orten installiert.
   </para>
  </section>

--- a/reference/v8js/v8js/getpendingexception.xml
+++ b/reference/v8js/v8js/getpendingexception.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c6e69f3a4f553a8906e1ebcb64a7386c0074d276 Maintainer: raphaelm Status: ready -->
+<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: raphaelm Status: ready -->
 <refentry xml:id="v8js.getpendingexception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>V8Js::getPendingException</refname>

--- a/reference/var/functions/empty.xml
+++ b/reference/var/functions/empty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3ae0b14dd06ea9d47728f366dfe2c29476a2468e Maintainer: fa Status: ready -->
+<!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: fa Status: ready -->
 <!-- splitted from ./de/functions/var.xml in rev 1.2 -->
 <refentry xml:id="function.empty" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -29,14 +29,6 @@
       <para>
        Die zu prüfende Variable.
       </para>
-      <note>
-       <para>
-        Vor PHP 5.5 überprüft <function>empty</function> nur Variablen, alles
-        andere führt zu einem Parse-Error. Anders gesagt wird folgendes nicht
-        funktionieren: <command>empty(trim($name))</command>. Statt dessen
-        sollte <command>trim($name) == false</command> verwendet werden.
-       </para>
-      </note>
       <para>
        Es wird keine Warnung erzeugt, wenn die Variable nicht existiert. Das
        bedeutet, dass <function>empty</function> im Wesentlichen das kurzgefasste
@@ -85,10 +77,6 @@ if (isset($var)) {
   </para>
   <example>
    <title><function>empty</function> und Zeichenketten-Offsets</title>
-   <para>
-    PHP 5.4 ändert das Verhalten von <function>empty</function>, wenn
-    Zeichenketten-Offsets übergeben werden.
-   </para>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -102,18 +90,7 @@ var_dump(empty($expected_array_got_string['0 Mostel']));
 ?>
 ]]>
    </programlisting>
-   &example.outputs.53;
-   <screen>
-<![CDATA[
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-bool(false)
-]]>
-   </screen>
-   &example.outputs.54;
+   &example.outputs;
    <screen>
 <![CDATA[
 bool(true)

--- a/reference/var/functions/get-defined-vars.xml
+++ b/reference/var/functions/get-defined-vars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e41aab5ecacf449e51179886c17f1d41735b0234 Maintainer: fa Status: ready -->
+<!-- EN-Revision: ccc438a27bae31d71fe2ca7dc095360db5bc1af6 Maintainer: fa Status: ready -->
 <refentry xml:id="function.get-defined-vars" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>get_defined_vars</refname>
@@ -20,6 +20,10 @@
    oder benutzerdefiniert, innerhalb des Zugriffsbereichs, in dem 
    <function>get_defined_vars</function> aufgerufen wird, zurück.
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/var/functions/get-resource-type.xml
+++ b/reference/var/functions/get-resource-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e4c3d5d495373a8ae080e9e8b62ffe512f2dfd11 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 5770355a66d2949f3132c7c6f4808dc035121a42 Maintainer: hholzgra Status: ready -->
 <refentry xml:id="function.get-resource-type" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>get_resource_type</refname>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>string</type><methodname>get_resource_type</methodname>
-   <methodparam><type>resource</type><parameter>handle</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>resource</parameter></methodparam>
   </methodsynopsis>
   <para>
    Diese Funktion gibt den Typ der angegebenen Ressource zurück.
@@ -23,7 +23,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>handle</parameter></term>
+     <term><parameter>resource</parameter></term>
      <listitem>
       <para>
        Das auszuwertende Ressourcen-Handle.
@@ -37,14 +37,14 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Ist der Parameter <parameter>handle</parameter> eine Ressource, so gibt die
+   Ist der Parameter <parameter>resource</parameter> eine Ressource, so gibt die
    Funktion eine textuelle Darstellung des Ressource-Typen zurück. Kann der
    Typ nicht von dieser Funktion ermittelt werden, so wird der String
    <literal>Unknown</literal> zurückgegeben.
   </para>
   <para>
    Die Funktion gibt &null; zurück und erzeugt eine Fehlermeldung, wenn
-   <parameter>handle</parameter> nicht vom Typ <type>resource</type> ist.
+   <parameter>resource</parameter> nicht vom Typ <type>resource</type> ist.
   </para>
  </refsect1>
 

--- a/reference/var/functions/gettype.xml
+++ b/reference/var/functions/gettype.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 51aee00be4000b28ddecc0c34555d5ce3ae54d1a Maintainer: hholzgra Status: ready -->
 <!-- Credits: fa -->
 <refentry xml:id="function.gettype" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -74,6 +74,33 @@
    </simplelist>
   </para>
  </refsect1>
+ 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        Geschlossene Ressourcen werden nun als <literal>'resource
+        (closed)'</literal>
+        gemeldet. Zuvor war der Rückgabewert für geschlossene Ressourcen
+        <literal>'unknown type'</literal>.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -107,37 +134,11 @@ string
   </para>
  </refsect1>
 
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        Geschlossene Ressourcen werden nun als <literal>'resource
-        (closed)'</literal>
-        gemeldet. Zuvor war der Rückgabewert für geschlossene Ressourcen
-        <literal>'unknown type'</literal>.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
- </refsect1>
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>
    <simplelist>
+    <member><function>get_debug_type</function></member>
    <member><function>settype</function></member>
    <member><function>get_class</function></member>
    <member><function>is_array</function></member>

--- a/reference/var/functions/is-object.xml
+++ b/reference/var/functions/is-object.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: ccc438a27bae31d71fe2ca7dc095360db5bc1af6 Maintainer: sammywg Status: ready -->
 
 <refentry xml:id="function.is-object" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -42,6 +42,33 @@
    <type>object</type> ist, ansonsten &false;.
   </para>
  </refsect1>
+ 
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        <function>is_object</function> liefert nun &true; für unserialisierte
+        Objekte ohne Klassendefinition (Klasse
+        <classname>__PHP_Incomplete_Class</classname>) zurück. Zuvor wurde
+        &false; zurückgeliefert.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
@@ -71,33 +98,6 @@ var_dump(get_students($obj));
 ]]>
     </programlisting>
    </example>
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>7.2.0</entry>
-       <entry>
-        <function>is_object</function> liefert nun &true; für unserialisierte
-        Objekte ohne Klassendefinition (Klasse
-        <classname>__PHP_Incomplete_Class</classname>) zurück. Zuvor wurde
-        &false; zurückgeliefert.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/var/functions/isset.xml
+++ b/reference/var/functions/isset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e0f03ac354d797d1d16c0fcc1663e5e170f2727 Maintainer: fa Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: fa Status: ready -->
 <refentry xml:id="function.isset" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>isset</refname>
@@ -138,10 +138,6 @@ var_dump(isset($a['cake']['a']['b']));  // FALSE
   </para>
   <example>
    <title><function>isset</function> und Zeichenketten-Offsets</title>
-   <para>
-    PHP 5.4 ändert das Verhalten von <function>isset</function>, wenn
-    Zeichenketten-Offsets übergeben werden.
-   </para>
    <programlisting role="php">
 <![CDATA[
 <?php
@@ -155,18 +151,7 @@ var_dump(isset($expected_array_got_string['0 Mostel']));
 ?>
 ]]>
    </programlisting>
-   &example.outputs.53;
-   <screen>
-<![CDATA[
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-bool(true)
-]]>
-   </screen>
-   &example.outputs.54;
+   &example.outputs;
    <screen>
 <![CDATA[
 bool(false)

--- a/reference/var/functions/print-r.xml
+++ b/reference/var/functions/print-r.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 565d140248adf5507092461279dfaec75a1d1c0c Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: ccc438a27bae31d71fe2ca7dc095360db5bc1af6 Maintainer: sammywg Status: ready -->
 
 <refentry xml:id="function.print-r" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -72,11 +72,6 @@
   </para>
  </refsect1>
 
- <refsect1 role="notes">
-  &reftitle.notes;
-  &note.uses-ob-php70;
- </refsect1>
-
  <refsect1 role="examples">
   &reftitle.examples;
   <para>
@@ -125,6 +120,11 @@ $results = print_r($b, true); //$results enthaelt nun die Ausgabe von print_r
     </programlisting>
    </example>
   </para>
+ </refsect1>
+ 
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &note.uses-ob-php70;
  </refsect1>
 
  <refsect1 role="seealso">

--- a/reference/var/functions/serialize.xml
+++ b/reference/var/functions/serialize.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1987cb8e71019aeda7bd7947c42a2f64b7dfaad5 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 
 <refentry xml:id="function.serialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -128,8 +128,7 @@ if (!odbc_execute($stmt, $sqldata)) {
    <para>
     Es gibt einige historische Ausnahmen dieser Regel, bei denen interne
     Objekte serialisiert werden konnten, ohne das Interface zu implementieren
-    oder die Methoden offenzulegen. Namentlich
-    <classname>ArrayObject</classname> vor PHP 5.2.0.
+    oder die Methoden offenzulegen.
    </para>
   </note>
   <warning>

--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -64,7 +64,7 @@
   <para>
    <example>
     <title><function>strval</function>-Beispiel für die Verwendung der magischen
-     <link linkend="object.tostring">__toString</link> Methode</title>
+     <link linkend="object.tostring">__toString</link>-Methode</title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -63,8 +63,10 @@
   &reftitle.examples;
   <para>
    <example>
-    <title><function>strval</function>-Beispiel für die Verwendung der magischen
-     <link linkend="object.tostring">__toString</link>-Methode</title>
+    <title>
+     <function>strval</function>-Beispiel für die Verwendung der magischen
+     <link linkend="object.tostring">__toString</link>-Methode
+    </title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/var/functions/strval.xml
+++ b/reference/var/functions/strval.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 
 <refentry xml:id="function.strval" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/var/functions/var-dump.xml
+++ b/reference/var/functions/var-dump.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Maintainer: sammywg Status: ready -->
 <!-- splitted from ./de/functions/var.xml, last change in rev 1.5 -->
 <refentry xml:id="function.var-dump" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -26,7 +26,7 @@
    geschützten (protected) Eigenschaften eines Objekts werden in der Ausgabe
    dargestellt, außer wenn das Objekt eine
    <link linkend="language.oop5.magic.debuginfo">__debugInfo()</link>-Methode
-   implementiert (eingeführt in PHP 5.6.0).
+   implementiert.
   </simpara>
   &tip.ob-capture;
  </refsect1>

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94f0332bf02fb11c0dd267defa031fadd8a93e9b Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: hholzgra Status: ready -->
 
 <refentry xml:id="function.var-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -160,7 +160,7 @@ echo $v;
   </para>
   <para>
    <example>
-    <title>Export von Klassen ab PHP 5.1.0</title>
+    <title>Export von Klassen</title>
     <programlisting role="php">
 <![CDATA[
 <?php
@@ -183,7 +183,7 @@ A::__set_state(array(
   </para>
   <para>
    <example>
-    <title>Nutzung von <link linkend="object.set-state">__set_state</link> (ab PHP 5.1.0)</title>
+    <title>Nutzung von <link linkend="object.set-state">__set_state</link></title>
     <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/xmlreader/constants.xml
+++ b/reference/xmlreader/constants.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: nikic Status: ready -->
+<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: nikic Status: ready -->
 <appendix xml:id="xmlreader.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
-  <warning>
-   <para>
-    Seit PHP 5.1 verwendet XMLReader Klassenkonstanten. Frühere Versionen
-    verwenden globale Konstanten wie <constant>XMLREADER_ELEMENT</constant>.
-   </para>
-  </warning>
   <table>
    <title>XMLReader Knotentypen</title>
    <tgroup cols="3">

--- a/reference/xmlreader/xmlreader/close.xml
+++ b/reference/xmlreader/xmlreader/close.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 656d1610af1a960d87c8b7056e54d0d4c75fb123 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: cee13276de5f38e80dba817653ae8668b5672e7a Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::close</refname>
@@ -15,6 +15,10 @@
   <para>
    Beenden der Eingabe die das XMLReader-Objekt gerade parst.
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/xmlreader/xmlreader/getattributeno.xml
+++ b/reference/xmlreader/xmlreader/getattributeno.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9d3b35d2a8bc6326f5981827eec18b028007b1f2 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: 5fabd07880ab15b0ad2cf7eb055c7c2b36d7120f Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.getattributeno" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::getAttributeNo</refname>
@@ -36,34 +36,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Der Wert des Attributes oder eine leere Zeichenkette (vor PHP 5.6) oder
-   &null; (von PHP 5.6 an), wenn kein Attribut an der Position
+   Der Wert des Attributes oder &null;, wenn kein Attribut an der Position
    <parameter>index</parameter> im aktuellen Element gefunden wurde.
-  </para>
- </refsect1>
-
- <refsect1 role="changelog">
-  &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>5.6.0</entry>
-       <entry>
-        <methodname>XMLReader::getAttributeNo</methodname> gibt nun &null;
-        zurück, wenn das Attribut nicht existiert.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/xmlreader/xmlreader/getattributens.xml
+++ b/reference/xmlreader/xmlreader/getattributens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 709f92e5d766db22dea39ca4ecfed42372754ee4 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: e294389da19bdb5d622e717a3f36812f3d94ae06 Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.getattributens" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::getAttributeNs</refname>
@@ -45,8 +45,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Der Wert des Attributes oder eine leere Zeichenkette (vor PHP 5.6) oder
-   &null; (von PHP 5.6 an), wenn kein Attribut mit den Parametern
+   Der Wert des Attributes oder &null;, wenn kein Attribut mit den Parametern
    <parameter>name</parameter> und <parameter>namespace</parameter> im
    aktuellen Element gefunden wurde oder der Cursor sich derzeitig nicht über
    einem Element befindet.
@@ -69,13 +68,6 @@
        <entry>8.0.0</entry>
        <entry>
         This function can no longer return &false;.
-       </entry>
-      </row>
-      <row>
-       <entry>5.6.0</entry>
-       <entry>
-        <methodname>XMLReader::getAttributeNS</methodname> gibt nun &null;
-        zurück, wenn das Attribut nicht existiert.
        </entry>
       </row>
      </tbody>

--- a/reference/xmlreader/xmlreader/isvalid.xml
+++ b/reference/xmlreader/xmlreader/isvalid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 94d82f4272ca73a39726d7182a338384f520e963 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: cee13276de5f38e80dba817653ae8668b5672e7a Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.isvalid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::isValid</refname>
@@ -16,6 +16,10 @@
    Gibt einen boolschen Wert zurück, der anzeigt, ob das geparste Dokument 
    sich aktuell in einem validen Zustand befindet.
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/xmlreader/xmlreader/movetoelement.xml
+++ b/reference/xmlreader/xmlreader/movetoelement.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 656d1610af1a960d87c8b7056e54d0d4c75fb123 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: cee13276de5f38e80dba817653ae8668b5672e7a Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.movetoelement" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader->moveToElement</refname>
@@ -15,6 +15,10 @@
   <para>
    Setzt Zeiger auf das Elternelement des aktuellen Attributes. 
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/xmlreader/xmlreader/movetofirstattribute.xml
+++ b/reference/xmlreader/xmlreader/movetofirstattribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 656d1610af1a960d87c8b7056e54d0d4c75fb123 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: cee13276de5f38e80dba817653ae8668b5672e7a Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.movetofirstattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::moveToFirstAttribute</refname>
@@ -15,6 +15,10 @@
   <para>
    Setzt den Zeiger auf das erste Attribut im Element.
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/xmlreader/xmlreader/movetonextattribute.xml
+++ b/reference/xmlreader/xmlreader/movetonextattribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 656d1610af1a960d87c8b7056e54d0d4c75fb123 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: cee13276de5f38e80dba817653ae8668b5672e7a Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.movetonextattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::moveToNextAttribute</refname>
@@ -16,6 +16,10 @@
    Setzt den Zeiger auf das nächste Attribut, wenn er auf ein Attribut 
    verweist oder auf's erste Attribut, wenn er auf ein Element verweist.
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/xmlreader/xmlreader/read.xml
+++ b/reference/xmlreader/xmlreader/read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 656d1610af1a960d87c8b7056e54d0d4c75fb123 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: cee13276de5f38e80dba817653ae8668b5672e7a Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlreader.read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLReader::read</refname>
@@ -15,6 +15,10 @@
   <para>
    Zeiger auf das nächste Element im Dokument setzen.
   </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
  </refsect1>
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;

--- a/reference/xmlwriter/xmlwriter/startattribute.xml
+++ b/reference/xmlwriter/xmlwriter/startattribute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c31630ca23d219c758a8b580e1d583103e97e377 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: 7a59549dbba8cbf530a38ef3d168f4fc628649c0 Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlwriter.startattribute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLWriter::startAttribute</refname>
@@ -74,7 +74,7 @@
 <?php
 $writer = new XMLWriter;
 $writer->openURI('php://output');
-$writer->startDocument('1.0', 'UTF-8');?>
+$writer->startDocument('1.0', 'UTF-8');
 $writer->startElement('element');
 $writer->startAttribute('attribute');
 $writer->text('value');

--- a/reference/xsl/configure.xml
+++ b/reference/xsl/configure.xml
@@ -4,7 +4,7 @@
 <section xml:id="xsl.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
   <para>
-   Die Erweiterung XSL ist in der PHP-Distribution enthalten und kann über die Option
+   Die Erweiterung XSL ist in PHP enthalten und kann über die Option
    <option role="configure">--with-xsl[=DIR]</option> in Ihrer Build-Konfiguration aktiviert
    werden. Dabei steht <literal>DIR</literal> für das Installationsverzeichnis der libxslt-Bibliothek.
   </para>

--- a/reference/xsl/configure.xml
+++ b/reference/xsl/configure.xml
@@ -4,7 +4,7 @@
 <section xml:id="xsl.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
   <para>
-   Die Erweiterung XSL ist PHP in der Distribution enthalten und kann über die Option
+   Die Erweiterung XSL ist in der PHP-Distribution enthalten und kann über die Option
    <option role="configure">--with-xsl[=DIR]</option> in Ihrer Build-Konfiguration aktiviert
    werden. Dabei steht <literal>DIR</literal> für das Installationsverzeichnis der libxslt-Bibliothek.
   </para>

--- a/reference/xsl/configure.xml
+++ b/reference/xsl/configure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5445f249d7acae0773e3d77241b13bff80afeb67 Maintainer: theseer Status: ready -->
+<!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: theseer Status: ready -->
 <section xml:id="xsl.installation" xmlns="http://docbook.org/ns/docbook">
  &reftitle.install;
   <para>
-   Die Erweiterung XSL ist seit PHP 5 in der Distribution enthalten und kann über die Option
+   Die Erweiterung XSL ist PHP in der Distribution enthalten und kann über die Option
    <option role="configure">--with-xsl[=DIR]</option> in Ihrer Build-Konfiguration aktiviert
    werden. Dabei steht <literal>DIR</literal> für das Installationsverzeichnis der libxslt-Bibliothek.
   </para>

--- a/reference/xsl/constants.xml
+++ b/reference/xsl/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: theseer Status: ready -->
+<!-- EN-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Maintainer: theseer Status: ready -->
 <appendix xml:id="xsl.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
  &extension.constants;
@@ -42,7 +42,7 @@
    </term>
    <listitem>
     <simpara>
-     Version der libxslt als Zahl, beispielsweise 10117. Verfügbar seit PHP 5.1.2.
+     Version der libxslt als Zahl, beispielsweise 10117.
     </simpara>
    </listitem>
   </varlistentry>
@@ -53,7 +53,7 @@
    </term>
    <listitem>
     <simpara>
-     Version der libxslt als String, beispielsweise 1.1.17. Verfügbar seit PHP 5.1.2.
+     Version der libxslt als String, beispielsweise 1.1.17.
     </simpara>
    </listitem>
   </varlistentry>
@@ -64,7 +64,7 @@
    </term>
    <listitem>
     <simpara>
-     Version der libexslt als Zahl, beispielsweise 813. Verfügbar seit PHP 5.1.2.
+     Version der libexslt als Zahl, beispielsweise 813.
     </simpara>
    </listitem>
   </varlistentry>
@@ -75,7 +75,7 @@
    </term>
    <listitem>
     <simpara>
-     Version der libexslt als String, beispielsweise 1.1.17. Verfügbar seit PHP 5.1.2.
+     Version der libexslt als String, beispielsweise 1.1.17.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/xsl/xsltprocessor/hasexsltsupport.xml
+++ b/reference/xsl/xsltprocessor/hasexsltsupport.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 33be73da1e3ffdccabce21a402b69a4fd9b7d04b Maintainer: theseer Status: ready -->
+<!-- EN-Revision: e17ff04a4ad4f20fe55e848f439a5e28313d9916 Maintainer: theseer Status: ready -->
 <refentry xml:id="xsltprocessor.hasexsltsupport" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>XSLTProcessor::hasExsltSupport</refname>
@@ -17,12 +17,19 @@
    xlink:href="&url.exsltlib;">EXSLT-Bibliothek</link> kompiliert wurde.
   </para>
  </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
    &return.success;
   </para>
  </refsect1>
+
  <refsect1 role="examples">
   &reftitle.examples;
   <para>

--- a/reference/xsl/xsltprocessor/transformtouri.xml
+++ b/reference/xsl/xsltprocessor/transformtouri.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0d604bbc9d3b741d53e7fac26f5b24c306751e9a Maintainer: theseer Status: ready -->
+<!-- EN-Revision: 4754397753fd79f1c846868b66a2448babab1c54 Maintainer: theseer Status: ready -->
 <refentry xml:id="xsltprocessor.transformtouri" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XSLTProcessor::transformToURI</refname>

--- a/reference/zlib/constants.xml
+++ b/reference/zlib/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86e6094e86b84a51d00ab217ac50ce8dde33d82a Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: eec6a4a36bf452bf271f116e7b6b9bb09d1181c3 Maintainer: sammywg Status: ready -->
 
 <appendix xml:id="zlib.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -35,7 +35,7 @@
    </term>
    <listitem>
     <simpara>
-     DEFLATE-Algorithmus gemäß RFC 1951. Verfügbar ab PHP 7.0.0.
+     DEFLATE-Algorithmus gemäß RFC 1951.
     </simpara>
    </listitem>
   </varlistentry>
@@ -46,7 +46,7 @@
    </term>
    <listitem>
     <simpara>
-     ZLIB-Komprimierungsalgorithmus gemäß RFC 1950. Verfügbar ab PHP 7.0.0.
+     ZLIB-Komprimierungsalgorithmus gemäß RFC 1950.
     </simpara>
    </listitem>
   </varlistentry>
@@ -57,7 +57,7 @@
    </term>
    <listitem>
     <simpara>
-     GZIP-Algorithmus gemäß RFC 1952. Verfügbar ab PHP 7.0.0.
+     GZIP-Algorithmus gemäß RFC 1952.
     </simpara>
    </listitem>
   </varlistentry>
@@ -68,7 +68,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -79,7 +79,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -90,7 +90,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -101,7 +101,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -112,7 +112,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -123,7 +123,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -134,7 +134,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -145,7 +145,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -156,7 +156,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -167,7 +167,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>
@@ -178,7 +178,7 @@
    </term>
    <listitem>
     <simpara>
-      Verfügbar ab PHP 7.0.0.
+
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/zlib/examples.xml
+++ b/reference/zlib/examples.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4691b6ddbdf4058b2190e123e31e25af0abd319d Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: eec6a4a36bf452bf271f116e7b6b9bb09d1181c3 Maintainer: sammywg Status: ready -->
 
 <chapter xml:id="zlib.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.examples;
@@ -51,7 +51,7 @@ echo "</pre>\n</body>\n</html>\n";
   </programlisting>
  </example>
  <example>
-  <title>Arbeiten mit den inkrementellen Kompriemierungs- und Dekomprimierungs-API ab PHP 7.0.0</title>
+  <title>Arbeiten mit den inkrementellen Kompriemierungs- und Dekomprimierungs-API</title>
   <programlisting role="php">
 <![CDATA[
 <?php

--- a/reference/zlib/functions/gzwrite.xml
+++ b/reference/zlib/functions/gzwrite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ba67b51f2bde571b6ce07026e935f4e81019af Maintainer: hholzgra  Status: ready -->
+<!-- EN-Revision: 9d2b858bca85edbeebb83f05a1cd2e87cf90127d Maintainer: hholzgra  Status: ready -->
 <refentry xml:id="function.gzwrite" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>gzwrite</refname>
@@ -49,15 +49,6 @@
        <parameter>data</parameter> geschriebenen Bytes abgebrochen, wenn bis
        dahin das Ende des Strings nicht erreicht ist.
       </para>
-      <note>
-       <para>
-        Es ist zu beachten, dass der Konfigurationsparameter <link
-        linkend="ini.magic-quotes-runtime">magic_quotes_runtime</link>
-        ignoriert wird und keine Slashes aus <parameter>data</parameter>
-        entfernt, werden wenn der optionale Parameter
-        <parameter>length</parameter> übergeben wird.
-       </para>
-      </note>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/reference/zlib/functions/zlib-get-coding-type.xml
+++ b/reference/zlib/functions/zlib-get-coding-type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ba67b51f2bde571b6ce07026e935f4e81019af Maintainer: hholzgra  Status: ready -->
+<!-- EN-Revision: 435885e2f78afd591a0b201a3bb7e8c8d1260165 Maintainer: hholzgra  Status: ready -->
 <refentry xml:id="function.zlib-get-coding-type" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>zlib_get_coding_type</refname>
@@ -16,6 +16,12 @@
    Gibt die für Ausgabekomprimierung genutzte Methode zurück.
   </para>
  </refsect1>
+ 
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
@@ -23,6 +29,7 @@
    oder &false;.
   </para>
  </refsect1>
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <para>

--- a/reference/zlib/setup.xml
+++ b/reference/zlib/setup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 02ba67b51f2bde571b6ce07026e935f4e81019af Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: sammywg Status: ready -->
 
 <chapter xml:id="zlib.setup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.setup;
@@ -11,8 +11,8 @@
   <para>
    Diese Erweiterung nutzt die Funktionen der <link
    xlink:href="&url.zlib;">zlib</link>-Bibliothek von Jean-loup Gailly und
-   Mark Adler. Sie benötigen zlib &gt;= 1.0.9, um die Funktionen nutzen zu
-   können. Von PHP 5.4.0 an muss zlib &gt;= 1.2.0.4 verwendet werden.
+   Mark Adler. Sie benötigen zlib &gt;= 1.2.0.4, um die Funktionen nutzen zu
+   können.
   </para>
  </section>
  <!-- }}} -->


### PR DESCRIPTION
I cannot fix the build, there are too many language-dependent changes in the `language-snippets.ent`.

Here are updates to the English version, which I can do without a good knowledge of German.