### PR TITLE
Improve sentence

### DIFF
--- a/reference/exec/functions/exec.xml
+++ b/reference/exec/functions/exec.xml
@@ -38,10 +38,10 @@
      <term><parameter>output</parameter></term>
      <listitem>
       <para>
-       Ist der Parameter <parameter>output</parameter> angegeben, wird
-       dieses mit jeder Zeile der Befehlsausgabe gefüllt. Am Ende
+       Ist der Parameter <parameter>output</parameter> vorhanden, wird
+       das angegebene Array mit jeder Zeile der Befehlsausgabe gefüllt. Am Ende
        einer jeweiligen Zeile stehende Whitespaces wie beispielsweise
-       ein <literal>\n</literal> wird nicht in dieses Array übernommen.
+       ein <literal>\n</literal> werden nicht in dieses Array übernommen.
        Beachten Sie, dass wenn das Array bereits Elemente enthält, die Funktion
        <function>exec</function> die Ausgabe an das Array anhängt.  Wenn
        Sie dieses nicht wünschen, rufen Sie die Funktion <function>unset


### PR DESCRIPTION
Some words were missing and the whole sentence made not much sense.