### PR TITLE
translate: openssl cipher & digest functions

### DIFF
--- a/reference/openssl/functions/openssl-cipher-iv-length.xml
+++ b/reference/openssl/functions/openssl-cipher-iv-length.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d1e3ea622e5d4f542cd36eca59a9f22aa0142633 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.openssl-cipher-iv-length" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_cipher_iv_length</refname>
+  <refpurpose>Ermittelt die Länge des Initialisierungsvektors einer Verschlüsselungsmethode</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>openssl_cipher_iv_length</methodname>
+   <methodparam><type>string</type><parameter>cipher_algo</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ermittelt die Länge des Initialisierungsvektors (IV) einer
+   Verschlüsselungsmethode.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>cipher_algo</parameter></term>
+    <listitem>
+     <para>
+      Die Verschlüsselungsmethode; <function>openssl_get_cipher_methods</function>
+      liefert eine Liste der möglichen Werte.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die Länge des Initialisierungsvektors zurück, im Fehlerfall
+   &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Gibt einen Fehler der Stufe <constant>E_WARNING</constant> aus, wenn die
+   Verschlüsselungsmethode unbekannt ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="openssl-cipher-iv-length.example.basic">
+   <title>Beispiel für <function>openssl_cipher_iv_length</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$method = 'AES-128-CBC';
+$ivlen = openssl_cipher_iv_length($method);
+
+echo $ivlen;
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+16
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/openssl/functions/openssl-cipher-key-length.xml
+++ b/reference/openssl/functions/openssl-cipher-key-length.xml
@@ -36,7 +36,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Gibt bei Erfolg die Schlüssellänge zurück, &return.falseforfailure;.
+   Gibt bei Erfolg die Schlüssellänge zurück. &return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-cipher-key-length.xml
+++ b/reference/openssl/functions/openssl-cipher-key-length.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: a68a0b2da0e304128cf04016300ebcb31f761385 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.openssl-cipher-key-length" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_cipher_key_length</refname>
+  <refpurpose>Ermittelt die Schlüssellänge einer Verschlüsselungsmethode</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>openssl_cipher_key_length</methodname>
+   <methodparam><type>string</type><parameter>cipher_algo</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ermittelt die Schlüssellänge einer Verschlüsselungsmethode.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>cipher_algo</parameter></term>
+    <listitem>
+     <para>
+      Die Verschlüsselungsmethode; <function>openssl_get_cipher_methods</function>
+      liefert eine Liste der möglichen Werte.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die Schlüssellänge zurück, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Gibt einen Fehler der Stufe <constant>E_WARNING</constant> aus, wenn die
+   Verschlüsselungsmethode unbekannt ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>openssl_cipher_key_length</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$method = 'AES-128-CBC';
+
+var_dump(openssl_cipher_key_length($method));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(16)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/openssl/functions/openssl-decrypt.xml
+++ b/reference/openssl/functions/openssl-decrypt.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: e5ab2937efd9b1d7184993e0fdfa957893f7f827 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.openssl-decrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_decrypt</refname>
+  <refpurpose>Entschlüsselt Daten</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>openssl_decrypt</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cipher_algo</parameter></methodparam>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>passphrase</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>iv</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>tag</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>aad</parameter><initializer>""</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Entschlüsselt eine unbearbeitete oder base64-kodierte Zeichenkette mit der
+   angegebenen Methode und der angegebenen Passphrase.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       Die zu entschlüsselnde verschlüsselte Nachricht.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>cipher_algo</parameter></term>
+     <listitem>
+      <para>
+       Die Verschlüsselungsmethode.
+       <function>openssl_get_cipher_methods</function> liefert eine Liste der
+       verfügbaren Verschlüsselungsmethoden.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>passphrase</parameter></term>
+     <listitem>
+      <para>
+       Die Passphrase. Ist die Passphrase kürzer als erwartet, wird sie
+       stillschweigend mit <literal>NUL</literal>-Zeichen aufgefüllt; ist die
+       Passphrase länger als erwartet, wird sie stillschweigend abgeschnitten.
+      </para>
+      <caution>
+       <simpara>
+        Für <parameter>passphrase</parameter> wird keine Funktion zur Ableitung
+        eines Schlüssels verwendet, wie der Name vielleicht vermuten lässt.
+        Die einzige Operation, die verwendet wird, ist das Auffüllen mit
+        <literal>NUL</literal>-Zeichen oder das Abschneiden, wenn die Länge
+        anders ist als erwartet.
+       </simpara>
+      </caution>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>options</parameter></term>
+     <listitem>
+      <para>
+       <parameter>options</parameter> kann einer der Werte
+       <constant>OPENSSL_RAW_DATA</constant>,
+       <constant>OPENSSL_ZERO_PADDING</constant>
+       oder <constant>OPENSSL_DONT_ZERO_PAD_KEY</constant> sein.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>iv</parameter></term>
+     <listitem>
+      <para>
+       Der Initialisierungsvektor (darf nicht &null; sein). Ist der IV kürzer
+       als erwartet, wird er mit <literal>NUL</literal>-Zeichen aufgefüllt und
+       eine Warnung ausgegeben; ist die Passphrase länger als erwartet, wird
+       sie abgeschnitten und eine Warnung ausgegeben.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>tag</parameter></term>
+     <listitem>
+      <para>
+       Das Authentifizierungskennzeichen im AEAD-Verschlüsselungsmodus. Ist es
+       falsch, schlägt die Authentifizierung fehl und die Funktion gibt
+       &false; zurück.
+      </para>
+      <caution>
+       <simpara>
+        Die Länge des Parameters <parameter>tag</parameter> wird von der
+        Funktion nicht überprüft. Es liegt in der Verantwortung des Aufrufers
+        sicherzustellen, dass die Länge des Kennzeichens mit der Länge des
+        Kennzeichens übereinstimmt, das beim Aufruf von
+        <function>openssl_encrypt</function> zurückgegeben wurde. Andernfalls
+        kann die Entschlüsselung auch dann erfolgreich sein, wenn das
+        übergebene Kennzeichen nur dem Anfang des korrekten Kennzeichens
+        entspricht.
+       </simpara>
+      </caution>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>aad</parameter></term>
+     <listitem>
+      <para>
+       Zusätzliche authentifizierte Daten.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die entschlüsselte Zeichenkette zurück,
+   &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Gibt einen Fehler der Stufe <constant>E_WARNING</constant> aus, wenn eine
+   unbekannte Verschlüsselungsmethode über den Parameter
+   <parameter>cipher_algo</parameter> übergeben wird.
+  </para>
+  <para>
+   Gibt einen Fehler der Stufe <constant>E_WARNING</constant> aus, wenn eine
+   leere Zeichenkette über den Parameter <parameter>iv</parameter> übergeben
+   wird.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Der Parameter <parameter>tag</parameter> ist nun nullable.
+      </entry>
+     </row>
+     <row>
+      <entry>7.1.0</entry>
+      <entry>
+       Die Parameter <parameter>tag</parameter> und <parameter>aad</parameter>
+       wurden hinzugefügt.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>openssl_encrypt</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/openssl/functions/openssl-digest.xml
+++ b/reference/openssl/functions/openssl-digest.xml
@@ -39,7 +39,7 @@
      <term><parameter>digest_algo</parameter></term>
      <listitem>
       <para>
-       Die zu verwendende Hash-Methode, z. B. "sha256";
+       Die zu verwendende Hash-Methode, &zb; "sha256";
        <function>openssl_get_md_methods</function> liefert eine Liste der
        verfügbaren Hash-Methoden.
       </para>

--- a/reference/openssl/functions/openssl-digest.xml
+++ b/reference/openssl/functions/openssl-digest.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: d1e3ea622e5d4f542cd36eca59a9f22aa0142633 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.openssl-digest" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_digest</refname>
+  <refpurpose>Berechnet einen Hashwert (Digest)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>openssl_digest</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>digest_algo</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>binary</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Berechnet einen Hashwert (Digest) für die übergebenen Daten mit der
+   angegebenen Methode und gibt das Ergebnis als unbearbeitete oder
+   hexadezimal kodierte Zeichenkette zurück.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>data</parameter></term>
+     <listitem>
+      <para>
+       Die Daten.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>digest_algo</parameter></term>
+     <listitem>
+      <para>
+       Die zu verwendende Hash-Methode, z. B. "sha256";
+       <function>openssl_get_md_methods</function> liefert eine Liste der
+       verfügbaren Hash-Methoden.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>binary</parameter></term>
+     <listitem>
+      <para>
+       Wird der Wert auf &true; gesetzt, werden die Daten unbearbeitet
+       zurückgegeben, andernfalls hexadezimal kodiert.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg den berechneten Hashwert zurück, &return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Gibt einen Fehler der Stufe <constant>E_WARNING</constant> aus, wenn eine
+   unbekannte Signaturmethode über den Parameter
+   <parameter>digest_algo</parameter> übergeben wird.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>openssl_get_md_methods</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/openssl/functions/openssl-digest.xml
+++ b/reference/openssl/functions/openssl-digest.xml
@@ -61,7 +61,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Gibt bei Erfolg den berechneten Hashwert zurück, &return.falseforfailure;.
+   Gibt bei Erfolg den berechneten Hashwert zurück. &return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/openssl/functions/openssl-get-cipher-methods.xml
+++ b/reference/openssl/functions/openssl-get-cipher-methods.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: ec4849a7581aaefbb105ca7b13d78eb8ab0217e2 Maintainer: lacatoire Status: ready -->
+
+<refentry xml:id="function.openssl-get-cipher-methods" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_get_cipher_methods</refname>
+  <refpurpose>Liefert die verfügbaren Verschlüsselungsmethoden</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>openssl_get_cipher_methods</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>aliases</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Liefert eine Liste der verfügbaren Verschlüsselungsmethoden.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>aliases</parameter></term>
+     <listitem>
+      <para>
+       Auf &true; setzen, wenn Aliase der Verschlüsselungsmethoden im
+       zurückgegebenen <type>array</type> enthalten sein sollen.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Ein <type>array</type> der verfügbaren Verschlüsselungsmethoden.
+   Es ist zu beachten, dass vor OpenSSL 1.1.1 die Verschlüsselungsmethoden in
+   Groß- und Kleinschreibung zurückgegeben wurden; ab OpenSSL 1.1.1 werden nur
+   die Varianten in Kleinschreibung zurückgegeben.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Beispiel für <function>openssl_get_cipher_methods</function></title>
+    <para>
+     Zeigt, wie die verfügbaren Verschlüsselungsmethoden aussehen können und
+     welche Aliase verfügbar sein können.
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$ciphers             = openssl_get_cipher_methods();
+$ciphers_and_aliases = openssl_get_cipher_methods(true);
+$cipher_aliases      = array_diff($ciphers_and_aliases, $ciphers);
+
+// Der ECB-Modus sollte vermieden werden
+$ciphers = array_filter( $ciphers, function($n) { return stripos($n,"ecb")===FALSE; } );
+
+// Spätestens seit August 2016 stuft OpenSSL die folgenden Verfahren als schwach ein: RC2, RC4, DES, 3DES, MD5-basierte
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"des")===FALSE; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"rc2")===FALSE; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"rc4")===FALSE; } );
+$ciphers = array_filter( $ciphers, function($c) { return stripos($c,"md5")===FALSE; } );
+$cipher_aliases = array_filter($cipher_aliases,function($c) { return stripos($c,"des")===FALSE; } );
+$cipher_aliases = array_filter($cipher_aliases,function($c) { return stripos($c,"rc2")===FALSE; } );
+
+print_r($ciphers);
+print_r($cipher_aliases);
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => aes-128-cbc
+    [1] => aes-128-cbc-hmac-sha1
+    [2] => aes-128-cbc-hmac-sha256
+    [3] => aes-128-ccm
+    [4] => aes-128-cfb
+    [5] => aes-128-cfb1
+    [6] => aes-128-cfb8
+    [7] => aes-128-ctr
+    [9] => aes-128-gcm
+    [10] => aes-128-ocb
+    [11] => aes-128-ofb
+    [12] => aes-128-xts
+    [13] => aes-192-cbc
+    [14] => aes-192-ccm
+    [15] => aes-192-cfb
+    [16] => aes-192-cfb1
+    [17] => aes-192-cfb8
+    [18] => aes-192-ctr
+    [20] => aes-192-gcm
+    [21] => aes-192-ocb
+    [22] => aes-192-ofb
+    [23] => aes-256-cbc
+    [24] => aes-256-cbc-hmac-sha1
+    [25] => aes-256-cbc-hmac-sha256
+    [26] => aes-256-ccm
+    [27] => aes-256-cfb
+    [28] => aes-256-cfb1
+    [29] => aes-256-cfb8
+    [30] => aes-256-ctr
+    [32] => aes-256-gcm
+    [33] => aes-256-ocb
+    [34] => aes-256-ofb
+    [35] => aes-256-xts
+    [36] => aria-128-cbc
+    [37] => aria-128-ccm
+    [38] => aria-128-cfb
+    [39] => aria-128-cfb1
+    [40] => aria-128-cfb8
+    [41] => aria-128-ctr
+    [43] => aria-128-gcm
+    [44] => aria-128-ofb
+    [45] => aria-192-cbc
+    [46] => aria-192-ccm
+    [47] => aria-192-cfb
+    [48] => aria-192-cfb1
+    [49] => aria-192-cfb8
+    [50] => aria-192-ctr
+    [52] => aria-192-gcm
+    [53] => aria-192-ofb
+    [54] => aria-256-cbc
+    [55] => aria-256-ccm
+    [56] => aria-256-cfb
+    [57] => aria-256-cfb1
+    [58] => aria-256-cfb8
+    [59] => aria-256-ctr
+    [61] => aria-256-gcm
+    [62] => aria-256-ofb
+    [63] => bf-cbc
+    [64] => bf-cfb
+    [66] => bf-ofb
+    [67] => camellia-128-cbc
+    [68] => camellia-128-cfb
+    [69] => camellia-128-cfb1
+    [70] => camellia-128-cfb8
+    [71] => camellia-128-ctr
+    [73] => camellia-128-ofb
+    [74] => camellia-192-cbc
+    [75] => camellia-192-cfb
+    [76] => camellia-192-cfb1
+    [77] => camellia-192-cfb8
+    [78] => camellia-192-ctr
+    [80] => camellia-192-ofb
+    [81] => camellia-256-cbc
+    [82] => camellia-256-cfb
+    [83] => camellia-256-cfb1
+    [84] => camellia-256-cfb8
+    [85] => camellia-256-ctr
+    [87] => camellia-256-ofb
+    [88] => cast5-cbc
+    [89] => cast5-cfb
+    [91] => cast5-ofb
+    [92] => chacha20
+    [93] => chacha20-poly1305
+    [111] => id-aes128-CCM
+    [112] => id-aes128-GCM
+    [113] => id-aes128-wrap
+    [114] => id-aes128-wrap-pad
+    [115] => id-aes192-CCM
+    [116] => id-aes192-GCM
+    [117] => id-aes192-wrap
+    [118] => id-aes192-wrap-pad
+    [119] => id-aes256-CCM
+    [120] => id-aes256-GCM
+    [121] => id-aes256-wrap
+    [122] => id-aes256-wrap-pad
+    [124] => idea-cbc
+    [125] => idea-cfb
+    [127] => idea-ofb
+    [137] => seed-cbc
+    [138] => seed-cfb
+    [140] => seed-ofb
+    [141] => sm4-cbc
+    [142] => sm4-cfb
+    [143] => sm4-ctr
+    [145] => sm4-ofb
+)
+Array
+(
+    [36] => aes128
+    [37] => aes128-wrap
+    [38] => aes192
+    [39] => aes192-wrap
+    [40] => aes256
+    [41] => aes256-wrap
+    [69] => aria128
+    [70] => aria192
+    [71] => aria256
+    [72] => bf
+    [77] => blowfish
+    [99] => camellia128
+    [100] => camellia192
+    [101] => camellia256
+    [102] => cast
+    [103] => cast-cbc
+    [146] => idea
+    [164] => seed
+    [169] => sm4
+)
+
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>openssl_get_md_methods</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Adds German translations for 5 OpenSSL functions covering symmetric cipher introspection and digest computation: openssl_decrypt, openssl_cipher_iv_length, openssl_cipher_key_length, openssl_get_cipher_methods, openssl_digest.

Terminology mirrors the existing openssl_encrypt translation (Verschlüsselungsmethode, Initialisierungsvektor, Authentifizierungskennzeichen…).