### PR TITLE
translate: array_find / array_find_key / array_all / array_any (PHP 8.4)

### DIFF
--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-all" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -43,7 +43,9 @@
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
       </methodsynopsis>
-      Wenn diese Funktion &false; zurückgibt, gibt <function>array_all</function> ebenfalls &false; zurück, und die Callback-Funktion wird für keine weiteren Elemente mehr aufgerufen.
+      Wenn diese Funktion &false; zurückgibt, gibt <function>array_all</function>
+      ebenfalls &false; zurück, und die Callback-Funktion wird für keine weiteren
+      Elemente mehr aufgerufen.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -43,9 +43,7 @@
        <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
        <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
       </methodsynopsis>
-      Wenn diese Funktion &false; zurückgibt, wird &false; von
-      <function>array_all</function> zurückgegeben und die Callback-Funktion
-      wird für weitere Elemente nicht mehr aufgerufen.
+      Wenn diese Funktion &false; zurückgibt, gibt <function>array_all</function> ebenfalls &false; zurück, und die Callback-Funktion wird für keine weiteren Elemente mehr aufgerufen.
      </para>
     </listitem>
    </varlistentry>

--- a/reference/array/functions/array-all.xml
+++ b/reference/array/functions/array-all.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.array-all" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_all</refname>
+  <refpurpose>Prüft, ob alle Elemente eines &array;s eine Callback-Funktion erfüllen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>array_all</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_all</function> gibt &true; zurück, wenn die übergebene
+   <parameter>callback</parameter>-Funktion für alle Elemente &true; zurückgibt.
+   Andernfalls gibt die Funktion &false; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      Das zu durchsuchende &array;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      Die Callback-Funktion, die zur Prüfung jedes Elements aufgerufen wird
+      und die folgende Signatur haben muss:
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      Wenn diese Funktion &false; zurückgibt, wird &false; von
+      <function>array_all</function> zurückgegeben und die Callback-Funktion
+      wird für weitere Elemente nicht mehr aufgerufen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die Funktion gibt &true; zurück, wenn <parameter>callback</parameter> für
+   alle Elemente &true; zurückgibt. Andernfalls gibt die Funktion &false;
+   zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_all</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Prüft, ob alle Tiernamen kürzer als 12 Buchstaben sind.
+var_dump(array_all($array, function (string $value) {
+    return strlen($value) < 12;
+}));
+
+// Prüft, ob alle Tiernamen länger als 5 Buchstaben sind.
+var_dump(array_all($array, function (string $value) {
+    return strlen($value) > 5;
+}));
+
+// Prüft, ob alle Array-Schlüssel Zeichenketten sind.
+var_dump(array_all($array, function (string $value, $key) {
+   return is_string($key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.array-any" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_any</refname>
+  <refpurpose>Prüft, ob mindestens ein Element eines &array;s eine Callback-Funktion erfüllt</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>array_any</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_any</function> gibt &true; zurück, wenn die übergebene
+   <parameter>callback</parameter>-Funktion für mindestens ein Element &true;
+   zurückgibt. Andernfalls gibt die Funktion &false; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      Das zu durchsuchende &array;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      Die Callback-Funktion, die zur Prüfung jedes Elements aufgerufen wird
+      und die folgende Signatur haben muss:
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      Wenn diese Funktion &true; zurückgibt, wird &true; von
+      <function>array_any</function> zurückgegeben und die Callback-Funktion
+      wird für weitere Elemente nicht mehr aufgerufen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die Funktion gibt &true; zurück, wenn es mindestens ein Element gibt, für
+   das <parameter>callback</parameter> &true; zurückgibt. Andernfalls gibt
+   die Funktion &false; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_any</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Prüft, ob irgendein Tiername länger als 5 Buchstaben ist.
+var_dump(array_any($array, function (string $value) {
+    return strlen($value) > 5;
+}));
+
+// Prüft, ob irgendein Tiername kürzer als 3 Buchstaben ist.
+var_dump(array_any($array, function (string $value) {
+    return strlen($value) < 3;
+}));
+
+// Prüft, ob irgendein Array-Schlüssel keine Zeichenkette ist.
+var_dump(array_any($array, function (string $value, $key) {
+   return !is_string($key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_all</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_find</function></member>
+   <member><function>array_find_key</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-any.xml
+++ b/reference/array/functions/array-any.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-any" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-find-key" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/array/functions/array-find-key.xml
+++ b/reference/array/functions/array-find-key.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.array-find-key" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_find_key</refname>
+  <refpurpose>Gibt den Schlüssel des ersten Elements zurück, das eine Callback-Funktion erfüllt</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_find_key</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_find_key</function> gibt den Schlüssel des ersten Elements
+   eines &array;s zurück, für das die übergebene <parameter>callback</parameter>-Funktion
+   &true; zurückgibt. Wenn kein passendes Element gefunden wird, gibt die Funktion
+   &null; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      Das zu durchsuchende &array;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      Die Callback-Funktion, die zur Prüfung jedes Elements aufgerufen wird
+      und die folgende Signatur haben muss:
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      Wenn diese Funktion &true; zurückgibt, wird der Schlüssel von
+      <function>array_find_key</function> zurückgegeben und die Callback-Funktion
+      wird für weitere Elemente nicht mehr aufgerufen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die Funktion gibt den Schlüssel des ersten Elements zurück, für das
+   <parameter>callback</parameter> &true; zurückgibt. Wenn kein passendes
+   Element gefunden wird, gibt die Funktion &null; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_find_key</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Findet das erste Tier mit einem Namen, der länger als 4 Zeichen ist.
+var_dump(array_find_key($array, function (string $value) {
+    return strlen($value) > 4;
+}));
+
+// Findet das erste Tier, dessen Name mit f beginnt.
+var_dump(array_find_key($array, function (string $value) {
+    return str_starts_with($value, 'f');
+}));
+
+// Findet das erste Tier, bei dem der Array-Schlüssel das erste Zeichen des Tiernamens ist.
+var_dump(array_find_key($array, function (string $value, $key) {
+   return $value[0] === $key;
+}));
+
+// Findet das erste Tier, bei dem der Array-Schlüssel einem regulären Ausdruck entspricht.
+var_dump(array_find_key($array, function ($value, $key) {
+   return preg_match('/^([a-f])$/', $key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(1) "e"
+NULL
+string(1) "c"
+string(1) "a"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_find</function></member>
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_reduce</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>array_find</refname>
+  <refpurpose>Gibt das erste Element zurück, das eine Callback-Funktion erfüllt</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>array_find</methodname>
+   <methodparam><type>array</type><parameter>array</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>array_find</function> gibt den Wert des ersten Elements eines
+   &array;s zurück, für das die übergebene <parameter>callback</parameter>-Funktion
+   &true; zurückgibt. Wenn kein passendes Element gefunden wird, gibt die Funktion
+   &null; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>array</parameter></term>
+    <listitem>
+     <simpara>
+      Das zu durchsuchende &array;.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      Die Callback-Funktion, die zur Prüfung jedes Elements aufgerufen wird
+      und die folgende Signatur haben muss:
+      <methodsynopsis>
+       <type>bool</type><methodname><replaceable>callback</replaceable></methodname>
+       <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+       <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+      </methodsynopsis>
+      Wenn diese Funktion &true; zurückgibt, wird der Wert von
+      <function>array_find</function> zurückgegeben und die Callback-Funktion
+      wird für weitere Elemente nicht mehr aufgerufen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die Funktion gibt den Wert des ersten Elements zurück, für das
+   <parameter>callback</parameter> &true; zurückgibt. Wenn kein passendes
+   Element gefunden wird, gibt die Funktion &null; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>array_find</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$array = [
+    'a' => 'dog',
+    'b' => 'cat',
+    'c' => 'cow',
+    'd' => 'duck',
+    'e' => 'goose',
+    'f' => 'elephant'
+];
+
+// Findet das erste Tier mit einem Namen, der länger als 4 Zeichen ist.
+var_dump(array_find($array, function (string $value) {
+    return strlen($value) > 4;
+}));
+
+// Findet das erste Tier, dessen Name mit f beginnt.
+var_dump(array_find($array, function (string $value) {
+    return str_starts_with($value, 'f');
+}));
+
+// Findet das erste Tier, bei dem der Array-Schlüssel das erste Zeichen des Tiernamens ist.
+var_dump(array_find($array, function (string $value, $key) {
+   return $value[0] === $key;
+}));
+
+// Findet das erste Tier, bei dem der Array-Schlüssel einem regulären Ausdruck entspricht.
+var_dump(array_find($array, function ($value, $key) {
+   return preg_match('/^([a-f])$/', $key);
+}));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+string(5) "goose"
+NULL
+string(3) "cow"
+string(3) "dog"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>array_find_key</function></member>
+   <member><function>array_all</function></member>
+   <member><function>array_any</function></member>
+   <member><function>array_filter</function></member>
+   <member><function>array_reduce</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/array/functions/array-find.xml
+++ b/reference/array/functions/array-find.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
 <refentry xml:id="function.array-find" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>


### PR DESCRIPTION
Translate the four functional array helpers introduced in PHP 8.4, mirroring the EN structure tag-by-tag. Glossary follows the existing array reference (Callback-Funktion, &array;, Schlüssel, Zeichenkette).

Happy to adjust naming or terminology if there's a different convention preferred.