### PR TITLE
Fix German return value documentation for umask()

### DIFF
--- a/reference/filesystem/functions/umask.xml
+++ b/reference/filesystem/functions/umask.xml
@@ -40,7 +40,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Wenn <function>umask</function> &null; ist, gibt <function>umask</function>
+   Wenn <parameter>mask</parameter> &null; ist, gibt <function>umask</function>
    einfach die aktuelle umask zurück, ansonsten wird die alte umask zurückgegeben.
   </para>
  </refsect1>


### PR DESCRIPTION
The current umask is returned if the `$mask` parameter is null, see https://github.com/php/doc-en/blob/master/reference/filesystem/functions/umask.xml