### PR TITLE
Fixed translation in first example of array_diff_assoc

### DIFF
--- a/reference/array/functions/array-diff-assoc.xml
+++ b/reference/array/functions/array-diff-assoc.xml
@@ -87,8 +87,8 @@
      <literal>"a" =&gt; "gruen"</literal>-Paar in beiden Arrays enthalten ist
      und daher nicht in der Ausgabe der Funktion auftaucht. Andererseits ist das
      Paar <literal>0 =&gt; "rot"</literal> in der Ausgabe, weil
-     <literal>"red"</literal> im zweiten Array den Wert
-     <literal>1</literal> enthält.
+     <literal>"rot"</literal> im zweiten Array den Schlüssel
+     <literal>1</literal> hat.
     </para>
     <programlisting role="php">
 <![CDATA[


### PR DESCRIPTION
In the first example of `array_diff_assoc` function, there were two translation errors, which are fixed with this commit.