### PR TITLE
crypt: Fix example

### DIFF
--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: cc88cbd3303ca3342dcdcd643eae793e564730c7 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 60b29fbe11384d5233398d70fdc74e9078fe32ad Maintainer: sammywg Status: ready -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.crypt">
  <refnamediv>
   <refname>crypt</refname>

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -209,11 +209,10 @@
     <programlisting role="php">
 <![CDATA[
 <?php
-
 $benutzer_eingabe = 'rasmuslerdorf';
 $gehashtes_passwort = '$6$rounds=1000000$NJy4rIPjpOaU$0ACEYGg/aKCY3v8O8AfyiO7CTfZQ8/W231Qfh2tRLmfdvFD6XfHk12u6hMr9cYIA4hnpjLNSTRtUwYr9km9Ij/';
 
-// Prüfen eines vorhandenen crypt()-Hashs für Kompatibilität mit Nicht-PHP-Software.
+// Prüfen eines vorhandenen crypt()-Hashs auf eine Weise, die mit Nicht-PHP-Software kompatibel ist.
 if (hash_equals($gehashtes_passwort, crypt($benutzer_eingabe, $gehashtes_passwort))) {
    echo "Passwort stimmt überein!";
 }

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -210,18 +210,10 @@
 <![CDATA[
 <?php
 
-/* Sie sollten das vollständige Ergebnis von crypt() als Salt zum
-   Passwort-Vergleich übergeben, um Problemen mit unterschiedlichen
-   Hash-Algorithmen vorzubeugen. (Wie bereits ausgeführt, verwendet
-   ein Standard-DES-Passwort-Hash einen 2-Zeichen-Salt, ein
-   MD5-basierter hingegen nutzt 12 Zeichen. */
-if (crypt($benutzer_eingabe, $gehashtes_passwort) == $gehashtes_passwort) {
-   echo "Passwort stimmt überein!";
-
 $benutzer_eingabe = 'rasmuslerdorf';
 $gehashtes_passwort = '$6$rounds=1000000$NJy4rIPjpOaU$0ACEYGg/aKCY3v8O8AfyiO7CTfZQ8/W231Qfh2tRLmfdvFD6XfHk12u6hMr9cYIA4hnpjLNSTRtUwYr9km9Ij/';
 
-// Prüfen eines vorhandenen crypt()-Hashs auf Kompatibilität mit Nicht-PHP-Software .
+// Prüfen eines vorhandenen crypt()-Hashs auf Kompatibilität mit Nicht-PHP-Software.
 if (hash_equals($gehashtes_passwort, crypt($benutzer_eingabe, $gehashtes_passwort))) {
    echo "Passwort stimmt überein!";
 }

--- a/reference/strings/functions/crypt.xml
+++ b/reference/strings/functions/crypt.xml
@@ -213,7 +213,7 @@
 $benutzer_eingabe = 'rasmuslerdorf';
 $gehashtes_passwort = '$6$rounds=1000000$NJy4rIPjpOaU$0ACEYGg/aKCY3v8O8AfyiO7CTfZQ8/W231Qfh2tRLmfdvFD6XfHk12u6hMr9cYIA4hnpjLNSTRtUwYr9km9Ij/';
 
-// Prüfen eines vorhandenen crypt()-Hashs auf Kompatibilität mit Nicht-PHP-Software.
+// Prüfen eines vorhandenen crypt()-Hashs für Kompatibilität mit Nicht-PHP-Software.
 if (hash_equals($gehashtes_passwort, crypt($benutzer_eingabe, $gehashtes_passwort))) {
    echo "Passwort stimmt überein!";
 }


### PR DESCRIPTION
The example is not properly in sync with the English version and got broken in 588eb367d7d8084f9accca43bca2a983c1cf680f.