### PR TITLE
Sync reference/soap with EN

### DIFF
--- a/reference/soap/book.xml
+++ b/reference/soap/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 1634a886415d0ab4df195fe49d18a1c150b70758 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: sammywg Status: ready -->
 
 <book xml:id="book.soap" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundledexternal" ?>
@@ -20,17 +20,18 @@
  
  &reference.soap.setup;
  &reference.soap.constants;
- <!-- &reference.soap.examples; -->
  &reference.soap.reference;
- 
+
  &reference.soap.soapclient;
  &reference.soap.soapserver;
  &reference.soap.soapfault;
  &reference.soap.soapheader;
  &reference.soap.soapparam;
  &reference.soap.soapvar;
- 
- 
+
+ &reference.soap.soap.sdl;
+ &reference.soap.soap.url;
+
 </book>
 
 <!-- Keep this comment at the end of the file

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 37280533a76693adac626a37ffc8daa2276400ce Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <appendix xml:id="soap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -147,7 +147,9 @@
      <entry>32</entry>
      <entry>
       Wenn als Teil der
-      <link linkend="soapclient.construct.options.compression">Option <parameter>compression</parameter></link>
+      <link linkend="soapclient.construct.options.compression">
+       Option <parameter>compression</parameter>
+      </link>
       an <methodname>SoapClient::__construct</methodname> übergeben, wird eine
       "Accept-Encoding"-Kopfzeile verwendet.
      </entry>
@@ -160,7 +162,9 @@
      <entry>0</entry>
      <entry>
       Wenn als Teil der
-      <link linkend="soapclient.construct.options.compression">Option <parameter>compression</parameter></link>
+      <link linkend="soapclient.construct.options.compression">
+       Option <parameter>compression</parameter>
+      </link>
       an <methodname>SoapClient::__construct</methodname> übergeben, wird die
       gzip-Komprimierung verwendet.
      </entry>
@@ -173,7 +177,9 @@
      <entry>16</entry>
      <entry>
       Wenn als Teil der
-      <link linkend="soapclient.construct.options.compression">Option <parameter>compression</parameter></link>
+      <link linkend="soapclient.construct.options.compression">
+       Option <parameter>compression</parameter>
+      </link>
       an <methodname>SoapClient::__construct</methodname> übergeben, wird die
       Deflate-Komprimierung verwendet.
      </entry>
@@ -210,7 +216,9 @@
      <entry>0</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die veraltete
-      <link linkend="soapclient.construct.options.ssl-method">Option <parameter>ssl_method</parameter></link>
+      <link linkend="soapclient.construct.options.ssl-method">
+       Option <parameter>ssl_method</parameter>
+      </link>
       verwendet.
      </entry>
     </row>
@@ -222,7 +230,9 @@
      <entry>1</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die veraltete
-      <link linkend="soapclient.construct.options.ssl-method">Option <parameter>ssl_method</parameter></link>
+      <link linkend="soapclient.construct.options.ssl-method">
+       Option <parameter>ssl_method</parameter>
+      </link>
       verwendet.
      </entry>
     </row>
@@ -234,7 +244,9 @@
      <entry>2</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die veraltete
-      <link linkend="soapclient.construct.options.ssl-method">Option <parameter>ssl_method</parameter></link>
+      <link linkend="soapclient.construct.options.ssl-method">
+       Option <parameter>ssl_method</parameter>
+      </link>
       verwendet.
      </entry>
     </row>
@@ -246,7 +258,9 @@
      <entry>3</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die veraltete
-      <link linkend="soapclient.construct.options.ssl-method">Option <parameter>ssl_method</parameter></link>
+      <link linkend="soapclient.construct.options.ssl-method">
+       Option <parameter>ssl_method</parameter>
+      </link>
       verwendet.
      </entry>
     </row>
@@ -682,7 +696,9 @@
      <entry>1</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die
-      <link linkend="soapclient.construct.options.features">Option <parameter>features</parameter></link>
+      <link linkend="soapclient.construct.options.features">
+       Option <parameter>features</parameter>
+      </link>
       verwendet.
      </entry>
     </row>
@@ -694,7 +710,9 @@
      <entry>2</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die
-      <link linkend="soapclient.construct.options.features">Option <parameter>features</parameter></link>
+      <link linkend="soapclient.construct.options.features">
+       Option <parameter>features</parameter>
+      </link>
       verwendet.
      </entry>
     </row>
@@ -706,7 +724,9 @@
      <entry>4</entry>
      <entry>
       Wird bei <methodname>SoapClient::__construct</methodname> für die
-      <link linkend="soapclient.construct.options.features">Option <parameter>features</parameter></link>
+      <link linkend="soapclient.construct.options.features">
+       Option <parameter>features</parameter>
+      </link>
       verwendet.
      </entry>
     </row>

--- a/reference/soap/soapclient.xml
+++ b/reference/soap/soapclient.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0e48705eb88453af785e0e4a6cbd526085dfe3a Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 89205c88a79fcaad39fd043ed5ef695cd7bf813e Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: fe4e8b87d18f17394e7177917c498774b062448c Reviewer: samesch -->
 <reference xml:id="class.soapclient" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -69,7 +69,7 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>private</modifier>
-     <type class="union"><type>resource</type><type>null</type></type>
+     <type class="union"><type>Soap\Sdl</type><type>null</type></type>
      <varname linkend="soapclient.props.sdl">sdl</varname>
      <initializer>null</initializer>
     </fieldsynopsis>
@@ -87,7 +87,7 @@
     </fieldsynopsis>
     <fieldsynopsis>
      <modifier>private</modifier>
-     <type class="union"><type>resource</type><type>null</type></type>
+     <type class="union"><type>Soap\Url</type><type>null</type></type>
      <varname linkend="soapclient.props.httpurl">httpurl</varname>
      <initializer>null</initializer>
     </fieldsynopsis>

--- a/reference/soap/soapclient/construct.xml
+++ b/reference/soap/soapclient/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 22583751fbfdaa3eaa41aeb6470d1343f5cb2c78 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 96f69db3ae2245082de88ff0cc4f8a76620a44d1 Reviewer: samesch -->
 <refentry xml:id="soapclient.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -29,9 +29,9 @@
      <term><parameter>wsdl</parameter></term>
      <listitem>
       <para>
-       Der URI einer WSDL-Datei, die den Dienst beschreibt, der verwendet
-       wird, um den Client automatisch zu konfigurieren. Wenn er nicht
-       angegeben wird, arbeitet der Client im non-WSDL-Modus.
+       Der URI einer <acronym>WSDL</acronym>-Datei, die den Dienst beschreibt,
+       der verwendet wird, um den Client automatisch zu konfigurieren. Wenn er
+       nicht angegeben wird, arbeitet der Client im non-WSDL-Modus.
       </para>
       <note>
        <para>
@@ -637,7 +637,7 @@
            von SSL 2 bzw. SSL 3. Die Angabe von
            <constant>SOAP_SSL_METHOD_SSLv23</constant> hat keine Auswirkung;
            Diese Konstante existiert nur aus Gründen der
-           Abwärtskompatibilität. Seit PHP 7.2 hat auch die Angabe von
+           Abwärtskompatibilität. Seit PHP 7.2.0 hat auch die Angabe von
            <constant>SOAP_SSL_METHOD_TLS</constant> keine Auswirkung mehr; in
            früheren Versionen erzwang sie die Verwendung von TLS 1.0.
           </para>
@@ -647,17 +647,18 @@
            nicht unterstützt werden.
           </para>
           <para>
-           Diese Option ist seit PHP 8.1.0 als <emphasis>VERALTET</emphasis>
-           markiert und sollte nicht mehr verwendet werden. Die Option
+           Diese Option ist seit PHP 8.1.0 als
+           <emphasis role="strong">veraltet</emphasis> markiert und sollte
+           nicht mehr verwendet werden. Die Option
            <link linkend="soapclient.construct.options.stream-context"><parameter>stream_context</parameter></link>
            bietet mit dem Kontextparameter 'crypto_method' eine flexiblere
            Alternative, die es ermöglicht, einzelne Versionen von TLS
            anzugeben.
-           <example>
-            <title>Die Verwendung von TLS 1.3 vorschreiben</title>
+           <informalexample>
             <programlisting role="php">
 <![CDATA[
 <?php
+// Die Verwendung von TLS 1.3 vorschreiben
 $context = stream_context_create([
     'ssl' => [
         'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT
@@ -666,7 +667,7 @@ $context = stream_context_create([
 $client = new SoapClient("some.wsdl", ['context' => $context]);
 ]]>
             </programlisting>
-           </example>
+           </informalexample>
           </para>
          </listitem>
         </varlistentry>

--- a/reference/soap/soapclient/dorequest.xml
+++ b/reference/soap/soapclient/dorequest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d9188340360dd1d160d3ddf24c532486214fce17 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: sammywg Status: ready -->
 <refentry xml:id="soapclient.dorequest" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapClient::__doRequest</refname>
@@ -16,6 +16,7 @@
    <methodparam><type>string</type><parameter>action</parameter></methodparam>
    <methodparam><type>int</type><parameter>version</parameter></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>oneWay</parameter><initializer>&false;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>uriParserClass</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Führt eine SOAP-Anfrage über HTTP aus.
@@ -73,6 +74,17 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>uriParserClass</parameter></term>
+     <listitem>
+      <simpara>
+       Der Klassenname, der zum Parsen der Umleitungs-URI verwendet werden soll,
+       wenn ein <literal>"Location"</literal>-Header in der Antwort empfangen wird,
+       oder &null;, um das Standardverhalten basierend auf <function>parse_url</function>
+       zu verwenden.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -95,6 +107,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>uriParserClass</parameter> wurde
+       hinzugefügt.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/soap/soapfault.xml
+++ b/reference/soap/soapfault.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0e48705eb88453af785e0e4a6cbd526085dfe3a Maintainer: nobody Status: ready -->
+<!-- EN-Revision: cdb9b8afa58e676e9c7844a892aa6eca152f916d Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 09c49da6f0167fcdfe53a76e3ea28ecfc0eb337b Reviewer: samesch -->
 <reference xml:id="class.soapfault" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
@@ -73,6 +73,12 @@
      <type>mixed</type>
      <varname linkend="soapfault.props.headerfault">headerfault</varname>
      <initializer>null</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <type>string</type>
+     <varname linkend="soapfault.props.lang">lang</varname>
+     <initializer>""</initializer>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&InheritedProperties;</classsynopsisinfo>
@@ -148,8 +154,40 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry xml:id="soapfault.props.lang">
+     <term><varname>lang</varname></term>
+     <listitem>
+      <simpara>
+       Wert des <literal>xml:lang</literal>-Attributs des Reason-Texts in
+       SOAP 1.2.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.5.0</entry>
+       <entry>
+        <property>SoapFault::lang</property> wurde hinzugefügt.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
  </partintro>
 
  &reference.soap.entities.soapfault;

--- a/reference/soap/soapfault/construct.xml
+++ b/reference/soap/soapfault/construct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: simp Status: ready -->
+<!-- EN-Revision: d9cfd78e58134785e2231bfc2d57f7f7a5698bb4 Maintainer: simp Status: ready -->
 <refentry xml:id="soapfault.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapFault::__construct</refname>
@@ -17,12 +17,13 @@
    <methodparam choice="opt"><type>mixed</type><parameter>details</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>name</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>headerFault</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>lang</parameter><initializer>""</initializer></methodparam>
   </constructorsynopsis>
   <para>
    Diese Klasse wird verwendet, um SOAP-Fehlerrückmeldungen vom PHP-Handler zu
-   senden. <parameter>faultcode</parameter>,
-   <parameter>faultstring</parameter>, <parameter>faultactor</parameter> und
-   <parameter>detail</parameter> sind die Standardelemente eines SOAP-Fehlers.
+   senden. <parameter>code</parameter>, <parameter>string</parameter>,
+   <parameter>actor</parameter> und <parameter>details</parameter> sind die
+   Standardelemente eines SOAP-Fehlers.
   </para>
  </refsect1>
 
@@ -31,7 +32,7 @@
   <para>
    <variablelist>
     <varlistentry>
-     <term><parameter>faultcode</parameter></term>
+     <term><parameter>code</parameter></term>
      <listitem>
       <para>
        Der Fehlercode von <classname>SoapFault</classname>.
@@ -39,7 +40,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>faultstring</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Die Fehlermeldung von <classname>SoapFault</classname>.
@@ -47,7 +48,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>faultactor</parameter></term>
+     <term><parameter>actor</parameter></term>
      <listitem>
       <para>
        Eine Zeichenkette, die den Verursacher des Fehlers identifiziert.
@@ -55,7 +56,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>detail</parameter></term>
+     <term><parameter>details</parameter></term>
      <listitem>
       <para>
        Weitere Details über die Ursache des Fehlers.
@@ -63,7 +64,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>faultname</parameter></term>
+     <term><parameter>name</parameter></term>
      <listitem>
       <para>
        Kann verwendet werden, um die genaue Fehlerkodierung aus WSDL zu
@@ -72,7 +73,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>headerfault</parameter></term>
+     <term><parameter>headerFault</parameter></term>
      <listitem>
       <para>
        Kann bei der Verarbeitung der SOAP-Header verwendet werden, um einen
@@ -80,8 +81,40 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>lang</parameter></term>
+     <listitem>
+      <simpara>
+       Die menschliche Sprache, in der die SoapFault verfasst ist. Wird nur für
+       SOAP Version 1.2 verwendet.
+      </simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>lang</parameter> wurde hinzugefügt,
+       um mit der SOAP-1.2-Spezifikation konform zu sein.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/soap/soapserver/addfunction.xml
+++ b/reference/soap/soapserver/addfunction.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 577239f64b3959c22d348a5f381eaf32fde996ed Maintainer: sammywg Status: ready -->
 <refentry xml:id="soapserver.addfunction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::addFunction</refname>
@@ -35,9 +35,14 @@
        exportieren.
       </para>
       <para>
-       Spezielle Konstante <constant>SOAP_FUNCTIONS_ALL</constant> übergeben,
-       um alle Funktionen zu exportieren.
+       Ein Array von Funktionsnamen übergeben, um alle Funktionen zu exportieren.
       </para>
+      <simpara>
+       Seit PHP 8.4.0 ist es veraltet, einen <type>int</type>-Wert (einschließlich
+       <constant>SOAP_FUNCTIONS_ALL</constant>) zu übergeben.
+       Stattdessen sollte <function>get_defined_functions</function> verwendet
+       werden, um alle Funktionen abzurufen und als Array zu übergeben.
+      </simpara>
       <note>
        <para>
         <parameter>functions</parameter> muss alle Argumente in der gleichen
@@ -58,6 +63,30 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Die Übergabe eines <type>int</type>-Werts an
+       <methodname>SoapServer::addFunction</methodname>, einschließlich
+       <constant>SOAP_FUNCTIONS_ALL</constant>, wurde als veraltet markiert.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
@@ -83,7 +112,8 @@ function echoTwoStrings($inputString1, $inputString2)
 }
 $server->addFunction(array("echoString", "echoTwoStrings"));
 
-$server->addFunction(SOAP_FUNCTIONS_ALL);
+$functions = array_merge(...get_defined_functions());
+$server->addFunction($functions);
 
 ?>
 ]]>

--- a/reference/soap/soapserver/fault.xml
+++ b/reference/soap/soapserver/fault.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: fe4e8b87d18f17394e7177917c498774b062448c Maintainer: simp Status: ready -->
+<!-- EN-Revision: 9a8c593c09cf7d84085989e42f3b2b23536279db Maintainer: simp Status: ready -->
 <refentry xml:id="soapserver.fault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SoapServer::fault</refname>
@@ -16,6 +16,7 @@
    <methodparam choice="opt"><type>string</type><parameter>actor</parameter><initializer>""</initializer></methodparam>
    <methodparam choice="opt"><type>mixed</type><parameter>details</parameter><initializer>&null;</initializer></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>name</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>lang</parameter><initializer>""</initializer></methodparam>
   </methodsynopsis>
   <para>
    Sendet dem Client der aktuellen Anfrage eine Antwort, die einen Fehler
@@ -75,6 +76,12 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><parameter>lang</parameter></term>
+     <listitem>
+      <simpara>Die menschliche Sprache, in der die SoapFault verfasst ist. Wird nur für SOAP Version 1.2 verwendet.</simpara>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </para>
  </refsect1>
@@ -84,6 +91,29 @@
   <para>
    &return.void;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der optionale Parameter <parameter>lang</parameter> wurde hinzugefügt,
+       um mit der SOAP-1.2-Spezifikation konform zu sein.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="seealso">


### PR DESCRIPTION
Porte les changements EN détectés par revcheck sur l'ensemble du dossier `reference/soap` (9 fichiers).

Le détail des changements (8.4 et 8.5 SOAP additions, renommages de paramètres dans `SoapFault::__construct`, formatage `constants.xml`) est dans le commit unique.