### PR TITLE
translate: sodium crypto functions

### DIFF
--- a/reference/sodium/functions/sodium-crypto-auth-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-auth-keygen.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-auth-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_auth_keygen</refname>
+  <refpurpose>Erzeugt einen zufälligen Schlüssel für sodium_crypto_auth</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_auth_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen Schlüssel zur Verwendung mit
+   <function>sodium_crypto_auth</function> und
+   <function>sodium_crypto_auth_verify</function>.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt einen zufälligen 256-Bit-Schlüssel zurück.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-auth-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-auth-keygen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-auth-keygen">
  <refnamediv>
   <refname>sodium_crypto_auth_keygen</refname>

--- a/reference/sodium/functions/sodium-crypto-auth-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-auth-keygen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-auth-keygen">
  <refnamediv>
   <refname>sodium_crypto_auth_keygen</refname>

--- a/reference/sodium/functions/sodium-crypto-box-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-box-keypair.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-box-keypair">
+ <refnamediv>
+  <refname>sodium_crypto_box_keypair</refname>
+  <refpurpose>Erzeugt zufällig einen geheimen Schlüssel und einen zugehörigen öffentlichen Schlüssel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_box_keypair</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen geheimen Schlüssel und einen öffentlichen Schlüssel als eine Zeichenkette.
+  </simpara>
+  <simpara>
+   Um den geheimen Schlüssel aus dieser vereinigten Schlüsselpaar-Zeichenkette zu extrahieren,
+   siehe <function>sodium_crypto_box_secretkey</function>.
+   Um den öffentlichen Schlüssel aus dieser vereinigten Schlüsselpaar-Zeichenkette zu extrahieren,
+   siehe <function>sodium_crypto_box_publickey</function>.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Eine Zeichenkette, die sowohl den geheimen X25519-Schlüssel als auch den
+   zugehörigen öffentlichen X25519-Schlüssel enthält.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-box-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-box-keypair.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-box-keypair">
  <refnamediv>
   <refname>sodium_crypto_box_keypair</refname>
-  <refpurpose>Erzeugt zufällig einen geheimen Schlüssel und einen zugehörigen öffentlichen Schlüssel</refpurpose>
+  <refpurpose>Erzeugt einen zufälligen geheimen Schlüssel und einen zugehörigen öffentlichen Schlüssel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-box-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-box-keypair.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-box-keypair">
  <refnamediv>
   <refname>sodium_crypto_box_keypair</refname>

--- a/reference/sodium/functions/sodium-crypto-box-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-box-keypair.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-box-keypair">
  <refnamediv>
   <refname>sodium_crypto_box_keypair</refname>

--- a/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_generichash_keygen</refname>
+  <refpurpose>Erzeugt einen zufälligen Generichash-Schlüssel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_generichash_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen zufälligen Schlüssel zur Verwendung mit der Generichash-API.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ein zufälliger 256-Bit-Schlüssel.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-keygen">
  <refnamediv>
   <refname>sodium_crypto_generichash_keygen</refname>

--- a/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-generichash-keygen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-generichash-keygen">
  <refnamediv>
   <refname>sodium_crypto_generichash_keygen</refname>

--- a/reference/sodium/functions/sodium-crypto-kdf-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-kdf-keygen.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-kdf-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_kdf_keygen</refname>
+  <refpurpose>Erzeugt einen zufälligen Stammschlüssel für die KDF-Schnittstelle</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_kdf_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen zufälligen Schlüssel, der als Stammschlüssel für
+   <function>sodium_crypto_kdf_derive_from_key</function> verwendet werden kann.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ein zufälliger 256-Bit-Schlüssel.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-kdf-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-kdf-keygen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-kdf-keygen">
  <refnamediv>
   <refname>sodium_crypto_kdf_keygen</refname>

--- a/reference/sodium/functions/sodium-crypto-kdf-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-kdf-keygen.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<!-- EN-Revision: 14e3e35ca0c82b3b5fb3fd71b9dd70e9eb250ab1 Maintainer: lacatoire Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-kdf-keygen">
  <refnamediv>
   <refname>sodium_crypto_kdf_keygen</refname>

--- a/reference/sodium/functions/sodium-crypto-scalarmult-base.xml
+++ b/reference/sodium/functions/sodium-crypto-scalarmult-base.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e961c859a75a952622cc47504a55e34b10b46549 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.sodium-crypto-scalarmult-base" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>sodium_crypto_scalarmult_base</refname>
+  <refpurpose>&Alias; <function>sodium_crypto_box_publickey_from_secretkey</function></refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &info.function.alias;
+   <function>sodium_crypto_box_publickey_from_secretkey</function>.
+  </simpara>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-secretstream-xchacha20poly1305-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-secretstream-xchacha20poly1305-keygen.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-secretstream-xchacha20poly1305-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_secretstream_xchacha20poly1305_keygen</refname>
+  <refpurpose>Erzeugt einen zufälligen Secretstream-Schlüssel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_secretstream_xchacha20poly1305_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen zufälligen Secretstream-Schlüssel.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt eine Zeichenkette aus zufälligen Bytes zurück.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-shorthash-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-shorthash-keygen.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-shorthash-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_shorthash_keygen</refname>
+  <refpurpose>Erzeugt zufällige Bytes für einen Schlüssel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_shorthash_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen Schlüssel zur Verwendung mit
+   <function>sodium_crypto_shorthash</function>.
+  </simpara>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-sign-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-sign-keypair.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-sign-keypair">
+ <refnamediv>
+  <refname>sodium_crypto_sign_keypair</refname>
+  <refpurpose>Erzeugt zufällig einen geheimen Schlüssel und einen zugehörigen öffentlichen Schlüssel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_sign_keypair</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt ein zufälliges Ed25519-Schlüsselpaar als eine Zeichenkette.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ed25519-Schlüsselpaar.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-sign-keypair.xml
+++ b/reference/sodium/functions/sodium-crypto-sign-keypair.xml
@@ -4,7 +4,7 @@
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-sign-keypair">
  <refnamediv>
   <refname>sodium_crypto_sign_keypair</refname>
-  <refpurpose>Erzeugt zufällig einen geheimen Schlüssel und einen zugehörigen öffentlichen Schlüssel</refpurpose>
+  <refpurpose>Erzeugt einen zufälligen geheimen Schlüssel und einen zugehörigen öffentlichen Schlüssel</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/sodium/functions/sodium-crypto-stream-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-keygen.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.sodium-crypto-stream-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_stream_keygen</refname>
+  <refpurpose>Erzeugt einen zufälligen sodium_crypto_stream-Schlüssel</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_stream_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt einen Schlüssel zur Verwendung mit
+   <function>sodium_crypto_stream</function> und
+   <function>sodium_crypto_stream_xor</function>.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Verschlüsselungsschlüssel (256-Bit).
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sodium/functions/sodium-crypto-stream-xchacha20-keygen.xml
+++ b/reference/sodium/functions/sodium-crypto-stream-xchacha20-keygen.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96a8863cc0403bb23a99caff9a113b64f3524671 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.sodium-crypto-stream-xchacha20-keygen">
+ <refnamediv>
+  <refname>sodium_crypto_stream_xchacha20_keygen</refname>
+  <refpurpose>Gibt einen sicheren zufälligen Schlüssel zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>sodium_crypto_stream_xchacha20_keygen</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt einen sicheren zufälligen Schlüssel zur Verwendung mit
+   <function>sodium_crypto_stream_xchacha20</function> zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt einen sicheren zufälligen 32-Byte-Schlüssel zur Verwendung mit
+   <function>sodium_crypto_stream_xchacha20</function> zurück.
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add German translations for sodium cryptography functions:
- sodium_crypto_scalarmult_base
- sodium_crypto_stream_xchacha20_keygen
- sodium_crypto_auth_keygen
- sodium_crypto_generichash_keygen
- sodium_crypto_kdf_keygen
- sodium_crypto_secretstream_xchacha20poly1305_keygen
- sodium_crypto_sign_keypair
- sodium_crypto_stream_keygen
- sodium_crypto_shorthash_keygen
- sodium_crypto_box_keypair