### PR TITLE
Convert curl-getinfo() constant list to table

### DIFF
--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: jaenecke Status: ready -->
 <!-- Reviewed: no -->
 <!-- Rev-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Reviewer: samesch -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f3d1cec9e549e5ac7bfbb076295537668ceb0e4a Maintainer: jaenecke Status: ready -->
-<!-- Reviewed: yes -->
+<!-- EN-Revision: 8b3f89ed6171cb711b00afb0fcacbea3462537b9 Maintainer: haszi Status: ready -->
+<!-- Reviewed: no -->
 <!-- Rev-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Reviewer: samesch -->
 <refentry xml:id="function.curl-getinfo" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/curl/functions/curl-getinfo.xml
+++ b/reference/curl/functions/curl-getinfo.xml
@@ -31,447 +31,513 @@
      <listitem>
       <para>
        Dies kann eine der folgenden Konstanten sein:
-       <itemizedlist>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAINFO</constant> - Der standardmäßige interne
-          Pfad zur CA-Zertifikatsdatei
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CAPATH</constant> - Der standardmäßige interne
-          Pfad zum CA-Verzeichnis
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_EFFECTIVE_URL</constant> - Die letzte
-          erfolgreiche URL
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CODE</constant> - Der letzte Antwortcode.
-          Von cURL 7.10.8 an ist dies ein veralteter Alias von
-          <constant>CURLINFO_RESPONSE_CODE</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME</constant> - Die (Server-) Zeit der
-          letzten Änderung des abgerufenen Dokuments, wenn die Option
-          <constant>CURLOPT_FILETIME</constant> aktiviert ist; wenn -1
-          zurückgegeben wird, ist die Zeit unbekannt
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME</constant> - Die Gesamtdauer des
-          letzten Transfers in Sekunden
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME</constant> - Die Zeit in
-          Sekunden, bis die Auflösung des Hostnamens abgeschlossen war.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME</constant> - Die Dauer des
-          Verbindungsaufbaus in Sekunden
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME</constant> - Die Zeit in
-          Sekunden zwischen dem Start und dem eigentlichen Beginn des Empfangs
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME</constant> - Die Zeit in
-          Sekunden bis zur Übertragung des ersten Bytes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_COUNT</constant> - Die Anzahl der
-          Weiterleitungen, wenn die Option
-          <constant>CURLOPT_FOLLOWLOCATION</constant> aktiviert ist
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME</constant> - Die Zeit in Sekunden,
-          die von allen Weiterleitungsschritten beansprucht wird, bevor der
-          eigentliche Transfer beginnt, wenn die Option
-          <constant>CURLOPT_FOLLOWLOCATION</constant> aktiviert ist
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_URL</constant> - Bei deaktivierter
-          <constant>CURLOPT_FOLLOWLOCATION</constant>-Option: die
-          Weiterleitungs-URL, die in der letzten Transaktion gefunden wurde
-          und als nächstes manuell angefordert werden sollte. Bei aktivierter
-          <constant>CURLOPT_FOLLOWLOCATION</constant>-Option ist dies immer
-          leer. Die Weiterleitungs-URL ist in diesem Fall in
-          <constant>CURLINFO_EFFECTIVE_URL</constant> verfügbar
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_IP</constant> - Die IP-Adresse der
-          jüngsten Verbindung
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIMARY_PORT</constant> - Der Ziel-Port der
-          jüngsten Verbindung
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_IP</constant> - Die lokale (Quell-)
-          IP-Adresse der jüngsten Verbindung
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_LOCAL_PORT</constant> - Der lokale (Quell-) Port
-          der jüngsten Verbindung
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD</constant> - Die Anzahl der
-          gesendeten Bytes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD</constant> - Die Anzahl der
-          empfangenen Bytes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD</constant> - Die durchschnittliche
-          Download-Geschwindigkeit
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD</constant> - Die durchschnittliche
-          Upload-Geschwindigkeit
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_SIZE</constant> - Die Gesamtgröße aller
-          empfangenen Header
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HEADER_OUT</constant> - Die gesendete Anfrage.
-          Damit dies funktioniert, muss die Option
-          <constant>CURLINFO_HEADER_OUT</constant> durch Aufruf von
-          <function>curl_setopt</function> zum Handle hinzugefügt werden
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REFERER</constant> - Der Referrer-Header
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REQUEST_SIZE</constant> - Die Gesamtgröße aller
-          Anfragen; momentan nur für HTTP verfügbar
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RETRY_AFTER</constant> - Die Information aus dem
-          <literal>Retry-After:</literal>-Header oder Null, wenn es keinen
-          gültigen Header gibt.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_VERIFYRESULT</constant> - Das Ergebnis der
-          Überprüfung des SSL-Zertifikats, angefordert durch das Setzen von
-          <constant>CURLOPT_SSL_VERIFYPEER</constant>
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant> - Die Größe
-          des Downloads, ermittelt aus dem
-          <literal>Content-Length:</literal>-Header
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant> - Die
-          festgesetzte Größe des Uploads
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_TYPE</constant> - Der
-          <literal>Content-Type:</literal> des angeforderten Dokuments. NULL
-          zeigt an, dass der Server keinen gültigen
-          <literal>Content-Type:</literal>-Header gesendet hat
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRIVATE</constant> - Private Daten, die zu diesem
-          cURL-Handle gehören und zuvor mit der Option
-          <constant>CURLOPT_PRIVATE</constant> der Funktion
-          <function>curl_setopt</function> gesetzt wurden
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_ERROR</constant> - Der detaillierte (SOCKS)
-          Proxy-Fehlercode, wenn bei der letzten Übertragung ein
-          <constant>CURLE_PROXY</constant> Fehler aufgetreten ist. Der
-          zurückgegebene Wert ist genau einer der
-          <constant>CURLPX_<replaceable>*</replaceable></constant>-Werte. Wenn
-          kein Antwortcode verfügbar ist, lautet der Fehlercode
-          <constant>CURLPX_OK</constant>.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RESPONSE_CODE</constant> - Der letzte Antwortcode
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_CONNECTCODE</constant> - Der
-          CONNECT-Antwortcode
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTPAUTH_AVAIL</constant> - Eine Bitmaske, die
-          die verfügbaren Authentifizierungsmethode(n) gemäß der vorherigen
-          Antwort anzeigt
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXYAUTH_AVAIL</constant> - Eine Bitmaske, die
-          die verfügbaren Proxy-Authentifikationsmethode(n) gemäß der
-          vorherigen Antwort anzeigt
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_OS_ERRNO</constant> - Die Fehlernummer (Errno)
-          eines Verbindungsfehlers. Die Zahl ist OS- und systemabhängig.
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NUM_CONNECTS</constant> - Die Anzahl der
-          Verbindungen, die cURL erzeugen musste, um die vorherigen
-          Übertragung durchzuführen
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SSL_ENGINES</constant> - Die unterstützten
-          OpenSSL-Crypto-Engines
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_COOKIELIST</constant> - Alle bekannten Cookies
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FTP_ENTRY_PATH</constant> - Der Entry-Pfad des
-          FTP-Servers
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME</constant> - Die Zeitdauer in
-          Sekunden, die bis zum SSL/SSH-Verbindungsaufbau/Handshake zum
-          entfernten Server verstrichen ist
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CERTINFO</constant> - Die TLS-Zertifikatskette
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONDITION_UNMET</constant> - Die Info über eine
-          nicht eingehaltene Zeitbedingung
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CLIENT_CSEQ</constant> - Die nächste CSeq
-          des RTSP-Clients
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_CSEQ_RECV</constant> - Die zuletzt
-          empfangene CSeq
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SERVER_CSEQ</constant> - Die nächste CSeq des
-          RTSP-Servers
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_RTSP_SESSION_ID</constant> - Die RTSP-Session-ID
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant> - Die
-          inhaltliche Länge des Downloads. Das ist der Wert, der aus dem
-          <literal>Content-Length:</literal>-Feld gelesen wurde. -1, wenn die
-          Größe nicht bekannt ist
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant> - Die
-          angegebene Größe des Uploads. -1, wenn die Größe nicht bekannt ist
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_HTTP_VERSION</constant> - Die Version, die in der
-          letzten HTTP-Verbindung verwendet wurde. Der Rückgabewert ist eine
-          der definierten <constant>CURL_HTTP_VERSION_*</constant>-Konstanten
-          oder 0, wenn die Version nicht ermittelt werden kann
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROTOCOL</constant> - Das Protokoll, das in der
-          letzten HTTP-Verbindung verwendet wurde. Der Rückgabewert ist genau
-          einer der <constant>CURLPROTO_*</constant>-Werte
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant> - Das Ergebnis
-          der Zertifikatsprüfung, die angefordert wurde (durch Verwendung der
-          Option <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Wird nur
-          für HTTPS-Proxies verwendet
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SCHEME</constant> - Das URL-Schema, das für die
-          jüngste Verbindung verwendet wurde
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_DOWNLOAD_T</constant> - Die Gesamtanzahl von
-          Bytes, die heruntergeladen wurden. Die Anzahl betrifft nur die
-          letzte Übertragung, und wird für jede neue Übertragung zurückgesetzt
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SIZE_UPLOAD_T</constant> - Die Gesamtanzahl von
-          Bytes, die hochgeladen wurden
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_DOWNLOAD_T</constant> - Die
-          durchschnittliche Download-Geschwindigkeit in Bytes pro Sekunde, die
-          CURL für den vollständigen Download gemessen hat
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_SPEED_UPLOAD_T</constant> - Die durchschnittliche
-          Upload-Geschwindigkeit in Bytes pro Sekunde, die CURL für den
-          vollständigen Upload gemessen hat
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_APPCONNECT_TIME_T</constant> - Die Zeit in
-          Mikrosekunden, die vom Beginn bis zur Vollendung der
-          SSL/SSH-Verbindung/des Handshakes zum Remote-Host vergangen ist
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_CONNECT_TIME_T</constant> - Die Gesamtdauer in
-          Mikrosekunden, vom Beginn bis zur Vollendung der Verbindung zum
-          Remote-Host (oder Proxy)
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_FILETIME_T</constant> - Die letzte Änderung des
-          abgerufenen Dokuments (als Unix-Zeitstempel); eine Alternative zu
-          <constant>CURLINFO_FILETIME</constant>, die es Systemen mit
-          32-Bit-Ganzzahlvariablen ermöglicht, Daten außerhalb des
-          32-Bit-Zeitstempelbereichs zu extrahieren
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_NAMELOOKUP_TIME_T</constant> - Die Dauer in
-          Mikrosekunden vom Beginn bis zur Vervollständigung der Namensauflösung
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_PRETRANSFER_TIME_T</constant> - Die benötigte
-          Zeit vom Beginn bis zum eigentlichen Beginn der Dateiübertragung in
-          Mikrosekunden
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_REDIRECT_TIME_T</constant> - Die Gesamtdauer in
-          Mikrosekunden für alle Weiterleitungsschritte einschließlich
-          Namenslookup, Verbindung, Vorübertragung und Übertragung, bis zum
-          Beginn der eigentlichen Transaktion
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_STARTTRANSFER_TIME_T</constant> - Die benötigte
-          Zeit in Mikrosekunden vom Beginn bis zum Empfang des ersten Bytes
-         </simpara>
-        </listitem>
-        <listitem>
-         <simpara>
-          <constant>CURLINFO_TOTAL_TIME_T</constant> - Die Gesamtdauer in
-          Mikrosekunden für die vorhergehende Übertragung einschließlich
-          Namensauflösung, TCP-Verbindung usw.
-         </simpara>
-        </listitem>
-       </itemizedlist>
+       <informaltable>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry valign="top">Option</entry>
+           <entry valign="top">&Description;</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry><constant>CURLINFO_CAINFO</constant></entry>
+           <entry>
+            Der standardmäßige interne Pfad zur CA-Zertifikatsdatei
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CAPATH</constant></entry>
+           <entry>
+            Der standardmäßige interne Pfad zum CA-Verzeichnis
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_EFFECTIVE_URL</constant></entry>
+           <entry>
+            Die letzte erfolgreiche URL
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CODE</constant></entry>
+           <entry>
+            Der letzte Antwortcode.
+            Von cURL 7.10.8 an ist dies ein veralteter Alias von
+            <constant>CURLINFO_RESPONSE_CODE</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME</constant></entry>
+           <entry>
+            Die (Server-) Zeit der
+            letzten Änderung des abgerufenen Dokuments, wenn die Option
+            <constant>CURLOPT_FILETIME</constant>
+            aktiviert ist; wenn -1
+            zurückgegeben wird, ist die Zeit unbekannt
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME</constant></entry>
+           <entry>
+            Die Gesamtdauer des
+            letzten Transfers in Sekunden
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME</constant></entry>
+           <entry>
+            Die Zeit in Sekunden,
+            bis die Auflösung des Hostnamens abgeschlossen war.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME</constant></entry>
+           <entry>
+            Die Dauer des Verbindungsaufbaus in Sekunden
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME</constant></entry>
+           <entry>
+            Die Zeit in Sekunden zwischen dem Start
+            und dem eigentlichen Beginn des Empfangs
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME</constant></entry>
+           <entry>
+            Die Zeit in Sekunden bis zur Übertragung des ersten Bytes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_COUNT</constant></entry>
+           <entry>
+            Die Anzahl der Weiterleitungen, wenn die Option
+            <constant>CURLOPT_FOLLOWLOCATION</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME</constant></entry>
+           <entry>
+            Die Zeit in Sekunden,
+            die von allen Weiterleitungsschritten beansprucht wird, bevor der
+            eigentliche Transfer beginnt, wenn die Option
+           <constant>CURLOPT_FOLLOWLOCATION</constant>
+            aktiviert ist
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_URL</constant></entry>
+           <entry>
+            Bei deaktivierter
+            <constant>CURLOPT_FOLLOWLOCATION</constant>-Option: die
+            Weiterleitungs-URL, die in der letzten Transaktion gefunden wurde
+            und als nächstes manuell angefordert werden sollte. Bei aktivierter
+            <constant>CURLOPT_FOLLOWLOCATION</constant>-Option ist dies immer
+            leer. Die Weiterleitungs-URL ist in diesem Fall in
+            <constant>CURLINFO_EFFECTIVE_URL</constant>
+            verfügbar
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_IP</constant></entry>
+           <entry>
+            Die IP-Adresse der jüngsten Verbindung
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIMARY_PORT</constant></entry>
+           <entry>
+            Der Ziel-Port der jüngsten Verbindung
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_IP</constant></entry>
+           <entry>
+            Die lokale (Quell-) IP-Adresse der jüngsten Verbindung
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_LOCAL_PORT</constant></entry>
+           <entry>
+            Der lokale (Quell-) Port der jüngsten Verbindung
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD</constant></entry>
+           <entry>
+            Die Anzahl der gesendeten Bytes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD</constant></entry>
+           <entry>
+            Die Anzahl der empfangenen Bytes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD</constant></entry>
+           <entry>
+            Die durchschnittliche Download-Geschwindigkeit
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD</constant></entry>
+           <entry>
+            Die durchschnittliche Upload-Geschwindigkeit
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_SIZE</constant></entry>
+           <entry>
+            Die Gesamtgröße aller empfangenen Header
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HEADER_OUT</constant></entry>
+           <entry>
+            Die gesendete Anfrage.
+            Damit dies funktioniert, muss die Option
+            <constant>CURLINFO_HEADER_OUT</constant>
+            durch Aufruf von
+            <function>curl_setopt</function> zum Handle hinzugefügt werden
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REFERER</constant></entry>
+           <entry>
+            Der Referrer-Header
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REQUEST_SIZE</constant></entry>
+           <entry>
+            Die Gesamtgröße aller
+            Anfragen; momentan nur für HTTP verfügbar
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RETRY_AFTER</constant></entry>
+           <entry>
+            Die Information aus dem
+            <literal>Retry-After:</literal>-Header oder Null, wenn es keinen
+            gültigen Header gibt.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            Das Ergebnis der
+            Überprüfung des SSL-Zertifikats, angefordert durch das Setzen von
+            <constant>CURLOPT_SSL_VERIFYPEER</constant>
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD</constant></entry>
+           <entry>
+            Die Größe
+            des Downloads, ermittelt aus dem
+            <literal>Content-Length:</literal>-Header
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD</constant></entry>
+           <entry>
+            Die festgesetzte Größe des Uploads
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_TYPE</constant></entry>
+           <entry>
+            Der
+            <literal>Content-Type:</literal> des angeforderten Dokuments. NULL
+            zeigt an, dass der Server keinen gültigen
+            <literal>Content-Type:</literal>-Header gesendet hat
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRIVATE</constant></entry>
+           <entry>
+            Private Daten, die zu diesem
+            cURL-Handle gehören und zuvor mit der Option
+            <constant>CURLOPT_PRIVATE</constant>
+            der Funktion
+            <function>curl_setopt</function> gesetzt wurden
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_ERROR</constant></entry>
+           <entry>
+            Der detaillierte (SOCKS)
+            Proxy-Fehlercode, wenn bei der letzten Übertragung ein
+            <constant>CURLE_PROXY</constant>
+            Fehler aufgetreten ist. Der
+            zurückgegebene Wert ist genau einer der
+            <constant>CURLPX_<replaceable>*</replaceable></constant>
+            -Werte. Wenn
+            kein Antwortcode verfügbar ist, lautet der Fehlercode
+            <constant>CURLPX_OK</constant>.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RESPONSE_CODE</constant></entry>
+           <entry>
+            Der letzte Antwortcode
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_CONNECTCODE</constant></entry>
+           <entry>
+            Der CONNECT-Antwortcode
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTPAUTH_AVAIL</constant></entry>
+           <entry>
+            Eine Bitmaske, die
+            die verfügbaren Authentifizierungsmethode(n) gemäß der vorherigen
+            Antwort anzeigt
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXYAUTH_AVAIL</constant></entry>
+           <entry>
+            Eine Bitmaske, die
+            die verfügbaren Proxy-Authentifikationsmethode(n) gemäß der
+            vorherigen Antwort anzeigt
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_OS_ERRNO</constant></entry>
+           <entry>
+            Die Fehlernummer (Errno)
+            eines Verbindungsfehlers. Die Zahl ist OS- und systemabhängig.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NUM_CONNECTS</constant></entry>
+           <entry>
+            Die Anzahl der
+            Verbindungen, die cURL erzeugen musste, um die vorherigen
+            Übertragung durchzuführen
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SSL_ENGINES</constant></entry>
+           <entry>
+            Die unterstützten
+            OpenSSL-Crypto-Engines
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_COOKIELIST</constant></entry>
+           <entry>
+            Alle bekannten Cookies
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FTP_ENTRY_PATH</constant></entry>
+           <entry>
+            Der Entry-Pfad des
+            FTP-Servers
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME</constant></entry>
+           <entry>
+            Die Zeitdauer in
+            Sekunden, die bis zum SSL/SSH-Verbindungsaufbau/Handshake zum
+            entfernten Server verstrichen ist
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CERTINFO</constant></entry>
+           <entry>
+            Die TLS-Zertifikatskette
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONDITION_UNMET</constant></entry>
+           <entry>
+            Die Info über eine
+            nicht eingehaltene Zeitbedingung
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CLIENT_CSEQ</constant></entry>
+           <entry>
+            Die nächste CSeq
+            des RTSP-Clients
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_CSEQ_RECV</constant></entry>
+           <entry>
+            Die zuletzt
+            empfangene CSeq
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SERVER_CSEQ</constant></entry>
+           <entry>
+            Die nächste CSeq des
+            RTSP-Servers
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_RTSP_SESSION_ID</constant></entry>
+           <entry>
+            Die RTSP-Session-ID
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_DOWNLOAD_T</constant></entry>
+           <entry>
+            Die
+            inhaltliche Länge des Downloads. Das ist der Wert, der aus dem
+            <literal>Content-Length:</literal>-Feld gelesen wurde. -1, wenn die
+            Größe nicht bekannt ist
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONTENT_LENGTH_UPLOAD_T</constant></entry>
+           <entry>
+            Die
+            angegebene Größe des Uploads. -1, wenn die Größe nicht bekannt ist
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_HTTP_VERSION</constant></entry>
+           <entry>
+            Die Version, die in der
+            letzten HTTP-Verbindung verwendet wurde. Der Rückgabewert ist eine
+            der definierten <constant>CURL_HTTP_VERSION_*</constant>-Konstanten
+            oder 0, wenn die Version nicht ermittelt werden kann
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROTOCOL</constant></entry>
+           <entry>
+            Das Protokoll, das in der
+            letzten HTTP-Verbindung verwendet wurde. Der Rückgabewert ist genau
+            einer der <constant>CURLPROTO_*</constant>-Werte
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PROXY_SSL_VERIFYRESULT</constant></entry>
+           <entry>
+            Das Ergebnis
+            der Zertifikatsprüfung, die angefordert wurde (durch Verwendung der
+            Option <constant>CURLOPT_PROXY_SSL_VERIFYPEER</constant>). Wird nur
+            für HTTPS-Proxies verwendet
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SCHEME</constant></entry>
+           <entry>
+            Das URL-Schema, das für die
+            jüngste Verbindung verwendet wurde
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_DOWNLOAD_T</constant></entry>
+           <entry>
+            Die Gesamtanzahl von
+            Bytes, die heruntergeladen wurden. Die Anzahl betrifft nur die
+            letzte Übertragung, und wird für jede neue Übertragung zurückgesetzt
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SIZE_UPLOAD_T</constant></entry>
+           <entry>
+            Die Gesamtanzahl von
+            Bytes, die hochgeladen wurden
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_DOWNLOAD_T</constant></entry>
+           <entry>
+            Die
+            durchschnittliche Download-Geschwindigkeit in Bytes pro Sekunde, die
+            CURL für den vollständigen Download gemessen hat
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_SPEED_UPLOAD_T</constant></entry>
+           <entry>
+            Die durchschnittliche
+            Upload-Geschwindigkeit in Bytes pro Sekunde, die CURL für den
+            vollständigen Upload gemessen hat
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_APPCONNECT_TIME_T</constant></entry>
+           <entry>
+            Die Zeit in
+            Mikrosekunden, die vom Beginn bis zur Vollendung der
+            SSL/SSH-Verbindung/des Handshakes zum Remote-Host vergangen ist
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_CONNECT_TIME_T</constant></entry>
+           <entry>
+            Die Gesamtdauer in
+            Mikrosekunden, vom Beginn bis zur Vollendung der Verbindung zum
+            Remote-Host (oder Proxy)
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_FILETIME_T</constant></entry>
+           <entry>
+            Die letzte Änderung des
+            abgerufenen Dokuments (als Unix-Zeitstempel); eine Alternative zu
+            <constant>CURLINFO_FILETIME</constant>, die es Systemen mit
+            32-Bit-Ganzzahlvariablen ermöglicht, Daten außerhalb des
+            32-Bit-Zeitstempelbereichs zu extrahieren
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_NAMELOOKUP_TIME_T</constant></entry>
+           <entry>
+            Die Dauer in
+            Mikrosekunden vom Beginn bis zur Vervollständigung der Namensauflösung
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_PRETRANSFER_TIME_T</constant></entry>
+           <entry>
+            Die benötigte
+            Zeit vom Beginn bis zum eigentlichen Beginn der Dateiübertragung in
+            Mikrosekunden
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_REDIRECT_TIME_T</constant></entry>
+           <entry>
+            Die Gesamtdauer in
+            Mikrosekunden für alle Weiterleitungsschritte einschließlich
+            Namenslookup, Verbindung, Vorübertragung und Übertragung, bis zum
+            Beginn der eigentlichen Transaktion
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_STARTTRANSFER_TIME_T</constant></entry>
+           <entry>
+            Die benötigte
+            Zeit in Mikrosekunden vom Beginn bis zum Empfang des ersten Bytes
+           </entry>
+          </row>
+          <row>
+           <entry><constant>CURLINFO_TOTAL_TIME_T</constant></entry>
+           <entry>
+            Die Gesamtdauer in
+            Mikrosekunden für die vorhergehende Übertragung einschließlich
+            Namensauflösung, TCP-Verbindung usw.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </informaltable>
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
This PR converts the constant list for the second (`option`) parameter of `curl_getinfo()` to a table (as it was done in `doc-en` [here](https://github.com/php/doc-en/pull/3130)).