### PR TITLE
Batch sync 54 small file updates

### DIFF
--- a/language/control-structures/do-while.xml
+++ b/language/control-structures/do-while.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7104ee97ced1768a3231588dfc0bc0d7eb1117ad Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 53fb200fed6d316b0616a915eb87a40de1d80f51 Maintainer: sammywg Status: ready -->
 
 <sect1 xml:id="control-structures.do.while" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>do-while</title>
@@ -60,7 +60,7 @@ do {
     if ($i < $minimum_limit) {
         break;
     }
-   echo "i ist ok";
+    echo "i ist ok";
 
     /* i verarbeiten */
 

--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2e5f2910f3a2a95dcbdaf580ba57a0b60b072c2a Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 5744be5a4d239c18d4610581bd32b69a7d82947e Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook">
   <title>Aufzählungen (Enum)</title>
@@ -119,6 +119,8 @@ $b = Suit::Spades;
 $a === $b; // true
 
 $a instanceof Suit;  // true
+
+$a !== 'Spades'; // true
 ?>
 ]]>
    </programlisting>

--- a/language/predefined/attribute/construct.xml
+++ b/language/predefined/attribute/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 681fd84dbdef6c0f8fe92848677d95a993b66143 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 0eb433f1dec35ba1c0daf2d8b30b47f284ad5670 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="attribute.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   &reftitle.description;
   <constructorsynopsis role="Attribute">
    <modifier>public</modifier> <methodname>Attribute::__construct</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>Attribute::TARGET_ALL</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>Attribute::TARGET_ALL</constant></initializer></methodparam>
   </constructorsynopsis>
   <para>
    Erstellt eine neue Instanz von <classname>Attribute</classname>.

--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e890e4a7f97a9ea85e60a38443e7c8eb7ae9383f Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <part xml:id="reserved.attributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Vordefinierte Attribute</title>
@@ -13,6 +13,7 @@
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
  &language.predefined.attributes.deprecated;
+ &language.predefined.attributes.nodiscard;
  &language.predefined.attributes.override;
  &language.predefined.attributes.returntypewillchange;
  &language.predefined.attributes.sensitiveparameter;

--- a/language/predefined/exception.xml
+++ b/language/predefined/exception.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c4752c0aea6bfdd6795213785e7d7cc07d160ae Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 462d2bcb3fa7e76dd84baadf261146bc62574ca9 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.exception" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Exception</title>

--- a/language/predefined/stdclass.xml
+++ b/language/predefined/stdclass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.stdclass" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -46,6 +46,7 @@
 
    <classsynopsis class="class">
     <ooclass>
+     <modifier role="attribute">#[\AllowDynamicProperties]</modifier>
      <classname>stdClass</classname>
     </ooclass>
    </classsynopsis>

--- a/language/predefined/variables/server.xml
+++ b/language/predefined/variables/server.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a124543dd3f6b1e5567b07420d23899e582514dc Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 6b413423c754810252b812d2a28fc627be4579dd Maintainer: sammywg Status: ready -->
 <!-- Reviewed:yes -->
 <!-- Rev-Revision: cdaea0421544885f02ff3d36bd203dc01b78299e Reviewer: samesch -->
 
@@ -168,7 +168,8 @@
      <term>'<varname>REQUEST_TIME</varname>'</term>
      <listitem>
       <simpara>
-       Der Timestamp des Zeitpunkts, an dem der Request eintraf.
+       Der Timestamp des Zeitpunkts, an dem PHP mit der Verarbeitung der
+       Anfrage begonnen hat.
       </simpara>
      </listitem>
     </varlistentry>
@@ -177,8 +178,8 @@
      <term>'<varname>REQUEST_TIME_FLOAT</varname>'</term>
      <listitem>
       <simpara>
-       Der Timestamp des Zeitpunkts, an dem der Request eintraf, in
-       Mikrosekunden-Genauigkeit.
+       Der Timestamp des Zeitpunkts, an dem PHP mit der Verarbeitung der
+       Anfrage begonnen hat, mit Mikrosekunden-Genauigkeit.
       </simpara>
      </listitem>
     </varlistentry>

--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 094816bd170e26abf0e057dae1cfb498dd6aad88 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 3061900171d4ae84d532571bfd6eda823726dad4 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: c140370c354496b38b97dfafe2e31f3f8df8bb44 Reviewer: samesch -->
 <sect1 xml:id="language.types.array">
  <title>Arrays</title>
+
+ <para>
+  Eine Liste aller Array-Funktionen findet sich im Kapitel
+  <link linkend="ref.array">Array-Funktionen</link> der Dokumentation.
+ </para>
 
  <para>
   Ein <type>Array</type> ist in PHP in Wirklichkeit eine geordnete Map

--- a/language/types/integer.xml
+++ b/language/types/integer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e587d0655e426f97b3fcb431453da5030e743b23 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 78a11d3ca004ee937549d932e77a79c51b9777cd Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.integer">
  <title>Ganzzahlen (Integer)</title>
@@ -157,13 +157,12 @@ var_dump(round(25/7));  // float(4)
   <title>Umwandlung in Integer</title>
 
   <simpara>
-   Um einen Wert explizit in <type>int</type> umzuwandeln, kann entweder
-   <literal>(int)</literal> oder <literal>(integer)</literal> verwendet
-   werden. In den meisten Fällen ist das jedoch nicht nötig, weil ein Wert
-   automatisch umgewandelt wird, wenn ein Operator, eine Funktion oder eine
-   Kontrollstruktur ein Argument vom Typ <type>int</type> benötigt. Ein Wert
-   kann auch mit der Funktion <function>intval</function> in <type>int</type>
-   umgewandelt werden.
+   Um einen Wert explizit in <type>int</type> umzuwandeln, kann der
+   <literal>(int)</literal>-Cast verwendet werden. In den meisten Fällen ist
+   das jedoch nicht nötig, weil ein Wert automatisch umgewandelt wird, wenn
+   ein Operator, eine Funktion oder eine Kontrollstruktur ein Argument vom
+   Typ <type>int</type> benötigt. Ein Wert kann auch mit der Funktion 
+   <function>intval</function> in <type>int</type> umgewandelt werden.
   </simpara>
 
   <simpara>

--- a/reference/array/functions/array-rand.xml
+++ b/reference/array/functions/array-rand.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4a1dedc24b1e085f298ab1d5dadefe306373691b Maintainer: gerdtsteltner Status: ready -->
+<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: gerdtsteltner Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: cd943f94a013b74df8765ab8e1a620a916a64a85 Reviewer: samesch -->
 <!-- CREDITS: tom -->
@@ -23,6 +23,7 @@
    Einträge zurück.
   </para>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/array/functions/shuffle.xml
+++ b/reference/array/functions/shuffle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f781803449007bb0e3a96c693e0eee067f7eb466 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 6a6f43d1c490a57b452656db285de6d136055ed2 Reviewer: samesch -->
 <!-- CREDITS: tom, simp -->
@@ -20,6 +20,7 @@
    Diese Funktion mischt die Elemente eines Arrays zufällig (shuffle).
   </para>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/calendar/functions/jdmonthname.xml
+++ b/reference/calendar/functions/jdmonthname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 855dd0c584224f0cee7667a3bc3dae62bace9c96 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: c6fb604f39a0fa7bf1ae872064b2a3a24f23d855 Maintainer: nobody Status: ready -->
 <refentry xml:id="function.jdmonthname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>jdmonthname</refname>
@@ -71,7 +71,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>jday</parameter></term>
+     <term><parameter>julian_day</parameter></term>
      <listitem>
       <para>
        Ein Julianischer Tag als Integer.

--- a/reference/datetime/constants.xml
+++ b/reference/datetime/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 130701dd4e64351d38da565ab3043a8f795698f8 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: b53f03f249fca24b7b1f32564e7dde31fa8b713e Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <appendix xml:id="datetime.constants" xmlns="http://docbook.org/ns/docbook">
@@ -71,7 +71,8 @@
    </term>
    <listitem>
     <simpara>
-     Atom (&zb; <literal>2005-08-15T15:52:01+00:00</literal>)
+     Atom (&zb; <literal>2005-08-15T15:52:01+00:00</literal>); kompatibel
+     mit ISO-8601, RFC 3339 und XML Schema
     </simpara>
    </listitem>
   </varlistentry>
@@ -95,7 +96,7 @@
    </term>
    <listitem>
     <simpara>
-     ISO-8601 (&zb; <literal>2005-08-15T15:52:01+0000</literal>)
+     ISO-8601-ähnlich (&zb; <literal>2005-08-15T15:52:01+0000</literal>)
     </simpara>
     <note>
      <simpara>

--- a/reference/hash/book.xml
+++ b/reference/hash/book.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 0904e1f4db189dfd2873a126bf72fe34fa9c50f8 Maintainer: nikic Status: ready -->
-<book xml:id="book.hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- EN-Revision: a19139232af73a3c2054fcf5a687640ade63a393 Maintainer: nikic Status: ready -->
+<book xml:id="book.hash" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="interactive">
  <?phpdoc extension-membership="core" ?>
  <title>HASH Message Digest Framework</title>
  <titleabbrev>Hash</titleabbrev>

--- a/reference/image/functions/imagearc.xml
+++ b/reference/image/functions/imagearc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: jaenecke Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: jaenecke Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagearc" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagearc</methodname>
+   <type>true</type><methodname>imagearc</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_x</parameter></methodparam>
    <methodparam><type>int</type><parameter>center_y</parameter></methodparam>
@@ -93,7 +93,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagechar.xml
+++ b/reference/image/functions/imagechar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Maintainer: jaenecke Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: jaenecke Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Reviewer: samesch -->
 <refentry xml:id="function.imagechar" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagechar</methodname>
+   <type>true</type><methodname>imagechar</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -76,7 +76,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecharup.xml
+++ b/reference/image/functions/imagecharup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Reviewer: samesch -->
 <refentry xml:id="function.imagecharup" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecharup</methodname>
+   <type>true</type><methodname>imagecharup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -71,7 +71,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecolordeallocate.xml
+++ b/reference/image/functions/imagecolordeallocate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagecolordeallocate" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecolordeallocate</methodname>
+   <type>true</type><methodname>imagecolordeallocate</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>color</parameter></methodparam>
   </methodsynopsis>
@@ -42,7 +42,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopy.xml
+++ b/reference/image/functions/imagecopy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 59688c0133174b84186175b3d7666420f3a7f74e Reviewer: samesch -->
 <refentry xml:id="function.imagecopy" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopy</methodname>
+   <type>true</type><methodname>imagecopy</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -100,7 +100,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagecopyresized.xml
+++ b/reference/image/functions/imagecopyresized.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: simp Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: simp Status: ready -->
 <refentry xml:id="function.imagecopyresized" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>imagecopyresized</refname>
@@ -9,7 +9,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagecopyresized</methodname>
+   <type>true</type><methodname>imagecopyresized</methodname>
    <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
    <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
    <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
@@ -129,7 +129,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagedashedline</methodname>
+   <type>true</type><methodname>imagedashedline</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -79,7 +79,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefill.xml
+++ b/reference/image/functions/imagefill.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagefill" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefill</methodname>
+   <type>true</type><methodname>imagefill</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefilledrectangle.xml
+++ b/reference/image/functions/imagefilledrectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagefilledrectangle" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilledrectangle</methodname>
+   <type>true</type><methodname>imagefilledrectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagefilltoborder" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagefilltoborder</methodname>
+   <type>true</type><methodname>imagefilltoborder</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -70,7 +70,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagegammacorrect.xml
+++ b/reference/image/functions/imagegammacorrect.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagegammacorrect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagegammacorrect</methodname>
+   <type>true</type><methodname>imagegammacorrect</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>float</type><parameter>input_gamma</parameter></methodparam>
    <methodparam><type>float</type><parameter>output_gamma</parameter></methodparam>
@@ -49,7 +49,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imageinterlace.xml
+++ b/reference/image/functions/imageinterlace.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: c6fb604f39a0fa7bf1ae872064b2a3a24f23d855 Maintainer: nobody Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imageinterlace" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -30,7 +30,7 @@
    <variablelist>
     &gd.image.description;
     <varlistentry>
-     <term><parameter>interlace</parameter></term>
+     <term><parameter>enable</parameter></term>
      <listitem>
       <para>
        Falls &true;, wird das Bild im Interlace-Verfahren erstellt, falls

--- a/reference/image/functions/imageline.xml
+++ b/reference/image/functions/imageline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imageline" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imageline</methodname>
+   <type>true</type><methodname>imageline</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -77,7 +77,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagerectangle</methodname>
+   <type>true</type><methodname>imagerectangle</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x1</parameter></methodparam>
    <methodparam><type>int</type><parameter>y1</parameter></methodparam>
@@ -78,7 +78,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesavealpha.xml
+++ b/reference/image/functions/imagesavealpha.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: cmb Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagesavealpha" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesavealpha</methodname>
+   <type>true</type><methodname>imagesavealpha</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>bool</type><parameter>enable</parameter></methodparam>
   </methodsynopsis>
@@ -59,7 +59,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagesetpixel.xml
+++ b/reference/image/functions/imagesetpixel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee0403b08276f179965318623980378033d34d72 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: ee0403b08276f179965318623980378033d34d72 Reviewer: samesch -->
 <refentry xml:id="function.imagesetpixel" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagesetpixel</methodname>
+   <type>true</type><methodname>imagesetpixel</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
    <methodparam><type>int</type><parameter>y</parameter></methodparam>
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagestring.xml
+++ b/reference/image/functions/imagestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Reviewer: samesch -->
 <refentry xml:id="function.imagestring" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagestring</methodname>
+   <type>true</type><methodname>imagestring</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -69,7 +69,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/image/functions/imagestringup.xml
+++ b/reference/image/functions/imagestringup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Reviewer: samesch -->
 <refentry xml:id="function.imagestringup" xmlns="http://docbook.org/ns/docbook">
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>imagestringup</methodname>
+   <type>true</type><methodname>imagestringup</methodname>
    <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
    <methodparam><type class="union"><type>GdFont</type><type>int</type></type><parameter>font</parameter></methodparam>
    <methodparam><type>int</type><parameter>x</parameter></methodparam>
@@ -70,7 +70,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   &return.success;
+   &return.true.always;
   </para>
  </refsect1>
 

--- a/reference/json/functions/json-last-error-msg.xml
+++ b/reference/json/functions/json-last-error-msg.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9e3b30232be09c56bd18a766b2041da254ef95f0 Maintainer: tihox Status: ready -->
+<!-- EN-Revision: 811ad2ca065f6f5b92a911bba9d736e744e4682c Maintainer: tihox Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.json-last-error-msg" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>json_last_error_msg</refname>
   <refpurpose>
-   Liefert die Fehlermeldung des letzten Aufrufs von json_encode() oder
-   json_decode()
+   Liefert die Fehlermeldung des letzten Aufrufs von json_validate(),
+   json_encode() oder json_decode()
   </refpurpose>
  </refnamediv>
 
@@ -19,8 +19,9 @@
   </methodsynopsis>
   <para>
    Gibt die Fehlerzeichenkette des letzten Aufrufs
-   von <function>json_encode</function> oder <function>json_decode</function>
-   zurück, der nicht <constant>JSON_THROW_ON_ERROR</constant> angab.
+   von <function>json_validate</function>, <function>json_encode</function>
+   oder <function>json_decode</function> zurück, der nicht
+   <constant>JSON_THROW_ON_ERROR</constant> angab.
   </para>
  </refsect1>
 

--- a/reference/math/functions/fmod.xml
+++ b/reference/math/functions/fmod.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 761d72245071f89a626903c9bcdc6aaff1252d54 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 54a788ca59d95ff2b4189406437345a21b489435 Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.fmod" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -54,6 +54,7 @@
   <para>
    Der Gleitkommarest der Division
    <parameter>num1</parameter>/<parameter>num2</parameter>.
+   Falls das zweite Argument <literal>0</literal> ist: <constant>NAN</constant> (<type>float</type>).
   </para>
  </refsect1>
 

--- a/reference/misc/functions/pack.xml
+++ b/reference/misc/functions/pack.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c532eceb157530671958a3ef2710bbda3f5ddf68 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: ad0f1eaa6510e1d11231f46515ca513d2cd097c4 Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: f9c4a68ef4f89e51e6d9b905ad3ddb6492386dd3 Reviewer: samesch -->
 <refentry xml:id="function.pack" xmlns="http://docbook.org/ns/docbook">
@@ -225,7 +225,7 @@
           </row>
           <row>
            <entry>Z</entry>
-           <entry>NUL-aufgefüllte Zeichenkette</entry>
+           <entry>NUL-terminierte (ASCIIZ-)Zeichenkette, wird mit NUL aufgefüllt</entry>
           </row>
           <row>
            <entry>@</entry>

--- a/reference/outcontrol/functions/ob-end-clean.xml
+++ b/reference/outcontrol/functions/ob-end-clean.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 86b976d5afaf037868174fe5c242e886eb69baa4 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 5778b68049cc01810523b09b028398c70115cd56 Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 86b976d5afaf037868174fe5c242e886eb69baa4 Reviewer: samesch -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.ob-end-clean">

--- a/reference/pcntl/functions/pcntl-exec.xml
+++ b/reference/pcntl/functions/pcntl-exec.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b890f28c0c6d2856eadcdc34b3faf83a846b3d79 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: b890f28c0c6d2856eadcdc34b3faf83a846b3d79 Reviewer: samesch -->
 <refentry xml:id="function.pcntl-exec" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>pcntl_exec</methodname>
+   <type>false</type><methodname>pcntl_exec</methodname>
    <methodparam><type>string</type><parameter>path</parameter></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>args</parameter><initializer>[]</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>env_vars</parameter><initializer>[]</initializer></methodparam>
@@ -50,14 +50,14 @@
     <varlistentry>
      <term><parameter>env_vars</parameter></term>
      <listitem>
-      <para>
+     <para>
        <parameter>env_vars</parameter> ist ein Array von Strings, die dem
        Programm als Umgebungsvariablen übergeben werden. Das Array ist im
-       Format Name => Wert, wobei der Schlüssel der Name der Umgebungsvariable
+       Format Name =&gt; Wert, wobei der Schlüssel der Name der Umgebungsvariable
        und der Wert der Inhalt dieser Variable ist.
-      </para>
-     </listitem>
-    </varlistentry>
+     </para>
+    </listitem>
+   </varlistentry>
    </variablelist>
   </para>
  </refsect1>

--- a/reference/pdo/configure.xml
+++ b/reference/pdo/configure.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b3d09b7bb4513a6fc08c9adf8793929cb283acc6 Maintainer: fa Status: ready -->
+<!-- EN-Revision: 78cd8f0ba32f4d9921bb8b7eca066de8de29924d Maintainer: fa Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 8a058e9acded067eaa1bd445ed6943158e7311df Reviewer: samesch -->
 <section xml:id="pdo.installation" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.install;
+ <para>
+  &installation.enabled.disable;
+  <option role="configure">--disable-pdo</option>
+ </para>
  <procedure xml:id="pdo.install.unix51up">
   <title>PDO auf Unix-Systemen installieren</title>
   <step>

--- a/reference/pdo_sqlite/pdo/sqlite/createfunction.xml
+++ b/reference/pdo_sqlite/pdo/sqlite/createfunction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 51610360d58ed09bc9d1312f419057c0d1d1a998 Maintainer: lapistano Status: ready -->
+<!-- EN-Revision: 28930349caaaa78f908c380e44066d37a70e97b8 Maintainer: lapistano Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 51610360d58ed09bc9d1312f419057c0d1d1a998 Reviewer: samesch -->
 <refentry xml:id="pdo-sqlite.createfunction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -142,7 +142,7 @@ function sha256_und_umkehren($string)
 }
 
 $db = new Pdo\Sqlite('sqlite::sqlitedb');
-$db->sqliteCreateFunction('sha256rev', 'sha256_und_umkehren', 1);
+$db->createFunction('sha256rev', 'sha256_und_umkehren', 1);
 $zeilen = $db->query('SELECT sha256rev(dateiname) FROM dateien')->fetchAll();
 ?>
 ]]>

--- a/reference/pgsql/constants.xml
+++ b/reference/pgsql/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3c6c95fcfd7d9eaa603df40327693ea8dff89d53 Maintainer: conni Status: ready -->
+<!-- EN-Revision: f5419b6eddbbb69317b0b3e6d752532ee2ed0b2a Maintainer: conni Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <appendix xml:id="pgsql.constants" xmlns="http://docbook.org/ns/docbook">
@@ -996,7 +996,7 @@
     <simpara>
      Wird in <function>pg_trace</function> verwendet, damit der Zeitstempel
      nicht in den Meldungen der Ablaufverfolgung enthalten ist.
-     Verfügbar seit PHP 8.3.0.
+     Verfügbar seit PHP 8.4.20.
     </simpara>
    </listitem>
    </varlistentry>

--- a/reference/pgsql/functions/pg-affected-rows.xml
+++ b/reference/pgsql/functions/pg-affected-rows.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-affected-rows" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_affected_rows</refname>
@@ -20,9 +20,7 @@
    <literal>DELETE</literal>-Abfrage betroffen sind.
   </para>
   <para>
-   Ab PostgreSQL 9.0 und neuer gibt der Server die Anzahl von per SELECT
-   gewählten Zeilen zurück. Ältere PostgreSQL Versionen geben 0 für SELECT
-   zurück.
+   Der Server gibt auch die Anzahl der SELECTierten Zeilen zurück.
   </para>
   <note>
    <para>

--- a/reference/pgsql/functions/pg-client-encoding.xml
+++ b/reference/pgsql/functions/pg-client-encoding.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ad618eea48c773ff8768d9d27ea986f81a2a2400 Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-client-encoding" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_client_encoding</refname>
@@ -22,9 +22,8 @@
   </para>
   <note>
    <para>
-    Diese Funktion setzt PostgreSQL 7.0 oder höher
-    voraus. Wenn die libpq ohne multibyte-Unterstützung kompiliert wurde, gibt
-    <function>pg_set_client_encoding</function> immer
+    Wenn die libpq ohne multibyte-Unterstützung kompiliert wurde, gibt
+    <function>pg_client_encoding</function> immer
     <literal>SQL_ASCII</literal> zurück. Die unterstützten Kodierungen sind
     von der PostgreSQL-Version abhängig. Weitere Informationen entnehmen Sie
     bitte der PostgreSQL-Dokumentation.

--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id='function.pg-escape-string' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_escape_string</refname>
@@ -25,11 +25,6 @@
    verwenden. <function>pg_escape_identifier</function> muss verwendet werden,
    um Bezeichner (&zb; Tabellenamen, Feldnamen) zu maskieren.
   </para>
-  <note>
-   <para>
-    Diese Funktion setzt PostgreSQL 7.2 oder höher voraus.
-   </para>
-  </note>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_execute</refname>
@@ -29,9 +29,7 @@
    kein SQL-String ist. Damit werden Abfragen, die wiederholt verwendet
    werden, nur ein einziges Mal geparst und geplant und nicht jedesmal, wenn
    sie ausgeführt werden. Das Kommando muss zuvor in der aktuellen
-   Datenbanksitzung vorbereitet worden sein. <function>pg_execute</function>
-   wird von PostgreSQL ab der Version 7.4 unterstützt und wird in allen
-   früheren Versionen fehlschlagen.
+   Datenbanksitzung vorbereitet worden sein.
   </para>
   <para>
    Die Parameter sind identisch zu denen in

--- a/reference/pgsql/functions/pg-lo-import.xml
+++ b/reference/pgsql/functions/pg-lo-import.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: d0ae617680e58bde494f9d58d9c553e0a6944418 Maintainer: conni Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.pg-lo-import">
  <refnamediv>
@@ -11,7 +11,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>pg_lo_import</methodname>
+   <type>int|string|false</type><methodname>pg_lo_import</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>object_id</parameter></methodparam>

--- a/reference/pgsql/functions/pg-prepare.xml
+++ b/reference/pgsql/functions/pg-prepare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 469e5fa809cef61c0707d7447a2ab72cd66f65fd Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_prepare</refname>
@@ -24,9 +24,6 @@
    <function>pg_send_execute</function> ausgeführt werden kann. Dank dieser
    Eigenschaft brauchen wiederholt ausgeführte Abfragen nur ein einziges Mal
    geparst und geplant werden, anstatt bei jeder Ausführung.
-   <function>pg_prepare</function> wird nur für Verbindungen zu PostgreSQL ab
-   der Version 7.4 unterstützt und schlägt bei allen niedrigeren Versionen
-   fehl.
   </para>
   <para>
    Diese Funktion erzeugt aus der Abfrage <parameter>query</parameter> eine

--- a/reference/pgsql/functions/pg-query-params.xml
+++ b/reference/pgsql/functions/pg-query-params.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-query-params" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_query_params</refname>
@@ -26,9 +26,6 @@
    <function>pg_query_params</function> ist ähnlich wie
    <function>pg_query</function>, bietet aber zusätzlich die Möglichkeit,
    Parameterwerte ausserhalb des SQL-Kommandos separat zu übergeben.
-   <function>pg_query_params</function> wird nur für Verbindungen zu
-   PostgreSQL ab der Version 7.4 unterstützt und schlägt bei allen niedrigeren
-   Versionen fehl.
   </para>
   <para>
    Falls irgendwelche Parameter übergeben wurden, werden diese in

--- a/reference/pgsql/functions/pg-version.xml
+++ b/reference/pgsql/functions/pg-version.xml
@@ -15,8 +15,8 @@
   <methodsynopsis>
    <type>array</type><methodname>pg_version</methodname>
    <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
- </methodsynopsis>
- <para>
+  </methodsynopsis>
+  <para>
    <function>pg_version</function> Gibt ein Array zurück, das die Versionen
    von Client, Protokoll und Server enthält.
   </para>

--- a/reference/pgsql/functions/pg-version.xml
+++ b/reference/pgsql/functions/pg-version.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-version" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_version</refname>
@@ -15,11 +15,10 @@
   <methodsynopsis>
    <type>array</type><methodname>pg_version</methodname>
    <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
-  </methodsynopsis>
-  <para>
+ </methodsynopsis>
+ <para>
    <function>pg_version</function> Gibt ein Array zurück, das die Versionen
-   von Client, Protokoll und Server enthält. Protokoll- und Serverversion sind
-   nur verfügbar, wenn PHP mit PostgreSQL 7.4 und neuer kompiliert wurde.
+   von Client, Protokoll und Server enthält.
   </para>
   <para>
    Um genauere Informationen über den Server zu erhalten, verwenden Sie

--- a/reference/pgsql/reference.xml
+++ b/reference/pgsql/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3ba581880a9e5635109c65cef01a7ca192999ad1 Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 
 <reference xml:id="ref.pgsql" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>PostgreSQL-&Functions;</title>
@@ -39,8 +39,8 @@
     <para>
      PostgreSQL stellt keine speziellen Kommandos zur Verfügung, um
      Informationen über ein Datenbank-Schema (&zb; alle Tabellen in der
-     aktuellen Datenbank) zu erhalten. Stattdessen gibt es ab der Version
-     7.4 und höher ein Standard-Schema, das <literal>information_schema</literal>,
+     aktuellen Datenbank) zu erhalten. Stattdessen gibt es ein
+     Standard-Schema namens <literal>information_schema</literal>,
      in dem alle notwendigen Informationen in System-Views enthalten
      und die einfach abzufragen sind. Ausführliche Informationen darüber
      gibt es in der

--- a/reference/random/functions/mt-rand.xml
+++ b/reference/random/functions/mt-rand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0a5e7b12546b62a611a0cbc7105e617ab96fbcbd Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 826073522514072830b63bee2b6135dc675ea45d Reviewer: samesch -->
 <refentry xml:id="function.mt-rand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -37,6 +37,7 @@
    <literal>mt_rand(5, 15)</literal> verwendet werden.
   </simpara>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/random/functions/srand.xml
+++ b/reference/random/functions/srand.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9eb92e5c1851d7838ba02e88e7a0e5bb5c86880a Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 37cf0c5a0c66e94e4184e81d7dccc8eed001b66f Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 7973fd533364af4dd6282ca9e7bee2dffec39b1c Reviewer: samesch -->
 <refentry xml:id="function.srand" xmlns="http://docbook.org/ns/docbook">
@@ -13,13 +13,13 @@
   &reftitle.description;
   <methodsynopsis>
    <type>void</type><methodname>srand</methodname>
-   <methodparam choice="opt"><type>int</type><parameter>seed</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>seed</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>mode</parameter><initializer><constant>MT_RAND_MT19937</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    Setzt den Anfangswert für den Zufallsgenerator auf
-   <parameter>seed</parameter> oder auf einen zufälligen Wert, falls
-   <parameter>seed</parameter> <literal>0</literal> ist.
+   <parameter>seed</parameter> oder auf einen zufälligen Wert, falls kein
+   <parameter>seed</parameter> angegeben wurde.
   </para>
 
   &note.randomseed;

--- a/reference/simplexml/simplexmlelement/addChild.xml
+++ b/reference/simplexml/simplexmlelement/addChild.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c1f37a6c270aadbbb3da56a3973ffd62197adf2b Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: dca2a8354fc170f26545210ac78424ccc30950ea Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!--  Rev-Revision: 770c6facae667218f69c8ea2715ea20f6fab32f3 Reviewer: samesch -->
 <refentry xml:id="simplexmlelement.addchild" xmlns="http://docbook.org/ns/docbook">
@@ -39,6 +39,11 @@
      <listitem>
       <para>
        Wenn angegeben, der Wert des Kind-Elements.
+      </para>
+      <para>
+       Die speziellen Zeichen <literal>&lt;</literal> und
+       <literal>&gt;</literal> werden automatisch maskiert;
+       <literal>&amp;</literal> muss manuell maskiert werden.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/strings/functions/str-shuffle.xml
+++ b/reference/strings/functions/str-shuffle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 52c495140bdb84f45f186bfb1cccf09788b0121e Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: d6dc2be3c5c70e4a1c3d13f788643ea232747c19 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.str-shuffle" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>str_shuffle</refname>
@@ -18,6 +18,7 @@
    Permutation aller vorhandenen Zeichen.
   </simpara>
   &caution.cryptographically-insecure;
+  &caution.mt19937-global-state;
  </refsect1>
 
  <refsect1 role="parameters">

--- a/security/sessions.xml
+++ b/security/sessions.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8782bc734072865ade29b8951bc94d98a53750ef Maintainer: nobody Status: ready -->
+<!-- EN-Revision: c2face03ee1d79647914a73171a64ee1b67b9918 Maintainer: nobody Status: ready -->
 <!-- Reviewed: no -->
 
  <chapter xml:id="security.sessions" xmlns="http://docbook.org/ns/docbook">
   <title>Session Sicherheit</title>
 
   <para>
-   Es ist wichtig die HTTP Session Verwaltung sicher zu halten. Sessionbezogene Sicherheit ist beschrieben im Abschnitt <link linkend="session.security">Session Sicherheit</link> in der <link linkend="book.session">Session Modul</link> Referenz.
+   Es ist wichtig, die HTTP-Session-Verwaltung sicher zu halten.
+   Sessionbezogene Sicherheit wird im Abschnitt
+   <link linkend="session.security">Session Sicherheit</link> der
+   <link linkend="book.session">Referenz zum Session-Modul</link> beschrieben.
   </para>
 
  </chapter>


### PR DESCRIPTION
Went through https://doc.php.net/revcheck.php?p=files&lang=de and picked all files with minor cleanups and small numbers of lines changed to get the list a bit more manageable.

I hope this is easily reviewable, but let me know if you'd prefer PRs to be sliced differently.

Notes:
- reference/pgsql/functions/pg-affected-rows.xml: Translated `SELECTed` with `SELECTierten` als the whimsical way of putting that also works in German instead of "die Anzahl der mit dem SELECT gefunden Zeilen". 
- language/types/integer.xml: Reformatting made the diff a bit verbose
- language/types/integer.xml: We do say `cast` instead of `typumwandlung` in other places in the German docs as well, so I kept that.