### PR TITLE
random: Fix translation for the seed parameter explanation of mt_srand

### DIFF
--- a/reference/random/functions/mt-srand.xml
+++ b/reference/random/functions/mt-srand.xml
@@ -34,9 +34,9 @@
      <term><parameter>seed</parameter></term>
      <listitem>
       <para>
-       Füllt den Zustand mit Werten, die mit einem linearen kongruenten
-       Generator erzeugt wurden, der mit <parameter>seed</parameter>,
-       interpretiert als vorzeichenlose 32-Bit-Ganzzahl, geimpft wurde.
+       Füllt den Zustand mit Werten, die mit einem linearen Kongruenzgenerator
+       erzeugt wurden, der mit <parameter>seed</parameter>,
+       interpretiert als vorzeichenlose 32-Bit-Ganzzahl, initialisiert wurde.
       </para>
       <para>
        Wenn <parameter>seed</parameter> weggelassen wird oder &null; ist, wird

--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -40,9 +40,9 @@
      <term><parameter>seed</parameter></term>
      <listitem>
       <para>
-       Füllt den Zustand mit Werten, die mit einem linearen kongruenten
-       Generator erzeugt wurden, der mit <parameter>seed</parameter>,
-       interpretiert als vorzeichenlose 32-Bit-Ganzzahl, geimpft wurde.
+       Füllt den Zustand mit Werten, die mit einem linearen Kongruenzgenerator
+       erzeugt wurden, der mit <parameter>seed</parameter>,
+       interpretiert als vorzeichenlose 32-Bit-Ganzzahl, initialisiert wurde.
       </para>
       <para>
        Wenn <parameter>seed</parameter> weggelassen wird oder &null; ist, wird


### PR DESCRIPTION
Linearer Kongruenzgenerator is the proper German translation for “Linear Congruential Generator”: https://de.wikipedia.org/wiki/Kongruenzgenerator

I would have used “seeded” as-is in German, but “initialisiert” is a proper German word and fits the purpose. I've never heard “geimpft” in this context.

