### PR TITLE
translate: I/O & stream functions

### DIFF
--- a/reference/eio/functions/eio-sync.xml
+++ b/reference/eio/functions/eio-sync.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 4e53894013ec0d223e2723ece46447ba00d5baf5 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-sync">
+ <refnamediv>
+  <refname>eio_sync</refname>
+  <refpurpose>Schreibt den Puffer-Cache auf die Festplatte</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_sync</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_sync</function> gibt bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-sync.xml
+++ b/reference/eio/functions/eio-sync.xml
@@ -29,7 +29,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_sync</function> gibt bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+   <function>eio_sync</function> gibt bei Erfolg eine Anfrage-Ressource zurück. &return.falseforfailure;
   </simpara>
  </refsect1>
 

--- a/reference/lzf/functions/lzf-optimized-for.xml
+++ b/reference/lzf/functions/lzf-optimized-for.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: b274da1f1b2bc989b211c8ba50c51b27a3bc5af8 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.lzf-optimized-for">
+ <refnamediv>
+  <refname>lzf_optimized_for</refname>
+  <refpurpose>
+   Ermittelt, wofür die LZF-Erweiterung optimiert wurde
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>lzf_optimized_for</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Ermittelt, wofür die LZF-Erweiterung bei der Kompilierung optimiert wurde.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt 1 zurück, wenn LZF für Geschwindigkeit optimiert wurde, 0 für Komprimierung.
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/phpdbg/functions/phpdbg-start-oplog.xml
+++ b/reference/phpdbg/functions/phpdbg-start-oplog.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 06f14554e7e5d9a47de0eff61578759fea2e23d9 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.phpdbg-start-oplog">
+ <refnamediv>
+  <refname>phpdbg_start_oplog</refname>
+  <refpurpose>Startet ein Oplog</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>phpdbg_start_oplog</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+
+  </simpara>
+
+  &warn.undocumented.func;
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/radius/functions/radius-close.xml
+++ b/reference/radius/functions/radius-close.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9ac4d06c0bddbbb1b87ba93d1591ef1707d30420 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-close">
+   <refnamediv>
+    <refname>radius_close</refname>
+    <refpurpose>Gibt alle Ressourcen frei</refpurpose>
+   </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>radius_close</methodname>
+   <methodparam><type>resource</type><parameter>radius_handle</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Es ist nicht notwendig, diese Funktion aufzurufen, da PHP alle Ressourcen
+   am Ende jeder Anfrage freigibt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &radius.parameter.handle;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/radius/functions/radius-strerror.xml
+++ b/reference/radius/functions/radius-strerror.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 9ac4d06c0bddbbb1b87ba93d1591ef1707d30420 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.radius-strerror">
+ <refnamediv>
+  <refname>radius_strerror</refname>
+  <refpurpose>Gibt eine Fehlermeldung zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>radius_strerror</methodname>
+   <methodparam><type>resource</type><parameter>radius_handle</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Wenn Radius-Funktionen fehlschlagen, wird eine Fehlermeldung aufgezeichnet.
+   Diese Fehlermeldung kann mit dieser Funktion abgerufen werden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &radius.parameter.handle;
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt Fehlermeldungen als Zeichenkette von fehlgeschlagenen Radius-Funktionen zurück.
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/rnp/functions/rnp-backend-version.xml
+++ b/reference/rnp/functions/rnp-backend-version.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 462b2bc5580f4bfaabe48be54a91f978cc181e9b Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.rnp-backend-version">
+ <refnamediv>
+  <refname>rnp_backend_version</refname>
+  <refpurpose>Gibt die Version der kryptographischen Backend-Bibliothek zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>rnp_backend_version</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Versionszeichenkette.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/rnp/functions/rnp-version-string-full.xml
+++ b/reference/rnp/functions/rnp-version-string-full.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 462b2bc5580f4bfaabe48be54a91f978cc181e9b Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.rnp-version-string-full">
+ <refnamediv>
+  <refname>rnp_version_string_full</refname>
+  <refpurpose>Vollständige Versionszeichenkette der RNP-Bibliothek</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>rnp_version_string_full</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+
+  </simpara>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt die vollständige Versionszeichenkette der RNP-Bibliothek zurück.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/rnp/functions/rnp-version-string.xml
+++ b/reference/rnp/functions/rnp-version-string.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 462b2bc5580f4bfaabe48be54a91f978cc181e9b Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.rnp-version-string">
+ <refnamediv>
+  <refname>rnp_version_string</refname>
+  <refpurpose>Version der RNP-Bibliothek</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>rnp_version_string</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt die Versionszeichenkette der RNP-Bibliothek zurück.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/functions/swoole-clear-error.xml
+++ b/reference/swoole/functions/swoole-clear-error.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e48f15d64afec9861e23aa70f49b17ce504b35b2 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.swoole-clear-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>swoole_clear_error</refname>
+  <refpurpose>Löscht Fehler im Socket oder im letzten Fehlercode</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>swoole_clear_error</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Löscht Fehler im Socket oder im letzten Fehlercode.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/functions/swoole-cpu-num.xml
+++ b/reference/swoole/functions/swoole-cpu-num.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: dd07341fae2c414adc1f700be0890ff32e8daab4 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.swoole-cpu-num" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>swoole_cpu_num</refname>
+  <refpurpose>Ermittelt die Anzahl der CPUs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>swoole_cpu_num</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    Die Anzahl der CPUs.
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add German translations for I/O and stream function reference files:
- lzf_optimized_for
- rnp_backend_version, rnp_version_string, rnp_version_string_full
- swoole_clear_error, swoole_cpu_num
- eio_sync
- phpdbg_start_oplog
- radius_close, radius_strerror