### PR TITLE
Fix typo in `array_reduce` parameters list

### DIFF
--- a/reference/array/functions/array-reduce.xml
+++ b/reference/array/functions/array-reduce.xml
@@ -70,7 +70,7 @@
      <term><parameter>initial</parameter></term>
      <listitem>
       <para>
-       Ist der optionale Parameter <parameter>intial</parameter> angegeben,
+       Ist der optionale Parameter <parameter>initial</parameter> angegeben,
        wird er am Anfang des Prozesses benutzt oder als Resultat verwendet,
        falls das Array leer ist.
       </para>


### PR DESCRIPTION
The German translation contains a typo (`intial` instead of `initial`) in the description of that `initial` parameter.