### PR TITLE
Update to English version

### DIFF
--- a/language/predefined/arrayaccess/offsetexists.xml
+++ b/language/predefined/arrayaccess/offsetexists.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cfaa7659dab118ecf6b420c550a6b8183f4190ad Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 362f36f682424b5133cc47b3ba7d0a5162fe9d5e Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
-<!-- Rev-Revision: cfaa7659dab118ecf6b420c550a6b8183f4190ad Reviewer: samesch -->
+<!-- Rev-Revision: 362f36f682424b5133cc47b3ba7d0a5162fe9d5e Reviewer: samesch -->
 
 <refentry xml:id="arrayaccess.offsetexists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -85,7 +85,7 @@ class obj implements ArrayAccess {
     public function offsetUnset($var): void {
         var_dump(__METHOD__);
     }
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($var) {
         var_dump(__METHOD__);
         return "Wert";

--- a/language/predefined/iterator.xml
+++ b/language/predefined/iterator.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 214335df7e8b11b517779aa3420d794f343a7309 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 362f36f682424b5133cc47b3ba7d0a5162fe9d5e Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
-<!-- Rev-Revision: 214335df7e8b11b517779aa3420d794f343a7309 Reviewer: samesch -->
+<!-- Rev-Revision: 362f36f682424b5133cc47b3ba7d0a5162fe9d5e Reviewer: samesch -->
 <phpdoc:classref xml:id="class.iterator" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Das Iterator-Interface</title>
@@ -85,13 +85,13 @@ class meinIterator implements Iterator {
         $this->position = 0;
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current() {
         var_dump(__METHOD__);
         return $this->array[$this->position];
     }
 
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key() {
         var_dump(__METHOD__);
         return $this->position;

--- a/reference/datetime/functions/date-parse.xml
+++ b/reference/datetime/functions/date-parse.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: bbfdc364de79d739aeccc611ef82111e7f15b4da Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 6f845b90b480d7fd5f0999ff6c6c03d06dc86682 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-parse" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/json/functions/json-decode.xml
+++ b/reference/json/functions/json-decode.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 32f3a5a59f9f2ab2b97ad223b9e996cbc69e11c3 Maintainer: simp Status: ready -->
+<!-- EN-Revision: 20717145cf4551420cc8aa421f159ed55aa779f4 Maintainer: simp Status: ready -->
 <!-- Credits: sammywg -->
 <refentry xml:id="function.json-decode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
File `reference/json/functions/json-decode.xml` in f34c64ee7538bc4e8a35f6762c6e9031973621a2 has no updated En-rev :)

And I can be wrong, but it seems,
that `reference/datetime/functions/date-parse.xml` is also actual ([Current En-diff](http://doc.php.net/revcheck.php?p=plain&lang=de&hbp=bbfdc364de79d739aeccc611ef82111e7f15b4da&f=reference/datetime/functions/date-parse.xml&c=on)) 🤔 