### PR TITLE
Fixed mismatched Words & Fixed Table Title misspelling

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -11,7 +11,7 @@
   Ihrer PHP-Installation nutzen können.
  </para>
  <para>
-  Die "Änderbar"-Spalte gibt an, wann und wo die Direktive geändert werden
+  Die "Veränderbar"-Spalte gibt an, wann und wo die Direktive geändert werden
   kann. Siehe
   <link linkend="configuration.changes.modes">Liste der möglichen Modi</link>
   für deren Definitionen.

--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -11,7 +11,7 @@
   Ihrer PHP-Installation nutzen können.
  </para>
  <para>
-  Die "Veränderbar"-Spalte gibt an, wann und wo die Direktive geändert werden
+  Die "&Changeable;"-Spalte gibt an, wann und wo die Direktive geändert werden
   kann. Siehe
   <link linkend="configuration.changes.modes">Liste der möglichen Modi</link>
   für deren Definitionen.


### PR DESCRIPTION
The Changable-Column (Veränderbar-Spalte) in the Table of the article and the description of the columns do not use the same word, fixed.
![grafik](https://user-images.githubusercontent.com/50182241/183911299-c20f4f8a-396e-4972-85b0-862bcbb59d50.png)
