### PR TITLE
Sync translations for curl/ldap/openssl/pg

### DIFF
--- a/reference/curl/functions/curl-close.xml
+++ b/reference/curl/functions/curl-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: ce98b568f85353c4bf263133f09c4db9294833f9 Maintainer: jaenecke Status: ready -->
+<!-- EN-Revision: 86c8ebd19ed93843f293bdcecc9ce68cb4ab57bc Maintainer: jaenecke Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 52dc204a77076e1404257cf39f179882b90b5780 Reviewer: samesch -->
 <refentry xml:id="function.curl-close" xmlns="http://docbook.org/ns/docbook">
@@ -53,6 +53,18 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Diese Funktion wurde als veraltet eingestuft.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Diese Funktion ist jetzt ein <acronym>NOP</acronym>.
+      </entry>
+     </row>
      &curl.changelog.handle-param;
     </tbody>
    </tgroup>

--- a/reference/curl/functions/curl-share-close.xml
+++ b/reference/curl/functions/curl-share-close.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fc9a0a8b29a7a099998bdd71fe5350a10b18fe62 Maintainer: joshuaruesweg Status: ready -->
+<!-- EN-Revision: 29c3d13980c8b29b700afd85c916e064638a7944 Maintainer: joshuaruesweg Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.curl-share-close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -50,6 +50,18 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Diese Funktion wurde als veraltet markiert.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Diese Funktion ist jetzt ein <acronym>NOP</acronym>.
+      </entry>
+     </row>
      &curl.changelog.share-handle-param;
     </tbody>
    </tgroup>

--- a/reference/ftp/ftp.connection.xml
+++ b/reference/ftp/ftp.connection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ftp-connection" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Die Klasse FTP\Connection</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>FTP\Connection</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>FTP</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Connection</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/ftp/functions/ftp-set-option.xml
+++ b/reference/ftp/functions/ftp-set-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4d1c34c9b7a30cfc3a59641122c707a2812cfed7 Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 1.0 Reviewer: samesch -->
 <refentry xml:id="function.ftp-set-option" xmlns="http://docbook.org/ns/docbook">
@@ -12,7 +12,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>bool</type><methodname>ftp_set_option</methodname>
+   <type>true</type><methodname>ftp_set_option</methodname>
    <methodparam><type>FTP\Connection</type><parameter>ftp</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam><type class="union"><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
@@ -93,11 +93,18 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Gibt &true; zurück, wenn die Option gesetzt werden konnte, sonst
-   &false;. Eine Warnung wird ausgegeben, falls die
-   <parameter>option</parameter> nicht unterstützt wird oder falls der
-   angegebene <parameter>value</parameter> nicht mit dem erwarteten
-   Wert für die angegebene <parameter>option</parameter> übereinstimmt.
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Eine <exceptionname>ValueError</exceptionname>-Ausnahme wird ausgelöst, wenn die
+   <parameter>option</parameter> nicht unterstützt wird. Eine
+   <exceptionname>TypeError</exceptionname>-Ausnahme wird ausgelöst, wenn der
+   übergebene <parameter>value</parameter> nicht dem erwarteten Typ für die
+   angegebene <parameter>option</parameter> entspricht.
   </para>
  </refsect1>
 
@@ -112,6 +119,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der Rückgabetyp ist nun &true;; vorher war er <type>bool</type>.
+      </entry>
+     </row>
      &ftp.changelog.ftp-param;
     </tbody>
    </tgroup>

--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3ec3fa6848aae4b4535557105a42fbf8d57dcc07 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: bc90525a5a5ebcf8412ef34b8355d2de12166fff Reviewer: samesch -->
 <refentry xml:id="function.ldap-get-option" xmlns="http://docbook.org/ns/docbook">
@@ -13,7 +13,7 @@
   &reftitle.description;
   <methodsynopsis>
    <type>bool</type><methodname>ldap_get_option</methodname>
-   <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
+   <methodparam><type class="union"><type>LDAP\Connection</type><type>null</type></type><parameter>ldap</parameter></methodparam>
    <methodparam><type>int</type><parameter>option</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>array</type><type>string</type><type>int</type></type><parameter role="reference">value</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
@@ -30,7 +30,9 @@
      <term><parameter>ldap</parameter></term>
      <listitem>
       <para>
-       &ldap.parameter.ldap;
+       Entweder eine von <function>ldap_connect</function> zurückgegebene
+       <classname>LDAP\Connection</classname>-Instanz, um die Option für diese
+       Verbindung abzurufen, oder &null;, um die globale Option abzurufen.
       </para>
      </listitem>
     </varlistentry>
@@ -245,6 +247,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>ldap</parameter> ist jetzt nullable.
+      </entry>
+     </row>
      &ldap.changelog.ldap-object;
     </tbody>
    </tgroup>

--- a/reference/ldap/ldap.connection.xml
+++ b/reference/ldap/ldap.connection.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ldap-connection" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Die Klasse LDAP\Connection</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>LDAP\Connection</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>LDAP</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Connection</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/ldap/ldap.result.xml
+++ b/reference/ldap/ldap.result.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ldap-result" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Die Klasse LDAP\Result</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>LDAP\Result</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>LDAP</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Result</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/ldap/ldap.resultentry.xml
+++ b/reference/ldap/ldap.resultentry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: sergey Status: ready -->
+<!-- EN-Revision: 37d269b8f6d0f8e83a044a2902a7dc92580bbb87 Maintainer: sergey Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.ldap-result-entry" role="class" xmlns="http://docbook.org/ns/docbook">
  <title>Die Klasse LDAP\ResultEntry</title>
@@ -20,12 +20,16 @@
    &reftitle.classsynopsis;
 
    <!-- {{{ Synopsis -->
-   <classsynopsis class="class">
-    <ooclass>
-     <modifier>final</modifier>
-     <classname>LDAP\ResultEntry</classname>
-    </ooclass>
-   </classsynopsis>
+   <packagesynopsis>
+    <package>LDAP</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>ResultEntry</classname>
+     </ooclass>
+    </classsynopsis>
+   </packagesynopsis>
    <!-- }}} -->
 
   </section>

--- a/reference/openssl/functions/openssl-pkcs12-read.xml
+++ b/reference/openssl/functions/openssl-pkcs12-read.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5bc68add3da3cd18c40f851e944b15095d3a26aa Maintainer: nobody Status: ready -->
+<!-- EN-Revision: e2f2172bf114599926878017ab2dce356956fa9e Maintainer: nobody Status: ready -->
 <refentry xml:id="function.openssl-pkcs12-read" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_pkcs12_read</refname>

--- a/reference/openssl/functions/openssl-private-decrypt.xml
+++ b/reference/openssl/functions/openssl-private-decrypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7da0f9995a1a6928523f8d910898e79d88f45d5f Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 8108ac2a62dfc6577341b13a91fe1bdbaee870e4 Maintainer: nobody Status: ready -->
 <refentry xml:id="function.openssl-private-decrypt" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_private_decrypt</refname>
@@ -15,6 +15,7 @@
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter role="reference">decrypted_data</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>padding</parameter><initializer><constant>OPENSSL_PKCS1_PADDING</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>digest_algo</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>openssl_private_decrypt</function> entschlüsselt
@@ -68,6 +69,14 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>digest_algo</parameter></term>
+     <listitem>
+      <simpara>
+       Der Digest-Algorithmus für OAEP-Padding oder &null;, um den Standardalgorithmus zu verwenden.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -90,6 +99,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>digest_algo</parameter> wurde hinzugefügt.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/openssl/functions/openssl-public-encrypt.xml
+++ b/reference/openssl/functions/openssl-public-encrypt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7da0f9995a1a6928523f8d910898e79d88f45d5f Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 8108ac2a62dfc6577341b13a91fe1bdbaee870e4 Maintainer: nobody Status: ready -->
 <refentry xml:id="function.openssl-public-encrypt" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_public_encrypt</refname>
@@ -15,6 +15,7 @@
    <methodparam><type>string</type><parameter role="reference">encrypted_data</parameter></methodparam>
    <methodparam><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>public_key</parameter></methodparam>
    <methodparam choice="opt"><type>int</type><parameter>padding</parameter><initializer><constant>OPENSSL_PKCS1_PADDING</constant></initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>digest_algo</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    <function>openssl_public_encrypt</function> verschlüsselt
@@ -72,6 +73,14 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>digest_algo</parameter></term>
+     <listitem>
+      <simpara>
+       Der Digest-Algorithmus für OAEP-Padding oder &null;, um den Standardalgorithmus zu verwenden.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -94,6 +103,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>digest_algo</parameter> wurde hinzugefügt.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/openssl/functions/openssl-sign.xml
+++ b/reference/openssl/functions/openssl-sign.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5bc68add3da3cd18c40f851e944b15095d3a26aa Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: nobody Status: ready -->
 <refentry xml:id="function.openssl-sign" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_sign</refname>
@@ -15,6 +15,7 @@
    <methodparam><type>string</type><parameter role="reference">signature</parameter></methodparam>
    <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>private_key</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>int</type></type><parameter>algorithm</parameter><initializer><constant>OPENSSL_ALGO_SHA1</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>padding</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
    Die Funktion <function>openssl_sign</function> errechnet die Signatur für
@@ -72,6 +73,12 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>padding</parameter></term>
+     <listitem>
+      <simpara>Das zu verwendende RSA-PSS-Padding.</simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -94,6 +101,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>padding</parameter> wurde hinzugefügt.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/openssl/functions/openssl-verify.xml
+++ b/reference/openssl/functions/openssl-verify.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: jaenecke Status: ready -->
+<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: jaenecke Status: ready -->
 <refentry xml:id="function.openssl-verify" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>openssl_verify</refname>
@@ -15,6 +15,7 @@
    <methodparam><type>string</type><parameter>signature</parameter></methodparam>
    <methodparam><type class="union"><type>OpenSSLAsymmetricKey</type><type>OpenSSLCertificate</type><type>array</type><type>string</type></type><parameter>public_key</parameter></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>int</type></type><parameter>algorithm</parameter><initializer><constant>OPENSSL_ALGO_SHA1</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>padding</parameter><initializer>0</initializer></methodparam>
   </methodsynopsis>
   <para>
    Die Funktion <function>openssl_verify</function> überprüft die Korrektheit
@@ -73,6 +74,12 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>padding</parameter></term>
+     <listitem>
+      <simpara>Das zu verwendende RSA-PSS-Padding.</simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -96,6 +103,12 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>padding</parameter> wurde hinzugefügt.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/pgsql/functions/pg-copy-from.xml
+++ b/reference/pgsql/functions/pg-copy-from.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-copy-from" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_copy_from</refname>
@@ -15,15 +15,14 @@
    <type>bool</type><methodname>pg_copy_from</methodname>
    <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>string</type><parameter>table_name</parameter></methodparam>
-   <methodparam><type>array</type><parameter>rows</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>Traversable</type></type><parameter>rows</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>separator</parameter><initializer>"\t"</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>null_as</parameter><initializer>"\\\\N"</initializer></methodparam>
   </methodsynopsis>
   <para>
-   <function>pg_copy_from</function> fügt Datensätze aus einem Array in
-     eine Tabelle ein. Intern wird der <literal>COPY</literal>-Befehl
-     aufgerufen, um die Datensätze einzufügen. Bei Erfolg gibt die
-     Funktion &true; zurück, &false; sonst.   
+   <function>pg_copy_from</function> fügt Datensätze aus
+   <parameter>rows</parameter> in eine Tabelle ein. Intern wird dazu der
+   <literal>COPY FROM</literal>-SQL-Befehl verwendet.
   </para>
  </refsect1>
 
@@ -49,12 +48,12 @@
      <term><parameter>rows</parameter></term>
      <listitem>
       <para>
-       Ein <type>array</type> mit Werten, die in die
-    <parameter>table_name</parameter> eingefügt werden.
+       <type>iterable</type> Daten, die in <parameter>table_name</parameter>
+       eingefügt werden.
        Jedes Element von <parameter>rows</parameter> wird zu einer
-    Zeile in <parameter>table_name</parameter>. Die Elemente in
-    <parameter>rows</parameter> müssen Strings mit Feldbegrenzern
-    sein, und mit einem Zeilenvorschub abgeschlossen sein.
+       Zeile in <parameter>table_name</parameter>. Die Elemente in
+       <parameter>rows</parameter> müssen Strings mit Feldbegrenzern
+       sein, und mit einem Zeilenvorschub abgeschlossen sein.
       </para>
      </listitem>
     </varlistentry>
@@ -99,6 +98,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       <parameter>rows</parameter> hat nun den Typ <type>iterable</type>;
+       vorher war er vom Typ <type>array</type>.
+      </entry>
+     </row>
      &pgsql.changelog.connection-object;
     </tbody>
    </tgroup>

--- a/reference/pgsql/functions/pg-lo-create.xml
+++ b/reference/pgsql/functions/pg-lo-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xml:id="function.pg-lo-create" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,12 +21,9 @@
   </methodsynopsis>
   <para>
    <function>pg_lo_create</function> erzeugt ein Large Object und gibt dessen
-   <varname>OID</varname> zurück. Die <constant>INV_READ</constant>-,
-   <constant>INV_WRITE</constant>- und
-   <constant>INV_ARCHIVE</constant>-Zugriffsmodi von PostgreSQL werden nicht
+   <varname>OID</varname> zurück. Die <constant>INV_READ</constant>- und
+   <constant>INV_WRITE</constant>-Zugriffsmodi von PostgreSQL werden nicht
    unterstützt. Ein Large Object wird immer mit Lese- und Schreibzugriff erzeugt.
-   <constant>INV_ARCHIVE</constant> wurde aus PostgreSQL (ab Version 6.3 und
-   höher) entfernt.
   </para>
   <para>
    Um die Large Object (lo) Schnittstelle benutzen zu können, müssen die
@@ -62,8 +59,6 @@
        Wenn es einen Parameter <parameter>object_id</parameter> gibt, wird
        diese Funktion versuchen, ein Large Object mit dieser ID zu erzeugen.
        Anderenfalls wird dem Large Object vom Server eine freie ID zugewiesen.
-       Dieser Parameter basiert auf Funktionalitäten, die seit PostgreSQL 8.1
-       implementiert sind.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/pgsql/functions/pg-parameter-status.xml
+++ b/reference/pgsql/functions/pg-parameter-status.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-parameter-status" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_parameter_status</refname>
@@ -25,33 +25,15 @@
    bekannt ist, anderenfalls &false;.
   </para>
   <para>
-   In PostgreSQL 8.0 werden die Werte für folgende Parameter zurückgegeben:
+   Zu den vom Server gemeldeten Parametern gehören
    <literal>server_version</literal>, <literal>server_encoding</literal>,
    <literal>client_encoding</literal>, <literal>is_superuser</literal>,
    <literal>session_authorization</literal>, <literal>DateStyle</literal>,
    <literal>TimeZone</literal> und <literal>integer_datetimes</literal>.
-   (<literal>server_encoding</literal>, <literal>TimeZone</literal> und
-   <literal>integer_datetimes</literal> werden von PostgreSQL vor 8.0 nicht
-   zurückgegeben.) Beachten Sie, dass <literal>server_version</literal>,
+   Beachten Sie, dass <literal>server_version</literal>,
    <literal>server_encoding</literal> und <literal>integer_datetimes</literal>
    nach dem Start von PostgreSQL nicht mehr verändert werden können.
   </para>
-  <para>
-   PostgreSQL 7.3 oder darunter geben gar keine Servereinstellungen zurück.
-   <function>pg_parameter_status</function> kann trotzdem benutzt werden, um
-   die Werte von <literal>server_version</literal> und
-   <literal>client_encoding</literal> zu ermitteln. Es wird empfohlen, in
-   Anwendungen <function>pg_parameter_status</function> zu verwenden, anstatt
-   speziellen Code zu schreiben, um diese Werte zu erhalten.
-  </para>
-  <caution>
-   <para>
-    In PostgreSQL-Versionen vor 7.4 wird ein nachträgliches (nach dem Start
-    des Servers) Ändern von <literal>client_encoding</literal> mit dem
-    Kommando <literal>SET</literal> von
-    <function>pg_parameter_status</function> ignoriert.
-   </para>
-  </caution>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/pgsql/functions/pg-result-error-field.xml
+++ b/reference/pgsql/functions/pg-result-error-field.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-result-error-field" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_result_error_field</refname>
@@ -17,9 +17,8 @@
   <para>
    <function>pg_result_error_field</function> gibt ein Feld der ausführlichen
    Fehlerbeschreibung zurück, die mit der
-   <parameter>result</parameter>-Instanz verbunden ist. Die Funktion wird nur für
-   Verbindungen zu PostgreSQL ab der Version 7.4 unterstützt. Das gewünschte
-   Feld wird im Parameter <parameter>field_code</parameter> übergeben.
+   <parameter>result</parameter>-Instanz verbunden ist. Das gewünschte Feld
+   wird im Parameter <parameter>field_code</parameter> übergeben.
   </para>
   <para>
    Da <function>pg_query</function> und <function>pg_query_params</function>
@@ -57,9 +56,9 @@
          <constant>PGSQL_DIAG_MESSAGE_DETAIL</constant>,
          <constant>PGSQL_DIAG_MESSAGE_HINT</constant>,
          <constant>PGSQL_DIAG_STATEMENT_POSITION</constant>,
-         <constant>PGSQL_DIAG_INTERNAL_POSITION</constant> (nur PostgreSQL ab
-         Version 8.0), <constant>PGSQL_DIAG_INTERNAL_QUERY</constant> (nur
-         PostgreSQL ab Version 8.0), <constant>PGSQL_DIAG_CONTEXT</constant>,
+         <constant>PGSQL_DIAG_INTERNAL_POSITION</constant>,
+         <constant>PGSQL_DIAG_INTERNAL_QUERY</constant>,
+         <constant>PGSQL_DIAG_CONTEXT</constant>,
          <constant>PGSQL_DIAG_SOURCE_FILE</constant>,
          <constant>PGSQL_DIAG_SOURCE_LINE</constant> und
          <constant>PGSQL_DIAG_SOURCE_FUNCTION</constant>.

--- a/reference/pgsql/functions/pg-unescape-bytea.xml
+++ b/reference/pgsql/functions/pg-unescape-bytea.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 58645a79f1993effc0571f7b49acc9aace0e417f Maintainer: conni Status: ready -->
+<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-unescape-bytea" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_unescape_bytea</refname>
@@ -24,17 +24,6 @@
     werden, gibt PostgreSQL Bytewerte als Oktalzahlen zurück, denen ein '\'
     vorangestellt ist (&zb; \032). Benutzer müssen diese Werte manuell in
     ein binäres Format konvertieren.
-   </para>
-   <para>
-    Diese Funktion setzt PostgreSQL ab der Version 7.2 voraus. Bei
-    PostgreSQ; 7.2.0 und 7.2.1 müssen bytea-Werte konvertiert werden, falls
-    die Multibyte-Unterstützung aktiviert ist, &zb; <literal>INSERT INTO
-    test_table (image) VALUES ('$image_escaped'::bytea);</literal>. Ab
-    PostgreSQL 7.2.2 müssen die Daten nicht mehr konvertiert werden. Eine
-    Ausnahme gibt es allerdings: wenn die Codierung des Clients und des
-    Datenbankservers einander nicht entsprechen, kann es zu
-    Multibyte-Fehlern kommen. Um diesen Fehler zu vermeiden, muss der
-    Anwender einen Typecast zu bytea machen.
    </para>
   </note>
  </refsect1>


### PR DESCRIPTION
Question for a potential follow-up PR:

Would it make sense to introduce a `&entity` for "Diese Funktion wurde als veraltet eingestuft."? 
There are >40 places with that phrase.