### PR TITLE
Translate Pcntl\QosClass enum and four pcntl functions

### DIFF
--- a/reference/pcntl/functions/pcntl-async-signals.xml
+++ b/reference/pcntl/functions/pcntl-async-signals.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b890f28c0c6d2856eadcdc34b3faf83a846b3d79 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-async-signals" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>pcntl_async_signals</refname>
+  <refpurpose>Aktiviert oder deaktiviert die asynchrone Signalverarbeitung oder gibt die vorherige Einstellung zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description"><!-- {{{ -->
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_async_signals</methodname>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>enable</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Ist der Parameter <parameter>enable</parameter> gleich &null;, gibt
+   <function>pcntl_async_signals</function> zurück, ob die asynchrone
+   Signalverarbeitung aktiviert ist. Andernfalls wird die asynchrone
+   Signalverarbeitung aktiviert oder deaktiviert.
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="parameters"><!-- {{{ -->
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>enable</parameter></term>
+    <listitem>
+     <para>
+      Gibt an, ob die asynchrone Signalverarbeitung aktiviert werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="returnvalues"><!-- {{{ -->
+  &reftitle.returnvalues;
+  <para>
+   Bei Verwendung als Getter (<parameter>enable</parameter> ist &null;) wird
+   zurückgegeben, ob die asynchrone Signalverarbeitung aktiviert ist. Bei
+   Verwendung als Setter (<parameter>enable</parameter> ist nicht &null;)
+   wird zurückgegeben, ob die asynchrone Signalverarbeitung
+   <emphasis>vor</emphasis> dem Funktionsaufruf aktiviert war.
+  </para>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>enable</parameter> akzeptiert nun &null;.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso"><!-- {{{ -->
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="control-structures.declare">declare</link></member>
+  </simplelist>
+ </refsect1><!-- }}} -->
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-get-last-error.xml
+++ b/reference/pcntl/functions/pcntl-get-last-error.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4ac5624be0dc8484a333514b605150e73cad06b8 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.pcntl-get-last-error" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>pcntl_get_last_error</refname>
+  <refpurpose>Gibt die Fehlernummer der zuletzt fehlgeschlagenen pcntl-Funktion zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pcntl_get_last_error</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Gibt die Fehlernummer (<literal>errno</literal>) zurück, die durch die
+   zuletzt fehlgeschlagene pcntl-Funktion gesetzt wurde. Die zugehörige
+   System-Fehlermeldung lässt sich mit <function>pcntl_strerror</function>
+   abfragen.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt die Fehlernummer (<literal>errno</literal>) zurück, die durch die
+   zuletzt fehlgeschlagene pcntl-Funktion gesetzt wurde. Trat kein Fehler
+   auf, wird 0 zurückgegeben.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>pcntl_get_last_error</function></title>
+   <para>
+    Dieses Beispiel versucht, auf Kindprozesse zu warten, obwohl keiner
+    existiert, und gibt anschließend die zugehörige Fehlermeldung aus.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$pid = pcntl_wait($status);
+if ($pid === -1) {
+    $errno = pcntl_get_last_error();
+    $message = pcntl_strerror($errno);
+    fwrite(STDERR, 'pcntl_wait failed with errno ' . $errno
+           . ': ' . $message . PHP_EOL);
+}
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+pcntl_wait failed with errno 10: No child processes
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_strerror</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl_getqos_class.xml
+++ b/reference/pcntl/functions/pcntl_getqos_class.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 30b0c51175bb9bc5a329d7924b0ca5eff1f1f9ad Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-getqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_getqos_class</refname>
+  <refpurpose>Gibt die QoS-Klasse des aktuellen Threads zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>Pcntl\QosClass</type><methodname>pcntl_getqos_class</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Ermittelt die QoS-Klasse.
+  </simpara>
+  <note>
+   <simpara>Diese Funktion ist nur auf Apple-Plattformen verfügbar.</simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt die <enumname>Pcntl\QosClass</enumname> zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Wirft einen <classname>Error</classname>, wenn der zugrunde liegende Aufruf von
+   <literal>pthread_get_qos_class_np()</literal> fehlschlägt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_setqos_class</function></member>
+   <member><enumname>Pcntl\QosClass</enumname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl_setqos_class.xml
+++ b/reference/pcntl/functions/pcntl_setqos_class.xml
@@ -38,7 +38,7 @@
         <listitem>
          <simpara>
           Höchste Priorität. Vorgesehen für Arbeiten, die unmittelbar
-          eine Benutzeroberfläche antreiben und nahezu sofort abgeschlossen
+          eine Benutzeroberfläche steuern und nahezu sofort abgeschlossen
           sein müssen, um spürbare Verzögerungen zu vermeiden, etwa
           Ereignisverarbeitung oder Zeichnen.
          </simpara>

--- a/reference/pcntl/functions/pcntl_setqos_class.xml
+++ b/reference/pcntl/functions/pcntl_setqos_class.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 30b0c51175bb9bc5a329d7924b0ca5eff1f1f9ad Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-setqos-class" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_setqos_class</refname>
+  <refpurpose>Setzt die QoS-Klasse des aktuellen Threads</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>pcntl_setqos_class</methodname>
+   <methodparam choice="opt"><type>Pcntl\QosClass</type><parameter>qos_class</parameter><initializer><constant>Pcntl\QosClass::Default</constant></initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Legt die QoS-Klasse fest.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>qos_class</parameter></term>
+    <listitem>
+     <para>
+      Die Quality-of-Service-Klasse, die dem aktuellen Thread zugewiesen
+      werden soll. Das Betriebssystem nutzt sie als Hinweis für die
+      Planung von CPU-Zeit, E/A-Priorität und Energieverbrauch; höhere
+      Klassen verdrängen niedrigere. Die verfügbaren Werte sind unter
+      <enumname>Pcntl\QosClass</enumname> aufgeführt.
+     </para>
+     <para>
+      <variablelist>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::UserInteractive</constant></term>
+        <listitem>
+         <simpara>
+          Höchste Priorität. Vorgesehen für Arbeiten, die unmittelbar
+          eine Benutzeroberfläche antreiben und nahezu sofort abgeschlossen
+          sein müssen, um spürbare Verzögerungen zu vermeiden, etwa
+          Ereignisverarbeitung oder Zeichnen.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::UserInitiated</constant></term>
+        <listitem>
+         <simpara>
+          Hohe Priorität, knapp unterhalb von
+          <constant>UserInteractive</constant>. Vorgesehen für Arbeiten,
+          die der Benutzer explizit angestoßen hat und auf deren Ergebnis
+          er aktiv wartet; Abschluss innerhalb weniger Sekunden zu erwarten.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::Default</constant></term>
+        <listitem>
+         <simpara>
+          Standardpriorität, wenn keine spezifischere Klasse passt. Wird
+          nach höher priorisierten Arbeiten ausgeführt, aber vor
+          <constant>Utility</constant> und <constant>Background</constant>.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::Utility</constant></term>
+        <listitem>
+         <simpara>
+          Niedrigere Priorität, vorgesehen für länger laufende Arbeiten,
+          die dem Benutzer bewusst sind, auf die er aber nicht aktiv
+          wartet, etwa Downloads, Importe oder umfangreiche Berechnungen.
+          Energieeffizient eingeplant.
+         </simpara>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term><constant>Pcntl\QosClass::Background</constant></term>
+        <listitem>
+         <simpara>
+          Niedrigste Priorität, vorgesehen für Arbeiten, die dem Benutzer
+          nicht bewusst sind, etwa Prefetching, Indexierung oder Wartung.
+          Stark auf Energieeffizienz optimiert; kann bei Systemlast
+          aufgeschoben werden.
+         </simpara>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <note>
+   <simpara>Diese Funktion ist nur auf Apple-Plattformen verfügbar.</simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Wirft einen <classname>Error</classname>, wenn der zugrunde liegende Aufruf von
+   <literal>pthread_set_qos_class_self_np()</literal> fehlschlägt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_getqos_class</function></member>
+   <member><enumname>Pcntl\QosClass</enumname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/pcntl.qosclass.xml
+++ b/reference/pcntl/pcntl.qosclass.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: aeba24a37b237885358909c8d9d50a0a7abe250b Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<reference xmlns="http://docbook.org/ns/docbook" xml:id="enum.pcntl-qosclass" role="enum">
+ <title>Die Aufzählung Pcntl\QosClass</title>
+ <titleabbrev>Pcntl\QosClass</titleabbrev>
+
+ <partintro>
+  <section xml:id="enum.pcntl-qosclass.intro">
+   &reftitle.intro;
+   <simpara>
+    Die Aufzählung <enumname>Pcntl\QosClass</enumname> wird verwendet, um
+    die Priorität von Benutzerprozessen über
+    <function>pcntl_setqos_class</function> festzulegen.
+   </simpara>
+  </section>
+
+  <section xml:id="enum.pcntl-qosclass.synopsis">
+   &reftitle.enumsynopsis;
+   <packagesynopsis>
+    <package>Pcntl</package>
+
+    <enumsynopsis>
+     <enumname>QosClass</enumname>
+
+     <enumitem>
+      <enumidentifier>UserInteractive</enumidentifier>
+      <enumitemdescription>
+      Führt den Prozess mit der höchsten Prioritätsstufe aus.
+     </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>UserInitiated</enumidentifier>
+      <enumitemdescription>
+      Führt den Prozess mit hoher Prioritätsstufe aus, aber unterhalb der
+      UserInteractive-Prozesse.
+     </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Default</enumidentifier>
+      <enumitemdescription>
+      Führt den Prozess nach allen hochprioritären Prozessen aus, jedoch
+      vor den niedrigprioritären.
+     </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Utility</enumidentifier>
+      <enumitemdescription>
+      Niedrigere Priorität, vorgesehen für länger laufende Arbeiten, die
+      dem Benutzer bewusst sind, auf die er aber nicht aktiv wartet.
+      Energieeffizient eingeplant.
+     </enumitemdescription>
+     </enumitem>
+
+     <enumitem>
+      <enumidentifier>Background</enumidentifier>
+      <enumitemdescription>
+      Führt den Prozess aus, nachdem alle hochprioritären Prozesse
+      abgearbeitet wurden.
+     </enumitemdescription>
+     </enumitem>
+    </enumsynopsis>
+   </packagesynopsis>
+  </section>
+ </partintro>
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/pcntl.qosclass.xml
+++ b/reference/pcntl/pcntl.qosclass.xml
@@ -41,8 +41,8 @@
      <enumitem>
       <enumidentifier>Default</enumidentifier>
       <enumitemdescription>
-      Führt den Prozess nach allen hochprioritären Prozessen aus, jedoch
-      vor den niedrigprioritären.
+      Führt den Prozess nach allen Prozessen mit hoher Priorität, aber
+      vor solchen mit niedriger Priorität.
      </enumitemdescription>
      </enumitem>
 


### PR DESCRIPTION
Behebt den verbliebenen Build-Fehler aus #204: `reference/pcntl/book.xml:49` verweist auf `&reference.pcntl.pcntl.qosclass;`, die Datei fehlte aber in doc-de. Diese PR fügt die deutsche Übersetzung der Aufzählung sowie der vier eng verwandten Funktionen hinzu:

- `pcntl.qosclass.xml` (Aufzählung)
- `pcntl_getqos_class`
- `pcntl_setqos_class`
- `pcntl_async_signals`
- `pcntl_get_last_error`

Die andere in #204 erwähnte Entität (`reference.imagick.entities.imagickkernelexception`) wurde bereits in einem früheren Build-Fix behoben.

Fixes #204