### PR TITLE
Improve translation of the "caution.cryptographically-insecure" snippet

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -33,8 +33,8 @@ weiteren Verwendung wird dringend abgeraten.</simpara></warning>'>
   <classname>Random\Engine\Secure</classname>-Engine verwendet werden. Für
   einfache Anwendungsfälle bieten die Funktionen <function>random_int</function>
   und <function>random_bytes</function> eine bequeme und sichere
-  <acronym>API</acronym>, die durch den <acronym>CSPRNG</acronym> des
-  Betriebssystems unterstützt wird.
+  <acronym>API</acronym>, die den <acronym>CSPRNG</acronym> des
+  Betriebssystems verwendet.
  </para>
 </caution>'>
 


### PR DESCRIPTION
As the author of the English version, "backed by" is better translated as "verwendet", instead of "unterstützt".