### PR TITLE
fix german FILTER_UNSAFE_RAW description

### DIFF
--- a/reference/filter/filters.xml
+++ b/reference/filter/filters.xml
@@ -543,7 +543,7 @@ filter.default_flags = 0
         <constant>FILTER_UNSAFE_RAW</constant>
        </entry>
        <entry>
-        Entfernt Zeichen, die einen numerischen Wert &gt;32 haben.
+        Entfernt Zeichen, die einen numerischen Wert &lt;32 haben.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
all other languages seem to have <32 in the description..