### PR TITLE
Sync reference/sockets with EN

### DIFF
--- a/reference/sockets/constants.xml
+++ b/reference/sockets/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 42402941bba0208a919e03e1320ca4732330eafa Maintainer: conni Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: conni Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: c0954ae4e632d2583118a7946681191a08c45eba Reviewer: samesch -->
 <appendix xml:id="sockets.constants" xmlns="http://docbook.org/ns/docbook">
@@ -47,7 +47,24 @@
    </term>
    <listitem>
     <simpara>
-     Verfügbar ab PHP 8.3.0 (nur FreeBSD)
+     Socket-Adressfamilie für die FreeBSD-Schnittstelle
+     <literal>divert(4)</literal>, die zum Empfangen von durch die Firewall
+     umgeleiteten Paketen verwendet wird.
+     Verfügbar ab PHP 8.3.0 (nur FreeBSD).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.af-packet">
+   <term>
+    <constant>AF_PACKET</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Socket-Adressfamilie für Low-Level-Paket-Sockets, die zum Senden und
+     Empfangen von Rohpaketen auf der Ebene des Gerätetreibers (OSI-Schicht 2)
+     verwendet wird.
+     Verfügbar ab PHP 8.5.0 (nur Linux).
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/sockets/functions/socket-bind.xml
+++ b/reference/sockets/functions/socket-bind.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 35883800e764cccacf5772330bc007b6b08ffc6e Maintainer: conni Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: conni Status: ready -->
 <refentry xml:id="function.socket-bind" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_bind</refname>
@@ -90,6 +90,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Es wird nun ein <exceptionname>ValueError</exceptionname> ausgelöst,
+       wenn <parameter>port</parameter> kleiner als 0 oder größer als 65535
+       ist.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0e097419a847a077c7d8a74ebc5237ba9d8ddc90 Maintainer: conni Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: conni Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a62a46e9c785336bb7a145d5c5805c228a515031 Reviewer: samesch -->
 <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">
@@ -80,6 +80,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Es wird nun ein <exceptionname>ValueError</exceptionname> ausgelöst,
+       wenn <parameter>port</parameter> kleiner als 0 oder größer als 65535
+       ist.
+      </entry>
+     </row>
      <row>
       <entry>8.4.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-create.xml
+++ b/reference/sockets/functions/socket-create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a871ef72edf436c59422dedd538594db2541d5f1 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xml:id="function.socket-create" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -240,6 +240,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Unterstützt nun das Erstellen von Sockets der Familie
+       <constant>AF_PACKET</constant>.
+      </entry>
+     </row>
      <row>
       <entry>8.0.0</entry>
       <entry>

--- a/reference/sockets/functions/socket-getsockname.xml
+++ b/reference/sockets/functions/socket-getsockname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 14dc7c47365f2b71f6c907a5ba5bccf42534d5a9 Maintainer: conni Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: conni Status: ready -->
 <refentry xml:id="function.socket-getsockname" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_getsockname</refname>
@@ -101,6 +101,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Liefert nun den Schnittstellenindex und seine Zeichenkettendarstellung,
+       wenn die Funktion auf einem Socket der Familie
+       <constant>AF_PACKET</constant> verwendet wird.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>

--- a/reference/sockets/functions/socket-sendto.xml
+++ b/reference/sockets/functions/socket-sendto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: e50e79746736dbdfbabe9bd3566793b3ddf38f58 Maintainer: conni Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: conni Status: ready -->
 <refentry xml:id="function.socket-sendto" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_sendto</refname>
@@ -143,6 +143,14 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Es wird nun ein <exceptionname>ValueError</exceptionname> ausgelöst,
+       wenn <parameter>port</parameter> kleiner als 0 oder größer als 65535
+       ist.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
      <row>
       <entry>8.0.0</entry>

--- a/reference/sockets/functions/socket-set-option.xml
+++ b/reference/sockets/functions/socket-set-option.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 93105c67e470df72333493cc2e534635dd16422d Maintainer: conni Status: ready -->
+<!-- EN-Revision: 890cc22d38fa747c9930fd0d5984c170f2490c1b Maintainer: conni Status: ready -->
 <refentry xml:id="function.socket-set-option" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>socket_set_option</refname>
@@ -92,6 +92,19 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Es wird nun eine Exception ausgelöst, wenn
+       <constant>MCAST_LEAVE_GROUP</constant> oder
+       <constant>MCAST_LEAVE_SOURCE_GROUP</constant> verwendet wird und der
+       Wert kein gültiges Objekt oder Array ist, sowie ein
+       <exceptionname>ValueError</exceptionname>, wenn eine
+       Multicast-Option auf einem Socket verwendet wird, der nicht zur
+       Familie <constant>AF_INET</constant> oder <constant>AF_INET6</constant>
+       gehört.
+      </entry>
+     </row>
      &sockets.changelog.socket-param;
     </tbody>
    </tgroup>


### PR DESCRIPTION
Porte les changements EN détectés par revcheck sur les 7 fichiers `reference/sockets` stale (nouvelles constantes `AF_PACKET`, lignes de changelog 8.5 pour ValueError port et options multicast).

Indépendante de la PR `reference/soap`, mergeable séparément.