### PR TITLE
translate: DB & extension functions

### DIFF
--- a/reference/apcu/functions/apcu-enabled.xml
+++ b/reference/apcu/functions/apcu-enabled.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 804d8a05451c13328eb1192553dcb2374706cabb Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.apcu-enabled">
+ <refnamediv>
+  <refname>apcu_enabled</refname>
+  <refpurpose>Prüft, ob APCu in der aktuellen Umgebung verfügbar ist</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>bool</type><methodname>apcu_enabled</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt zurück, ob APCu in der aktuellen Umgebung verfügbar ist.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt &true; zurück, wenn APCu in der aktuellen Umgebung verfügbar ist,
+   andernfalls &false;.
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-dict-add-to-personal.xml
+++ b/reference/enchant/functions/enchant-dict-add-to-personal.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 94f2c273f0bb214580b3cba17273f79e8cc2cb25 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.enchant-dict-add-to-personal" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>enchant_dict_add_to_personal</refname>
+  <refpurpose>&Alias; <function>enchant_dict_add</function></refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+   &warn.deprecated.alias-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &info.function.alias;
+   <function>enchant_dict_add</function>.
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-dict-is-in-session.xml
+++ b/reference/enchant/functions/enchant-dict-is-in-session.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 94f2c273f0bb214580b3cba17273f79e8cc2cb25 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.enchant-dict-is-in-session" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>enchant_dict_is_in_session</refname>
+  <refpurpose>&Alias; <function>enchant_dict_is_added</function></refpurpose>
+ </refnamediv>
+
+ <refsynopsisdiv>
+   &warn.deprecated.alias-8-0-0;
+ </refsynopsisdiv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+   &info.function.alias;
+   <function>enchant_dict_is_added</function>.
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fdf/functions/fdf-remove-item.xml
+++ b/reference/fdf/functions/fdf-remove-item.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.fdf-remove-item" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>fdf_remove_item</refname>
+  <refpurpose>Setzt den Zielrahmen für ein Formular</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fdf_remove_item</methodname>
+   <methodparam><type>resource</type><parameter>fdf_document</parameter></methodparam>
+   <methodparam><type>string</type><parameter>fieldname</parameter></methodparam>
+   <methodparam><type>int</type><parameter>item</parameter></methodparam>
+  </methodsynopsis>
+  &warn.undocumented.func;
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fpm/functions/fastcgi-finish-request.xml
+++ b/reference/fpm/functions/fastcgi-finish-request.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 0ba9e74ebc71fc8aa5fcd0f5f48654a4a6a83368 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.fastcgi-finish-request">
+ <refnamediv>
+  <refname>fastcgi_finish_request</refname>
+  <refpurpose>Sendet alle Antwortdaten an den Client</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fastcgi_finish_request</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Diese Funktion sendet alle Antwortdaten an den Client und beendet die
+   Anfrage. Dadurch können zeitaufwändige Aufgaben ausgeführt werden, ohne
+   die Verbindung zum Client offen zu halten.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/rrd/functions/rrd-error.xml
+++ b/reference/rrd/functions/rrd-error.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 0f2a5f5ddb1c342cee4c64268313e4ad8e671051 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.rrd-error">
+ <refnamediv>
+  <refname>rrd_error</refname>
+  <refpurpose>Gibt die letzte Fehlermeldung zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>rrd_error</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt die letzte globale rrd-Fehlermeldung zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die letzte Fehlermeldung.
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/rrd/functions/rrd-version.xml
+++ b/reference/rrd/functions/rrd-version.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 0f2a5f5ddb1c342cee4c64268313e4ad8e671051 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.rrd-version">
+ <refnamediv>
+  <refname>rrd_version</refname>
+  <refpurpose>Gibt Informationen über die zugrunde liegende rrdtool-Bibliothek zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>rrd_version</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt Informationen über die zugrunde liegende rrdtool-Bibliothek zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Zeichenkette mit der Versionsnummer von rrdtool, z.B. "1.4.3".
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/snmp/functions/snmp-set-oid-numeric-print.xml
+++ b/reference/snmp/functions/snmp-set-oid-numeric-print.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 40906725410aac6fe8cac4913a557a1784bf04b9 Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmp-set-oid-numeric-print">
+ <refnamediv>
+  <refname>snmp_set_oid_numeric_print</refname>
+  <refpurpose>&Alias; <function>snmp_set_oid_output_format</function></refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>
+  &info.function.alias; <function>snmp_set_oid_output_format</function>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>snmp_set_oid_output_format</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/xmlrpc/functions/xmlrpc-decode-request.xml
+++ b/reference/xmlrpc/functions/xmlrpc-decode-request.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.xmlrpc-decode-request" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>xmlrpc_decode_request</refname>
+  <refpurpose>Dekodiert XML in native PHP-Typen</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>xmlrpc_decode_request</methodname>
+   <methodparam><type>string</type><parameter>xml</parameter></methodparam>
+   <methodparam><type>string</type><parameter role="reference">method</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>encoding</parameter></methodparam>
+  </methodsynopsis>
+  &warn.experimental.func;
+  &warn.undocumented.func;
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/xmlrpc/functions/xmlrpc-server-register-method.xml
+++ b/reference/xmlrpc/functions/xmlrpc-server-register-method.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.xmlrpc-server-register-method" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>xmlrpc_server_register_method</refname>
+  <refpurpose>Registriert eine PHP-Funktion als Ressourcen-Methode passend zu method_name</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>xmlrpc_server_register_method</methodname>
+   <methodparam><type>resource</type><parameter>server</parameter></methodparam>
+   <methodparam><type>string</type><parameter>method_name</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
+  </methodsynopsis>
+  &warn.experimental.func;
+  &warn.undocumented.func;
+ </refsect1>
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add German translations for DB and extension function reference files:
- enchant_dict_add_to_personal, enchant_dict_is_in_session (aliases)
- xmlrpc_decode_request, xmlrpc_server_register_method
- fdf_remove_item
- snmp_set_oid_numeric_print (alias)
- apcu_enabled
- rrd_error, rrd_version
- fastcgi_finish_request