### PR TITLE
Add AVIF

### DIFF
--- a/reference/exif/functions/exif-imagetype.xml
+++ b/reference/exif/functions/exif-imagetype.xml
@@ -141,6 +141,10 @@
        <entry>18</entry>
        <entry><constant>IMAGETYPE_WEBP</constant></entry>
       </row>
+      <row>
+       <entry>19</entry>
+       <entry><constant>IMAGETYPE_AVIF</constant></entry>
+      </row>
      </tbody>
     </tgroup>
    </table>


### PR DESCRIPTION
The return value IMAGE TYPE AVIF was missing from the documentation.
https://github.com/php/php-src/blob/8eda3151eb5caefb71d468167c4bd0f9a3dd6a36/ext/standard/image.c#L1422C15-L1422C15