### PR TITLE
Fixed typo in json constants

### DIFF
--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -314,7 +314,7 @@
    <listitem>
     <simpara>
      Die Zeilentrenner bleiben unmaskiert, wenn
-     <constant>JSON_UNESCAPE_UNICODE</constant> übergeben wird. Das ist das
+     <constant>JSON_UNESCAPED_UNICODE</constant> übergeben wird. Das ist das
      gleiche Verhalten wie vor PHP 7.1 ohne diese Konstante.
      Verfügbar von PHP 7.1.0 an.
     </simpara>


### PR DESCRIPTION
The constant `JSON_UNESCAPE_UNICODE` does not exist, therefore this probably is a typo -> `JSON_UNESCAPED_UNICODE` exists