### PR TITLE
[Sync EN] Pull doc-en PRs #5586 (codespell) and #5583 (broken sentences)

### DIFF
--- a/appendices/migration81/deprecated.xml
+++ b/appendices/migration81/deprecated.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f164f8c8627d55910084c94e1dcea93b4a57c4a3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: samesch Status: ready -->
 <sect1 xml:id="migration81.deprecated">
  <title>Veraltete Features</title>
 
@@ -221,13 +221,13 @@ $arr[] = 2;
  <sect2 xml:id="migration81.deprecated.hash">
   <title>Hash</title>
 
-  <para>
+  <simpara>
    Die Funktionen <function>mhash</function>,
    <function>mhash_keygen_s2k</function>, <function>mhash_count</function>,
    <function>mhash_get_block_size</function> und
    <function>mhash_get_hash_name</function> sind veraltet. Stattdessen sollten
    die <literal>hash_*()</literal>-Funktionen verwendet werden.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration81.deprecated.imap">

--- a/appendices/migration81/incompatible.xml
+++ b/appendices/migration81/incompatible.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: samesch Status: ready -->
 <sect1 xml:id="migration81.incompatible" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nicht abwärtskompatible Änderungen</title>
 
@@ -297,12 +297,12 @@ ArgumentCountError - makeyogurt(): Argument #1 ($container) not passed
    Private EC-Schlüssel werden jetzt wie alle anderen Schlüssel im
    <acronym>PKCS</acronym>#8-Format statt im traditionellen Format exportiert.
   </para>
-  <para>
+  <simpara>
    <function>openssl_pkcs7_encrypt</function> und
    <function>openssl_cms_encrypt</function> verwenden nun standardmäßig
    AES-128-CBC anstelle von RC2-40. Die RC2-40-Chiffre gilt als unsicher und
    wird von OpenSSL 3 standardmäßig nicht aktiviert.
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration81.incompatible.pdo">

--- a/faq/build.xml
+++ b/faq/build.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b8e1b1357def73f310c9f7405035b3acc0cb1eaf Maintainer: gerdtsteltner Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: gerdtsteltner Status: ready -->
 <chapter xml:id="faq.build" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Probleme bei der Kompilierung</title>
   <titleabbrev>Probleme bei der Kompilierung</titleabbrev>
@@ -169,14 +169,14 @@
      </para>
     </question>
     <answer>
-     <para>
+     <simpara>
       Einige alte Versionen von make platzieren die kompilierten
       Versionen der Dateien nicht in das functions-Verzeichnis im gleichen
       Verzeichnis. Versuchen Sie, <command>cp *.o functions</command>
       auszuführen und danach erneut <command>make</command> zu starten,
       um zu prüfen, ob sich das Problem so lösen lässt. Sollte es dann
       funktionieren, empfehlen wir, Ihre Version von GNU make zu aktualisieren.
-     </para>
+     </simpara>
     </answer>
    </qandaentry>
 

--- a/install/unix/lighttpd-14.xml
+++ b/install/unix/lighttpd-14.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7006df7c1fbc64457ac4011ae33309c3f3e5b202 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 7006df7c1fbc64457ac4011ae33309c3f3e5b202 Reviewer: samesch -->
 <sect1 xml:id="install.unix.lighttpd-14" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -56,7 +56,7 @@ fastcgi.server = ( ".php" =>
    </screen>
   </example>
 
-  <para>
+  <simpara>
    Die Direktive <filename>bin-path</filename> erlaubt es Lighttpd,
    FastCGI-Prozesse dynamisch zu erzeugen. PHP erzeugt die Kindprozesse
    entsprechend der Umgebungsvariable <envar>PHP_FCGI_CHILDREN</envar>. Die
@@ -70,7 +70,7 @@ fastcgi.server = ( ".php" =>
    einen Wert größer <literal>1</literal> gesetzt ist, wird die Anzahl der
    PHP-Responder mit <envar>PHP_FCGI_CHILDREN</envar> multipliziert
    (2 min-procs * 16 Kindprozesse ergibt 32 Responder).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="install.unix.lighttpd-14.spawn-fcgi">

--- a/language/exceptions.xml
+++ b/language/exceptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c81a48e58fc530a74827316027fae74668d17a1d Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 2e8ef0a1bd98243cb2c6c5c627a195bb53a7a440 Reviewer: samesch -->
 <chapter xml:id="language.exceptions" xmlns="http://docbook.org/ns/docbook">

--- a/language/oop5/changelog.xml
+++ b/language/oop5/changelog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6a3ce2f9a191ad00fdd709c249e6dea16df316e3 Maintainer: simp Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: simp Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.oop5.changelog" xmlns="http://docbook.org/ns/docbook">
  <title>OOP-Changelog</title>

--- a/language/types/type-system.xml
+++ b/language/types/type-system.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f908fff129bcd8ec1605658e06457cb04e5b2b51 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.type-system">
  <title>Typsystem</title>
@@ -182,7 +182,7 @@
 
   <sect3 xml:id="language.types.type-system.composite.union">
    <title>Zusammengefasste Typen (Union-Typen)</title>
-   <para>
+   <simpara>
     Ein Union-Typ akzeptiert die Werte mehrerer verschiedener Typen und nicht
     nur eines einzigen. Die einzelnen Typen, die den Union-Typ bilden, werden
     durch das Symbol <literal>|</literal> verbunden. Daher wird ein Union-Typ,
@@ -191,7 +191,7 @@
     Wenn einer der Typen ein Schnittmengentyp ist, muss er in Klammern gesetzt
     werden, damit er in <acronym>DNF</acronym> geschrieben werden kann:
     <literal>T|(X&amp;Y)</literal>.
-   </para>
+   </simpara>
   </sect3>
  </sect2>
 

--- a/reference/curl/constants_curl_setopt.xml
+++ b/reference/curl/constants_curl_setopt.xml
@@ -1764,14 +1764,14 @@
     (<type>int</type>)
    </term>
    <listitem>
-    <para>
+    <simpara>
      Die maximal erlaubte Anzahl von HTTP-Weiterleitungen. Diese Option sollte
      zusammen mit <constant>CURLOPT_FOLLOWLOCATION</constant> verwendet werden.
      Der Standardwert von <literal>20</literal> wird gesetzt, um
      Endlos-Weiterleitungen zu verhindern. Der Wert <literal>-1</literal>
      erlaubt unendlich viele Weiterleitungen und <literal>0</literal>
      verhindert jegliche Weiterleitung.
-    </para>
+    </simpara>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.curlopt-max-recv-speed-large">

--- a/reference/datetime/datetime/settimezone.xml
+++ b/reference/datetime/datetime/settimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 255ec56b59083ac9c32e930ab5c9aaf89cc58cd2 Reviewer: samesch -->
 <!-- CREDITS: Stefan Schenke -->
@@ -55,11 +55,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Gibt das <classname>DateTime</classname>-Objekt für die Methodenverkettung
    zurück. Der zugrunde liegende Zeitpunkt wird beim Aufruf dieser Methode
    nicht verändert.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/datetime/datetimeimmutable/settimezone.xml
+++ b/reference/datetime/datetimeimmutable/settimezone.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetimeimmutable.settimezone" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -37,11 +37,11 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Gibt ein neues geändertes <classname>DateTimeImmutable</classname>-Objekt
    für die Methodenverkettung zurück. Der zugrunde liegende Zeitpunkt wird
    beim Aufruf dieser Methode nicht verändert.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/dba/setup.xml
+++ b/reference/dba/setup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b5fce74a6c0760daccc79063279e102873be6d77 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: samesch Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="dba.setup">

--- a/reference/fdf/functions/fdf-errno.xml
+++ b/reference/fdf/functions/fdf-errno.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f86fd7b1ce74d1ea3a6a2e3e40757590b14a3e7e Maintainer: hholzgra  Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: hholzgra  Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-errno">
  <refnamediv>
   <refname>fdf_errno</refname>

--- a/reference/fdf/functions/fdf-set-ap.xml
+++ b/reference/fdf/functions/fdf-set-ap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f86fd7b1ce74d1ea3a6a2e3e40757590b14a3e7e Maintainer: cmb Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: cmb Status: ready -->
 <!-- CREDITS: hholzgra -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-set-ap">
  <refnamediv>

--- a/reference/filter/constants.xml
+++ b/reference/filter/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 3cb239e6e98fc2b7353fca4149f08902d08b8100 Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: d83aa96e679c4e4d63390a41063469e51107c331 Reviewer: samesch -->
 <appendix xml:id="filter.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/image/book.xml
+++ b/reference/image/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 213fbd9440a224f9c1da4942c85124ce0c120c52 Maintainer: jaenecke Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: jaenecke Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a7e5e563d2d2269a6d7ccff506715a3e1a6f3902 Reviewer: samesch -->
 
@@ -62,11 +62,11 @@
     </simpara>
    </caution>
   </para>
-  <para>
+  <simpara>
    GD unterstützt viele Formate. Nachfolgend eine Liste aller von GD
    unterstützten Formaten und Hinweise zu Verfügbarkeit und
    Lese-/Schreibunterstützung.
-  </para>
+  </simpara>
   <para>
    <table>
     <title>Von GD unterstützte Formate</title>

--- a/reference/image/functions/getimagesize.xml
+++ b/reference/image/functions/getimagesize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 6bb90d24b240a0b81e4b203cd8b7ed56bd54033a Maintainer: simp Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: simp Status: ready -->
 <!-- Reviewed: no -->
 <!-- Credits: jaenecke -->
 <refentry xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://docbook.org/ns/docbook" xml:id="function.getimagesize">

--- a/reference/image/functions/imagecolortransparent.xml
+++ b/reference/image/functions/imagecolortransparent.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9960a09a5705102bf4dd0ce63e03d9ec716d0015 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagecolortransparent" xmlns="http://docbook.org/ns/docbook">
@@ -109,11 +109,11 @@ imagepng($im, './imagecolortransparent.png');
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
+   <simpara>
     Die Transparenz wird nur mit <function>imagecopymerge</function> und
     Echtfarbbildern kopiert, nicht mit <function>imagecopy</function> oder
     Palettenbildern.
-   </para>
+   </simpara>
   </note>
   <note>
    <para>

--- a/reference/image/functions/imagefilltoborder.xml
+++ b/reference/image/functions/imagefilltoborder.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nobody Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.imagefilltoborder" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/image/functions/imagettfbbox.xml
+++ b/reference/image/functions/imagettfbbox.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 48220b9fcde41afb13e0b7f3e806f51cd179df90 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagettfbbox" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/info/functions/phpversion.xml
+++ b/reference/info/functions/phpversion.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 30509282589c6fdee1bce55f3271caf464b5cd75 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 4e6f0774f03131cbeeb8c21019a690bf97fd22b6 Reviewer: samesch -->
 <!-- Credits: reinders -->

--- a/reference/ldap/functions/ldap-mod-add.xml
+++ b/reference/ldap/functions/ldap-mod-add.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: b7cbd468cb4c46d55d43a44cade0eb4590d25dea Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: b7cbd468cb4c46d55d43a44cade0eb4590d25dea Reviewer: samesch -->
 <refentry xml:id="function.ldap-mod-add" xmlns="http://docbook.org/ns/docbook">
@@ -48,12 +48,12 @@
     <varlistentry>
      <term><parameter>entry</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Ein assoziatives Array, das die Merkmalswerte aufführt, die hinzugefügt
        werden sollen. Existiert ein Merkmal noch nicht, wird es hinzugefügt.
        Existiert ein Merkmal bereits, können nur dann Werte hinzugefügt
        werden, wenn es mehrere Werte unterstützt.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/reference/mysqlnd/config.xml
+++ b/reference/mysqlnd/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 9598935f21bc472f22383fb989625f0b22785331 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="mysqlnd.config">
 

--- a/reference/network/functions/dns-get-record.xml
+++ b/reference/network/functions/dns-get-record.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 35ca7f1087870c6023ef7a3dd0248501741c8194 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 7be2426e49ee1c9131866f20b67a48aaea0a642a Reviewer: samesch -->
 <refentry xml:id="function.dns-get-record" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/pdo/pdo/prepare.xml
+++ b/reference/pdo/pdo/prepare.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 082ddc19f53e6e254010de1a1fbbe485ff744ec1 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.prepare" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/posix/functions/posix-geteuid.xml
+++ b/reference/posix/functions/posix-geteuid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f8854f6a6a7907720ed8ec8657a2f466a82c0394 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: samesch Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xml:id="function.posix-geteuid" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -14,12 +14,12 @@
    <type>int</type><methodname>posix_geteuid</methodname>
    <void/>
   </methodsynopsis>
-  <para>
+  <simpara>
    Gibt die effektive numerische Benutzer-ID des aktuellen Prozesses zurück.
    Für Informationen darüber, wie die Benutzer-ID in einen gebräuchlichen
    Benutzernamen umgewandelt werden kann, siehe auch
    <function>posix_getpwuid</function>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/sockets/functions/socket-create-listen.xml
+++ b/reference/sockets/functions/socket-create-listen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0e097419a847a077c7d8a74ebc5237ba9d8ddc90 Maintainer: conni Status: ready -->
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: conni Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a62a46e9c785336bb7a145d5c5805c228a515031 Reviewer: samesch -->
 <refentry xml:id="function.socket-create-listen" xmlns="http://docbook.org/ns/docbook">

--- a/reference/var/functions/var-export.xml
+++ b/reference/var/functions/var-export.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d816a0fad6c458d9515f697cc89e26ca9d8069f5 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: hholzgra Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <refentry xml:id="function.var-export" xmlns="http://docbook.org/ns/docbook">

--- a/reference/xmlwriter/xmlwriter/openmemory.xml
+++ b/reference/xmlwriter/xmlwriter/openmemory.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7776f9acb2fa3aeeed8a8661678b65b40db00abe Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: sammywg Status: ready -->
 <refentry xml:id="xmlwriter.openmemory" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLWriter::openMemory</refname>

--- a/reference/xmlwriter/xmlwriter/openuri.xml
+++ b/reference/xmlwriter/xmlwriter/openuri.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4a742792da6fd1ba27acd118bfeeed326c8d9aaf Maintainer: nikic Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: nikic Status: ready -->
 <refentry xml:id="xmlwriter.openuri" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>XMLWriter::openUri</refname>

--- a/reference/zip/constants.xml
+++ b/reference/zip/constants.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 8afee82662753fe5ed0c3b8003b14118f00547ef Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: hholzgra Status: ready -->
 <!-- Credits: jakoch -->
 <appendix xml:id="zip.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;


### PR DESCRIPTION
Bringt 30 doc-de Dateien auf den Stand zweier reiner Nit-PRs aus upstream:

- `php/doc-en#5586` (codespell typos in bundled extensions): 22 Dateien
- `php/doc-en#5583` (incomplete/broken sentences + para→simpara): 8 Dateien

In beiden Fällen vermittelten die deutschen Übersetzungen die korrigierte Bedeutung bereits, da die englischen Typos und holprigen Formulierungen sprachspezifisch waren. Die Änderungen bestehen daher überwiegend aus EN-Revision-Bumps und den entsprechenden `<para>` → `<simpara>`-Tag-Spiegelungen. Die bestehenden `Maintainer:`-Einträge wurden beibehalten.

Adressiert teilweise #235 und #236: nur die Abschnitte „Zu aktualisierende DE-Dateien“. Die Abschnitte „Neue EN-Dateien (noch nicht übersetzt)“ bleiben für nachfolgende Übersetzungs-Arbeit offen.