### PR TITLE
Sync reference/datetime with EN (no-content commits)

### DIFF
--- a/reference/datetime/dateperiod/getrecurrences.xml
+++ b/reference/datetime/dateperiod/getrecurrences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateperiod.getrecurrences" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/dateperiod/getstartdate.xml
+++ b/reference/datetime/dateperiod/getstartdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="dateperiod.getstartdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetime/createfromimmutable.xml
+++ b/reference/datetime/datetime/createfromimmutable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.createfromimmutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetime/createfrominterface.xml
+++ b/reference/datetime/datetime/createfrominterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: bbfdc364de79d739aeccc611ef82111e7f15b4da Reviewer: samesch -->
 <!-- CREDITS: Stefan Schenke -->

--- a/reference/datetime/datetimeimmutable/createfrominterface.xml
+++ b/reference/datetime/datetimeimmutable/createfrominterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.createfrominterface" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/createfrommutable.xml
+++ b/reference/datetime/datetimeimmutable/createfrommutable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.createfrommutable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/modify.xml
+++ b/reference/datetime/datetimeimmutable/modify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.modify" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/setdate.xml
+++ b/reference/datetime/datetimeimmutable/setdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.setdate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/setisodate.xml
+++ b/reference/datetime/datetimeimmutable/setisodate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.setisodate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/settime.xml
+++ b/reference/datetime/datetimeimmutable/settime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/settimestamp.xml
+++ b/reference/datetime/datetimeimmutable/settimestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeimmutable/sub.xml
+++ b/reference/datetime/datetimeimmutable/sub.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.sub" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeinterface/diff.xml
+++ b/reference/datetime/datetimeinterface/diff.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.diff" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeinterface/getoffset.xml
+++ b/reference/datetime/datetimeinterface/getoffset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.getoffset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeinterface/gettimestamp.xml
+++ b/reference/datetime/datetimeinterface/gettimestamp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.gettimestamp" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimeinterface/gettimezone.xml
+++ b/reference/datetime/datetimeinterface/gettimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.gettimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimezone/construct.xml
+++ b/reference/datetime/datetimezone/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: c7ee9cd4d1bb4538e283502b5f958b3042a61a63 Reviewer: samesch -->
 <refentry xml:id="datetimezone.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/datetime/datetimezone/getoffset.xml
+++ b/reference/datetime/datetimezone/getoffset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimezone.getoffset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/datetimezone/listabbreviations.xml
+++ b/reference/datetime/datetimezone/listabbreviations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimezone.listabbreviations" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/formats.xml
+++ b/reference/datetime/formats.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <chapter xml:id="datetime.formats" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Unterstützte Datums- und Zeitformate</title>

--- a/reference/datetime/functions/checkdate.xml
+++ b/reference/datetime/functions/checkdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 96c9d88bad9a7d7d44bfb7f26c226df7ee9ddf26 Reviewer: samesch -->
 <refentry xml:id="function.checkdate" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/date-default-timezone-get.xml
+++ b/reference/datetime/functions/date-default-timezone-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-default-timezone-get" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/datetime/functions/date-default-timezone-set.xml
+++ b/reference/datetime/functions/date-default-timezone-set.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 0a10abc50524fcbb21807b5e6ebffb3b86d45907 Reviewer: samesch -->
 <refentry xml:id="function.date-default-timezone-set" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/date-parse-from-format.xml
+++ b/reference/datetime/functions/date-parse-from-format.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-parse-from-format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/functions/date-sun-info.xml
+++ b/reference/datetime/functions/date-sun-info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-sun-info" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/datetime/functions/date-sunrise.xml
+++ b/reference/datetime/functions/date-sunrise.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-sunrise" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/functions/date-sunset.xml
+++ b/reference/datetime/functions/date-sunset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.date-sunset" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/functions/date.xml
+++ b/reference/datetime/functions/date.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: simp Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: simp Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 089983558f0d09521df6ef09582c451c1ec79ef3 Reviewer: samesch -->
 <!-- Credits: sammywg -->

--- a/reference/datetime/functions/getdate.xml
+++ b/reference/datetime/functions/getdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 34188f8256bdc6f0e6e1965c2be94247997165b6 Reviewer: samesch -->
 <refentry xml:id="function.getdate" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/gettimeofday.xml
+++ b/reference/datetime/functions/gettimeofday.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 0c9c2dd669fe9395eaa73d487fbd160f9057429a Reviewer: samesch -->
 <refentry xml:id="function.gettimeofday" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/gmdate.xml
+++ b/reference/datetime/functions/gmdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 9b7ab9bc8e78b1201b8b8c71eac051256d433993 Reviewer: samesch -->
 <refentry xml:id="function.gmdate" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/gmmktime.xml
+++ b/reference/datetime/functions/gmmktime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Reviewer: samesch -->
 <refentry xml:id="function.gmmktime" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/idate.xml
+++ b/reference/datetime/functions/idate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.idate" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/datetime/functions/localtime.xml
+++ b/reference/datetime/functions/localtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a4ba07f273fd7d34520a8d02052a746076094e32 Reviewer: samesch -->
 <refentry xml:id="function.localtime" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/microtime.xml
+++ b/reference/datetime/functions/microtime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Reviewer: samesch -->
 <refentry xml:id="function.microtime" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/mktime.xml
+++ b/reference/datetime/functions/mktime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 8cdc6621f9826d04abc3e50438c010804d7e8683 Reviewer: samesch -->
 <refentry xml:id="function.mktime" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/strftime.xml
+++ b/reference/datetime/functions/strftime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 9ff98b38276060be5c9e3fcd1aa6721f2f955213 Reviewer: samesch -->
 <refentry xml:id="function.strftime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/datetime/functions/strptime.xml
+++ b/reference/datetime/functions/strptime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.strptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>

--- a/reference/datetime/functions/strtotime.xml
+++ b/reference/datetime/functions/strtotime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: f5bd78b3c2c48b8702bc1547a08a9ad592047c1c Reviewer: samesch -->
 <refentry xml:id="function.strtotime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/datetime/functions/time.xml
+++ b/reference/datetime/functions/time.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: d91e36266dddbe570789dbe218e5672fc0b85089 Reviewer: samesch -->
 <refentry xml:id="function.time" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/timezone-name-from-abbr.xml
+++ b/reference/datetime/functions/timezone-name-from-abbr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: b95d28e6ec86e4a71e012737d36ebdc1cf009180 Reviewer: samesch -->
 <refentry xml:id="function.timezone-name-from-abbr" xmlns="http://docbook.org/ns/docbook">

--- a/reference/datetime/functions/timezone-version-get.xml
+++ b/reference/datetime/functions/timezone-version-get.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 31cea656f39a3941d372de79629dafe6d00a2e18 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.timezone-version-get" xmlns="http://docbook.org/ns/docbook"  xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>


### PR DESCRIPTION
Bumps EN-Revision on 43 files under reference/datetime/. The recorded DE hash and the current EN HEAD already produce identical file content (verified with git diff), so only the metadata hash needs to move forward; no translated text is touched.