### PR TITLE
Translate pcntl signal-family functions

### DIFF
--- a/reference/pcntl/functions/pcntl-signal-dispatch.xml
+++ b/reference/pcntl/functions/pcntl-signal-dispatch.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 782d62b55a004129d4a84b5d00d4f6935582f806 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-signal-dispatch" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_signal_dispatch</refname>
+  <refpurpose>Ruft die Signal-Handler für ausstehende Signale auf</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_signal_dispatch</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Die Funktion <function>pcntl_signal_dispatch</function> ruft für jedes
+   ausstehende Signal die mit <function>pcntl_signal</function> installierten
+   Signal-Handler auf.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pcntl_signal_dispatch</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo "Installing signal handler...\n";
+pcntl_signal(SIGHUP,  function($signo) {
+     echo "signal handler called\n";
+});
+
+echo "Generating signal SIGHUP to self...\n";
+posix_kill(posix_getpid(), SIGHUP);
+
+echo "Dispatching...\n";
+pcntl_signal_dispatch();
+
+echo "Done\n";
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Installing signal handler...
+Generating signal SIGHUP to self...
+Dispatching...
+signal handler called
+Done
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_signal</function></member>
+    <member><function>pcntl_sigprocmask</function></member>
+    <member><function>pcntl_sigwaitinfo</function></member>
+    <member><function>pcntl_sigtimedwait</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-signal-get-handler.xml
+++ b/reference/pcntl/functions/pcntl-signal-get-handler.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: b890f28c0c6d2856eadcdc34b3faf83a846b3d79 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-signal-get-handler" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>pcntl_signal_get_handler</refname>
+  <refpurpose>Gibt den aktuellen Handler für das angegebene Signal zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>callable</type><type>int</type></type><methodname>pcntl_signal_get_handler</methodname>
+   <methodparam><type>int</type><parameter>signal</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Die Funktion <function>pcntl_signal_get_handler</function> ermittelt den
+   aktuellen Handler für das angegebene <parameter>signal</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>signal</parameter></term>
+    <listitem>
+     <para>
+      Die Signalnummer.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Diese Funktion kann einen Integer-Wert zurückgeben, der sich auf
+   <constant>SIG_DFL</constant> oder <constant>SIG_IGN</constant> bezieht.
+   Wurde ein eigener Handler gesetzt, wird dieser <type>callable</type>
+   zurückgegeben.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.1.0</entry>
+      <entry>
+       <function>pcntl_signal_get_handler</function> wurde hinzugefügt.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pcntl_signal_get_handler</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+var_dump(pcntl_signal_get_handler(SIGUSR1)); // Ausgabe: int(0)
+
+function pcntl_test($signo) {}
+pcntl_signal(SIGUSR1, 'pcntl_test');
+var_dump(pcntl_signal_get_handler(SIGUSR1)); // Ausgabe: string(10) "pcntl_test"
+
+pcntl_signal(SIGUSR1, SIG_DFL);
+var_dump(pcntl_signal_get_handler(SIGUSR1)); // Ausgabe: int(0)
+
+pcntl_signal(SIGUSR1, SIG_IGN);
+var_dump(pcntl_signal_get_handler(SIGUSR1)); // Ausgabe: int(1)
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_signal</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-signal-get-handler.xml
+++ b/reference/pcntl/functions/pcntl-signal-get-handler.xml
@@ -38,7 +38,7 @@
   <para>
    Diese Funktion kann einen Integer-Wert zurückgeben, der sich auf
    <constant>SIG_DFL</constant> oder <constant>SIG_IGN</constant> bezieht.
-   Wurde ein eigener Handler gesetzt, wird dieser <type>callable</type>
+   Wurde ein eigener Handler gesetzt, wird dieses <type>callable</type>
    zurückgegeben.
   </para>
  </refsect1>

--- a/reference/pcntl/functions/pcntl-sigprocmask.xml
+++ b/reference/pcntl/functions/pcntl-sigprocmask.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-sigprocmask" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_sigprocmask</refname>
+  <refpurpose>Setzt und ermittelt blockierte Signale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pcntl_sigprocmask</methodname>
+   <methodparam><type>int</type><parameter>mode</parameter></methodparam>
+   <methodparam><type>array</type><parameter>signals</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">old_signals</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Die Funktion <function>pcntl_sigprocmask</function> fügt blockierte Signale
+   hinzu, entfernt sie oder setzt sie, abhängig vom Parameter
+   <parameter>mode</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>mode</parameter></term>
+     <listitem>
+      <para>
+       Legt das Verhalten von <function>pcntl_sigprocmask</function> fest.
+       Mögliche Werte:
+       <simplelist>
+        <member><constant>SIG_BLOCK</constant>: Die Signale zu den aktuell
+         blockierten Signalen hinzufügen.</member>
+        <member><constant>SIG_UNBLOCK</constant>: Die Signale aus den aktuell
+         blockierten Signalen entfernen.</member>
+        <member><constant>SIG_SETMASK</constant>: Die aktuell blockierten
+         Signale durch die angegebene Liste von Signalen ersetzen.</member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>signals</parameter></term>
+     <listitem>
+      <para>
+       Liste von Signalen.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>old_signals</parameter></term>
+     <listitem>
+      <para>
+       Der Parameter <parameter>old_signals</parameter> wird auf ein Array
+       gesetzt, das die Liste der zuvor blockierten Signale enthält.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>ValueError</classname> geworfen, wenn
+       <parameter>signal</parameter> leer ist.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>TypeError</classname> geworfen, wenn der Wert
+       von <parameter>signal</parameter> kein <type>int</type> ist.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>ValueError</classname> geworfen, wenn der Wert
+       von <parameter>signal</parameter> ungültig ist.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>ValueError</classname> geworfen, wenn der Wert
+       von <parameter>mode</parameter> nicht <constant>SIG_BLOCK</constant>,
+       <constant>SIG_UNBLOCK</constant> oder <constant>SIG_SETMASK</constant>
+       ist.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pcntl_sigprocmask</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+pcntl_sigprocmask(SIG_BLOCK, array(SIGHUP));
+$oldset = array();
+pcntl_sigprocmask(SIG_UNBLOCK, array(SIGHUP), $oldset);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_sigwaitinfo</function></member>
+    <member><function>pcntl_sigtimedwait</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -18,7 +18,7 @@
    Die Funktion <function>pcntl_sigwaitinfo</function> unterbricht die
    Ausführung des aufrufenden Skripts, bis eines der in
    <parameter>signals</parameter> angegebenen Signale zugestellt wird. Ist
-   eines der Signale bereits ausstehend (z. B. durch
+   eines der Signale bereits ausstehend (&zb; durch
    <function>pcntl_sigprocmask</function> blockiert), kehrt
    <function>pcntl_sigwaitinfo</function> sofort zurück.
   </para>

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -88,7 +88,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   Gibt bei Erfolg eine Signalnummer zurück,&return.falseforfailure;.
+   Gibt bei Erfolg eine Signalnummer zurück. &return.falseforfailure;
   </para>
  </refsect1>
 

--- a/reference/pcntl/functions/pcntl-sigwaitinfo.xml
+++ b/reference/pcntl/functions/pcntl-sigwaitinfo.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7bc131d65540e2a0f706cf4d99b5a3235c965fdb Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-sigwaitinfo" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pcntl_sigwaitinfo</refname>
+  <refpurpose>Wartet auf Signale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>pcntl_sigwaitinfo</methodname>
+   <methodparam><type>array</type><parameter>signals</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">info</parameter><initializer>[]</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Die Funktion <function>pcntl_sigwaitinfo</function> unterbricht die
+   Ausführung des aufrufenden Skripts, bis eines der in
+   <parameter>signals</parameter> angegebenen Signale zugestellt wird. Ist
+   eines der Signale bereits ausstehend (z. B. durch
+   <function>pcntl_sigprocmask</function> blockiert), kehrt
+   <function>pcntl_sigwaitinfo</function> sofort zurück.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>signals</parameter></term>
+     <listitem>
+      <para>
+       Array von Signalen, auf die gewartet werden soll.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>info</parameter></term>
+     <listitem>
+      <para>
+       Der Parameter <parameter>info</parameter> wird auf ein Array gesetzt,
+       das Informationen über das Signal enthält.
+      </para>
+      <para>
+       Die folgenden Elemente werden für alle Signale gesetzt:
+       <simplelist>
+        <member>signo: Signalnummer</member>
+        <member>errno: Eine Fehlernummer</member>
+        <member>code: Signalcode</member>
+       </simplelist>
+      </para>
+      <para>
+       Die folgenden Elemente können für das Signal
+       <constant>SIGCHLD</constant> gesetzt sein:
+       <simplelist>
+        <member>status: Exit-Wert oder Signal</member>
+        <member>utime: Verbrauchte Benutzerzeit</member>
+        <member>stime: Verbrauchte Systemzeit</member>
+        <member>pid: Prozess-ID des sendenden Prozesses</member>
+        <member>uid: Reale Benutzer-ID des sendenden Prozesses</member>
+       </simplelist>
+      </para>
+      <para>
+       Die folgenden Elemente können für die Signale
+       <constant>SIGILL</constant>, <constant>SIGFPE</constant>,
+       <constant>SIGSEGV</constant> und <constant>SIGBUS</constant> gesetzt
+       sein:
+       <simplelist>
+        <member>addr: Speicheradresse, die den Fehler verursacht hat</member>
+       </simplelist>
+      </para>
+      <para>
+       Die folgenden Elemente können für das Signal
+       <constant>SIGPOLL</constant> gesetzt sein:
+       <simplelist>
+        <member>band: Band-Ereignis</member>
+        <member>fd: Nummer des Dateideskriptors</member>
+       </simplelist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg eine Signalnummer zurück,&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>ValueError</classname> geworfen, wenn
+       <parameter>signal</parameter> leer ist.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>TypeError</classname> geworfen, wenn der Wert
+       von <parameter>signal</parameter> kein <type>int</type> ist.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Es wird ein <classname>ValueError</classname> geworfen, wenn der Wert
+       von <parameter>signal</parameter> ungültig ist.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>pcntl_sigwaitinfo</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+echo "Blocking SIGHUP signal\n";
+pcntl_sigprocmask(SIG_BLOCK, array(SIGHUP));
+
+echo "Sending SIGHUP to self\n";
+posix_kill(posix_getpid(), SIGHUP);
+
+echo "Waiting for signals\n";
+$info = array();
+pcntl_sigwaitinfo(array(SIGHUP), $info);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>pcntl_sigprocmask</function></member>
+    <member><function>pcntl_sigtimedwait</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pcntl/functions/pcntl-strerror.xml
+++ b/reference/pcntl/functions/pcntl-strerror.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: e7dcfdc34279798ad93592ca53978aef5d78996e Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.pcntl-strerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>pcntl_strerror</refname>
+  <refpurpose>Gibt die zur angegebenen errno gehörende Systemfehlermeldung zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>pcntl_strerror</methodname>
+   <methodparam><type>int</type><parameter>error_code</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Gibt die Systemfehlermeldung zurück, die zum angegebenen
+   <parameter>error_code</parameter> (<literal>errno</literal>) der zuletzt
+   fehlgeschlagenen pcntl-Funktion gehört. Der Parameter
+   <parameter>error_code</parameter> kann durch Aufruf von
+   <function>pcntl_get_last_error</function> ermittelt werden.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>error_code</parameter></term>
+    <listitem>
+     <para>
+      Eine Fehlernummer (<literal>errno</literal>),
+      die von <function>pcntl_get_last_error</function> zurückgegeben wird.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt die Fehlermeldung als String zurück.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>pcntl_strerror</function>-Beispiel</title>
+   <para>
+    Dieses Beispiel versucht, auf Kindprozesse zu warten, obwohl kein
+    Kindprozess existiert, und gibt anschließend die zugehörige Fehlermeldung
+    aus.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$pid = pcntl_wait($status);
+if ($pid === -1) {
+    $errno = pcntl_get_last_error();
+    $message = pcntl_strerror($errno);
+    fwrite(STDERR, 'pcntl_wait failed with errno ' . $errno
+           . ': ' . $message . PHP_EOL);
+}
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+pcntl_wait failed with errno 10: No child processes
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pcntl_get_last_error</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Fortsetzung von #230 mit fünf weiteren pcntl-Funktionen aus der Signal-Familie:

- `pcntl_strerror`
- `pcntl_signal_dispatch`
- `pcntl_signal_get_handler`
- `pcntl_sigprocmask`
- `pcntl_sigwaitinfo`

Stil: unpersönlich, wie in der Vorschlagsdatei `ÜBERSETZUNGEN.txt` aus #227. PHP-Code, String-Literale und `<screen>`-Ausgaben bleiben auf Englisch; nur Prosa und Code-Kommentare wurden übersetzt.