### PR TITLE
Translate a missing header.

### DIFF
--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -182,7 +182,7 @@ $myFoo->test(); // Bar::testPrivate
   </sect2>
 
   <sect2 xml:id="language.oop5.visiblity-constants">
-   <title>Constant Visibility</title>
+   <title>Sichtbarkeit von Konstanten</title>
    <para>
     Von PHP 7.1.0 an können Klassenkonstanten als public, private, oder
     protected definiert werden. Konstanten, die ohne eine explizite


### PR DESCRIPTION
Translated the header "constant visibility" into german "Sichtbarkeit von Konstanzen"