### PR TITLE
--with-password-argon2 option should not be translated

### DIFF
--- a/reference/password/setup.xml
+++ b/reference/password/setup.xml
@@ -9,7 +9,7 @@
   &no.requirement;
   <para>
    Für Argon2 Passwort-Hashing wird allerdings
-   <link xlink:href="&url.libargon2;">libargon2</link> benotigt. Von PHP 7.3.0
+   <link xlink:href="&url.libargon2;">libargon2</link> benötigt. Von PHP 7.3.0
    an wird libargon2 Version 20161029 oder neuer benötigt.
   </para>
  </section>
@@ -24,7 +24,7 @@
   </para>
   <para>
    Vor PHP 8.1.0 war es möglich, das argon2-Verzeichnis mit
-   <option role="configure">--mit-passwort-argon2[=DIR]</option> anzugeben.
+   <option role="configure">--with-password-argon2[=DIR]</option> anzugeben.
   </para>
  </section>
 


### PR DESCRIPTION
and an ö typo fix