### PR TITLE
[Sync EN] Catch up remaining small revcheck nits (38 files)

### DIFF
--- a/appendices/ini.list.xml
+++ b/appendices/ini.list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b1116af46680f7baf89c46610430a3b63ce9a1f0 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: a52e3d27cca786940272d0ae8efc21b5d6739070 Maintainer: nikic Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 3cdd39bb9505e6735d802da83a04870cfa8f2311 Reviewer: samesch -->
 <!-- Credits: reinders -->
@@ -213,7 +213,7 @@
       <entry><link linkend="ini.disable-classes">disable_classes</link></entry>
       <entry><literal>""</literal></entry>
       <entry>Nur &php.ini;</entry>
-      <entry></entry>
+      <entry>Entfernt ab PHP 8.5.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.disable-functions">disable_functions</link></entry>
@@ -557,13 +557,13 @@
       <entry><link linkend="ini.register-argc-argv">register_argc_argv</link></entry>
       <entry><literal>"1"</literal></entry>
       <entry><constant>INI_PERDIR</constant></entry>
-      <entry></entry>
+      <entry>Veraltet ab PHP 8.5.0</entry>
      </row>
      <row>
       <entry><link linkend="ini.report-memleaks">report_memleaks</link></entry>
       <entry><literal>"1"</literal></entry>
       <entry><constant>INI_ALL</constant></entry>
-      <entry></entry>
+      <entry>Veraltet ab PHP 8.5.0</entry>
      </row>
      <row>
       <entry>report_zend_debug</entry>

--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: simp Status: ready -->
 
 <sect1 xml:id="migration56.openssl" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/appendices/migration56/openssl.xml
+++ b/appendices/migration56/openssl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 497c40ac164d5873fd87f622dfdeb5206392b446 Maintainer: simp Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: simp Status: ready -->
 
 <sect1 xml:id="migration56.openssl" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>OpenSSL Änderungen in PHP 5.6.x</title>

--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 
 <sect1 xml:id="migration74.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/appendices/migration74/other-changes.xml
+++ b/appendices/migration74/other-changes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 90242f8793566eb87ee35a989912310a7c7c132b Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 
 <sect1 xml:id="migration74.other-changes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Sonstige Änderungen</title>
@@ -38,12 +38,12 @@
    ist eine neue INI-Direktive, um Parameter in die von Ausnahmen erzeugten
    Stacktraces einzubeziehen oder davon auszuschließen.
   </para>
-  <para>
+  <simpara>
    <link linkend="ini.opcache.preload-user">opcache.preload_user</link> ist
    eine neue INI-Direktive, um das Benutzerkonto anzugeben, unter dem der
    vorab geladene Code ausgeführt wird, wenn er sonst unter root laufen würde
    (was aus Sicherheitsgründen nicht erlaubt ist).
-  </para>
+  </simpara>
  </sect2>
 
  <sect2 xml:id="migration74.other-changes.pkg-config">
@@ -214,7 +214,7 @@
    </listitem>
 
    <listitem>
-    <simpara>Litespeed:</simpara>
+    <simpara>LiteSpeed:</simpara>
     <itemizedlist>
      <listitem>
       <simpara>

--- a/appendices/migration80/new-classes.xml
+++ b/appendices/migration80/new-classes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0b48d83885dc23f3818284dd6c10f21890cdf72a Maintainer: samesch Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration80.new-classes" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Neue Klassen und Schnittstellen</title>
@@ -107,7 +107,7 @@
  </sect2>
 
  <sect2 xml:id="migration80.new-classes.sysv">
-  <title>Systen V</title>
+  <title>System V</title>
 
   <itemizedlist>
    <listitem>

--- a/appendices/migration83/new-features.xml
+++ b/appendices/migration83/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 617b58b308d1f1916efaa4a3eb158fed251ae439 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="migration83.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Neue Features</title>
@@ -72,11 +72,11 @@
   <sect3 xml:id="migration83.new-features.core.static-variable-initializers">
    <title>Initialisierung statischer Variablen</title>
 
-   <para>
+   <simpara>
     Für die Initialisierung statischer Variablen können nun beliebige Ausdrücke
     verwendet werden.
-    <!-- RFC: RFC: https://wiki.php.net/rfc/arbitrary_static_variable_initializers -->
-   </para>
+    <!-- RFC: https://wiki.php.net/rfc/arbitrary_static_variable_initializers -->
+   </simpara>
   </sect3>
 
   <sect3 xml:id="migration83.new-features.core.fallback-value-syntax-for-php-ini">

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 04d9aded7bbd447523cf038ddf88e6d7f7e43c53 Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 12081e88fbd683e58a029153afd57f043df9721b Reviewer: samesch -->
 <sect1 xml:id="install.macosx.bundled" xmlns="http://docbook.org/ns/docbook">

--- a/install/macos/bundled.xml
+++ b/install/macos/bundled.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 12081e88fbd683e58a029153afd57f043df9721b Reviewer: samesch -->

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: f8682cd86a71640bf8771186d1d40881c7a0295e Reviewer: samesch -->

--- a/install/unix/debian.xml
+++ b/install/unix/debian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: f8682cd86a71640bf8771186d1d40881c7a0295e Reviewer: samesch -->
 <sect1 xml:id="install.unix.debian" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.windows.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/install/windows/apache2.xml
+++ b/install/windows/apache2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 2871f7103c7cfcfd95db64eb0930085965fd9330 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="install.windows.apache2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Installation für Apache 2.x auf Windows-Systemen</title>
@@ -15,14 +15,14 @@
   </para>
  </note>
 
- <para>
+ <simpara>
   Es wird außerdem dringend empfohlen, die
   <link xlink:href="&url.apache2.docs;">Apache-Dokumentation</link> zu lesen,
   um ein grundlegendes Verständnis des Apache 2.x Servers zu bekommen. Lesen
   Sie auch die
   <link xlink:href="&url.apache2.windows;">Windows-spezifischen Hinweise</link>
   für Apache 2.x, bevor Sie hier weiterlesen.
- </para>
+ </simpara>
 
  <para>
   Laden Sie die neueste Version von

--- a/language/basic-syntax.xml
+++ b/language/basic-syntax.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0e618211e53c66f33762be225a4d57c08ef4b2f7 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: cmb Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.basic-syntax" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Grundlagen der Syntax</title>

--- a/language/control-structures/match.xml
+++ b/language/control-structures/match.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17502ebe0691a84e7d0738c13e8c1061dde98de7 Maintainer: joshuaruesweg Status: ready -->
+<!-- EN-Revision: 840bdb9be79855ee4b2cc66c22cf3e88b781398a Maintainer: joshuaruesweg Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="control-structures.match" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -64,7 +64,7 @@ $output = match (true) {
     $age < 2 => "Baby",
     $age < 13 => "Kind",
     $age <= 19 => "Teenager",
-    $age >= 40 => "Alter Erwachsener",
+    $age >= 40 => "Erwachsener",
     $age > 19 => "Junger Erwachsener",
 };
 

--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: sammywg Status: ready -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 

--- a/language/predefined/arrayaccess.xml
+++ b/language/predefined/arrayaccess.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: sammywg Status: ready -->
 <reference xml:id="class.arrayaccess" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <title>Das ArrayAccess-Interface</title>
@@ -82,7 +82,6 @@ $obj[] = 'Anhängen 1';
 $obj[] = 'Anhängen 2';
 $obj[] = 'Anhängen 3';
 print_r($obj);
-?>
 ]]>
     </programlisting>
     &example.outputs.similar;
@@ -92,9 +91,9 @@ bool(true)
 int(2)
 bool(false)
 string(7) "Ein Wert"
-obj Object
+Obj Object
 (
-    [container:obj:private] => Array
+    [container] => Array
         (
             [eins] => 1
             [drei] => 3

--- a/language/predefined/attributes.xml
+++ b/language/predefined/attributes.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 02bee41067ab2822cbffcb4b3b2387f79488dffd Maintainer: samesch Status: ready -->
+<!-- EN-Revision: efda0bb311990257715bd3a41ab2b04769ce2e4e Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <part xml:id="reserved.attributes" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Vordefinierte Attribute</title>
 
  <partintro>
-  <para>
+  <simpara>
    PHP stellt einige vordefinierte Attribute zur Verfügung.
-  </para>
+  </simpara>
  </partintro>
 
  &language.predefined.attributes.attribute;
  &language.predefined.attributes.allowdynamicproperties;
+ &language.predefined.attributes.delayedtargetvalidation;
  &language.predefined.attributes.deprecated;
  &language.predefined.attributes.nodiscard;
  &language.predefined.attributes.override;

--- a/language/predefined/fiber.xml
+++ b/language/predefined/fiber.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fiber" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>Die Klasse Fiber</title>
  <titleabbrev>Fiber</titleabbrev>
 

--- a/language/predefined/fibererror.xml
+++ b/language/predefined/fibererror.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 14767af0f05dffa6fdb9b49e1a1f4e9ca7022a60 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 4b06b2d5c3a28a13504972df0f0be6deffabb4c5 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
-<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+<reference xml:id="class.fibererror" role="exception" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude"
+ annotations="non-interactive">
  <title>FiberError</title>
  <titleabbrev>FiberError</titleabbrev>
 

--- a/language/types/boolean.xml
+++ b/language/types/boolean.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f90b26b377a61c76c0f64028e47553e550411d08 Maintainer: hholzgra  Status: ready -->
+<!-- EN-Revision: 4657c1173e6b3852cdc8db4fc64f380d10ebae0c Maintainer: hholzgra  Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 346c0bd13f99888108cbefeb9c7c17923cac1a47 Reviewer: samesch -->
 <sect1 xml:id="language.types.boolean">
@@ -119,8 +119,8 @@ if ($show_separators) {
    <listitem>
     <simpara>
      Interne Objekte, die ihr Casting-Verhalten auf bool überladen, zum
-     Beispiel: <link linkend="ref.simplexml">SimpleXML</link>-Objekte, die aus
-     leeren Elementen ohne Attribute erstellt werden.
+     Beispiel <classname>GMP</classname>-Objekte, die den Wert
+     <literal>0</literal> repräsentieren.
     </simpara>
    </listitem>
   </itemizedlist>

--- a/language/types/singleton.xml
+++ b/language/types/singleton.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f908fff129bcd8ec1605658e06457cb04e5b2b51 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 828980b619bb4300e196924598b6a5d398f630e4 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <sect1 xml:id="language.types.singleton">
  <title>Singleton-Typen</title>

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 

--- a/language/wrappers/expect.xml
+++ b/language/wrappers/expect.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f94d903985119d3ac00f4528551df947f57b667f Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="wrappers.expect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" annotations="verify_info:false" role="stream_wrapper">
@@ -11,11 +11,11 @@
 
  <refsect1 role="description"><!-- {{{ -->
   &reftitle.description;
-  <para>
+  <simpara>
    Streams, die über den Wrapper <filename>expect://</filename> geöffnet
-   werden, bieten über PTY Zugriff auf stdio, stdout und stderr eines 
+   werden, bieten über PTY Zugriff auf stdin, stdout und stderr eines
    Prozesses.
-  </para>
+  </simpara>
   <note>
    <title>Dieser Wrapper ist standardmäßig nicht aktiviert</title>
    <simpara>

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: sammywg Status: ready -->
 
 <book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/apache/book.xml
+++ b/reference/apache/book.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 46a9cdd2dbef4ec89bf65fad9930e2feb78bbb98 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8a0888aeb20d187289664eb1116fa30228837478 Maintainer: sammywg Status: ready -->
 
 <book xml:id="book.apache" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <?phpdoc extension-membership="bundled" ?>
@@ -9,9 +9,12 @@
  <!-- {{{ preface -->
  <preface xml:id="intro.apache">
   &reftitle.intro;
-  <para>
-   Diese Funktionen stehen nur zur Verfügung, wenn PHP als Apachemodul läuft.
-  </para>
+  <simpara>
+   Diese Funktionen stehen zur Verfügung, wenn PHP als Apache-Modul läuft.
+   Einige Funktionen sind möglicherweise auch verfügbar, wenn PHP unter
+   anderen Webserver-APIs läuft. Details sind der Dokumentation der jeweiligen
+   Funktion zu entnehmen.
+  </simpara>
  </preface>
  <!-- }}} -->
 

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.class-alias" xmlns="http://docbook.org/ns/docbook">

--- a/reference/classobj/functions/class-alias.xml
+++ b/reference/classobj/functions/class-alias.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 194d020921b4f2bc7616ac9eacabe362e89752ef Maintainer: samesch Status: ready -->
+<!-- EN-Revision: ff9181ea03ac348b2c7ff4ad07896f277cddcb1d Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.class-alias" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -21,11 +21,13 @@
    benutzerdefinierten Klasse <parameter>class</parameter>. Die abgeleitete
    Klasse ist genau die gleiche wie die Originalklasse.
   </para>
+  <simpara>
+   Der Klassen-Alias darf keines der <link linkend="reserved.other-reserved-words">reservierten Wörter</link> von PHP sein.
+  </simpara>
    <note>
    <simpara>
     Seit PHP 8.3.0 kann mit <function>class_alias</function> auch ein Alias
     einer internen Klasse erstellt werden.
-    creating an alias of an PHP internal class.
    </simpara>
   </note>
  </refsect1>

--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 4586854a24b1ca532b5c9ba2410db1f1eee338ed Reviewer: samesch -->
 <!-- CREDITS: Yannic Schnetz -->
@@ -68,7 +68,7 @@
   <para>
    Nur bei objektorientierter API: Wenn eine ungültige
    Datum/Uhrzeit-Zeichenkette übergeben wird, wird eine
-   <exceptionname>DateMalformedStringException</exceptionname> ausgelöst.
+   <exceptionname>DateMalformedIntervalStringException</exceptionname> ausgelöst.
   </para>
  </refsect1>
 
@@ -87,7 +87,7 @@
       <entry>8.3.0</entry>
       <entry>
        <methodname>DateInterval::createFromDateString</methodname> löst nun
-       eine <exceptionname>DateMalformedStringException</exceptionname> aus,
+       eine <exceptionname>DateMalformedIntervalStringException</exceptionname> aus,
        wenn eine ungültige Zeichenkette übergeben wird. Zuvor wurde
        <literal>false</literal> zurückgegeben, und eine Warnung wurde
        ausgegeben.

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">

--- a/reference/datetime/datetimeinterface/format.xml
+++ b/reference/datetime/datetimeinterface/format.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 7f7fce55c075567a9b964be1d6ff131922930b17 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="datetime.format" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -344,7 +344,7 @@
          </row>
          <row>
           <entry><literal>c</literal></entry>
-          <entry>Datum gemäß ISO 8601</entry>
+          <entry>Datum gemäß ISO 8601. Nur kompatibel mit dem nicht erweiterten Format (bis zum Jahr 9999). Spätere Daten führen zu einer ungültigen Zeichenkette. Für spätere Daten und das erweiterte Format siehe <literal>x</literal> und <literal>X</literal>.</entry>
           <entry>2004-02-12T15:19:21+00:00</entry>
          </row>
          <row>
@@ -430,6 +430,12 @@ echo $date->format('Y-m-d H:i:s');
 ?>
 ]]>
     </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+2000-01-01 00:00:00
+]]>
+    </screen>
     <para>&style.procedural;</para>
     <programlisting role="php">
 <![CDATA[

--- a/reference/dio/functions/dio-fcntl.xml
+++ b/reference/dio/functions/dio-fcntl.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: hholzgra  Status: ready -->
 <!-- Credits: georg -->
 <refentry xml:id="function.dio-fcntl" xmlns="http://docbook.org/ns/docbook">

--- a/reference/dio/functions/dio-fcntl.xml
+++ b/reference/dio/functions/dio-fcntl.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 094906da54e6b9296c52505026c0f6a3fe68f6a6 Maintainer: hholzgra  Status: ready -->
+<!-- EN-Revision: ee1ce6a0e1875b6851274f8c373ca2bd48630fa0 Maintainer: hholzgra  Status: ready -->
 <!-- Credits: georg -->
 <refentry xml:id="function.dio-fcntl" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -93,7 +93,7 @@
      <listitem>
       <para>
        Die <parameter>cmd</parameter>-Operationen <constant>F_SETLK</constant>
-       und <constant>F_SETLLW</constant> erwarten ein Array mit den folgenden
+       und <constant>F_SETLKW</constant> erwarten ein Array mit den folgenden
        Elementen:
        <itemizedlist>
         <listitem>

--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: tihox Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 54935fc4b239f498040cc1fa3f7e6eef8f048671 Reviewer: samesch-->

--- a/reference/dom/functions/dom-import-simplexml.xml
+++ b/reference/dom/functions/dom-import-simplexml.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 54935fc4b239f498040cc1fa3f7e6eef8f048671 Maintainer: tihox Status: ready -->
+<!-- EN-Revision: 940ea8c1b2b727eb0f3f6412305ab699b9b47cc6 Maintainer: tihox Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 54935fc4b239f498040cc1fa3f7e6eef8f048671 Reviewer: samesch-->
 <refentry xml:id="function.dom-import-simplexml" xmlns="http://docbook.org/ns/docbook">
@@ -18,14 +18,14 @@
    <type class="union"><type>DOMAttr</type><type>DOMElement</type></type><methodname>dom_import_simplexml</methodname>
    <methodparam><type>object</type><parameter>node</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Diese Funktion verwendet das angegebene Attribut oder Element
    <parameter>node</parameter> (eine
    <classname>SimpleXMLElement</classname>-Instanz) und erstellt einen
    <classname>DOMAttr</classname>- bzw. <classname>DOMElement</classname>-Knoten.
    Der neue <classname>DOMNode</classname> verweist auf denselben
    zugrundeliegenden XML-Knoten wie das <classname>SimpleXMLElement</classname>.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">

--- a/reference/exif/functions/exif-read-data.xml
+++ b/reference/exif/functions/exif-read-data.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.exif-read-data">

--- a/reference/exif/functions/exif-read-data.xml
+++ b/reference/exif/functions/exif-read-data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 6a08181be1706dfebdb3ad6e45620bceb08019ba Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.exif-read-data">
  <refnamediv>

--- a/reference/fdf/functions/fdf-set-file.xml
+++ b/reference/fdf/functions/fdf-set-file.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: cmb Status: ready -->
 <!-- CREDITS: hholzgra -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-set-file">

--- a/reference/fdf/functions/fdf-set-file.xml
+++ b/reference/fdf/functions/fdf-set-file.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: f86fd7b1ce74d1ea3a6a2e3e40757590b14a3e7e Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: cmb Status: ready -->
 <!-- CREDITS: hholzgra -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-set-file">
  <refnamediv>

--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 627f933cfe6a033dccac32982cd68e7c1b86927f Maintainer: cmb Status: ready -->
+<!-- EN-Revision: f7e68a1a35d622977d1a1c2155795204243ec3f1 Maintainer: cmb Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="function.filter-input">
  <refnamediv>
   <refname>filter_input</refname>
@@ -58,11 +58,12 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Bei Erfolg wird die gefilterte Variable zurückgegeben.
-   Wenn die Variable nicht gesetzt ist, wird &false; zurückgegeben.
-   Im Fehlerfall wird &false; zurückgegeben, es sei denn, das Flag
-   <constant>FILTER_NULL_ON_FAILURE</constant> wird verwendet; in diesem Fall
-   wird &null; zurückgegeben.
+   Wert der angeforderten Variable bei Erfolg,
+   &false;, wenn der Filter fehlschlägt,
+   oder &null;, wenn die Variable <parameter>var_name</parameter> nicht gesetzt ist.
+   Wird das Flag <constant>FILTER_NULL_ON_FAILURE</constant> verwendet,
+   wird &false; zurückgegeben, wenn die Variable nicht gesetzt ist,
+   und &null;, wenn der Filter fehlschlägt.
   </simpara>
  </refsect1>
 

--- a/reference/filter/functions/filter-input.xml
+++ b/reference/filter/functions/filter-input.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: f7e68a1a35d622977d1a1c2155795204243ec3f1 Maintainer: cmb Status: ready -->
 <refentry xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="function.filter-input">
  <refnamediv>

--- a/reference/gnupg/reference.xml
+++ b/reference/gnupg/reference.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: tihox Status: ready -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ref.gnupg">
  <title>GnuPG &Functions;</title>

--- a/reference/gnupg/reference.xml
+++ b/reference/gnupg/reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a148eb08b658eafa139f8996ad92d860e023da3f Maintainer: tihox Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: tihox Status: ready -->
 <reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ref.gnupg">
  <title>GnuPG &Functions;</title>
 
@@ -8,7 +8,7 @@
    &reftitle.notes;
    <simpara>
     Diese Erweiterung verwendet den Schlüsselbund des aktuellen Benutzers.
-    Dieser Schlüsselbund ist normalerweise unter ~./.gnupg/ zu finden.
+    Dieser Schlüsselbund ist normalerweise unter ~/.gnupg/ zu finden.
     Um einen benutzerdefinierten Pfad festzulegen, kann der Pfad zum
     Schlüsselbund in der Umgebungsvariablen GNUPGHOME gespeichert werden.
     Siehe hierzu <link linkend="function.putenv">putenv</link> für weitere

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: raphaelm Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: raphaelm Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 1adf24615e8be8049f68db37513e37dc631d49d1 Reviewer: samesch -->
 <refentry xml:id="function.hash-hmac-file" xmlns="http://docbook.org/ns/docbook">

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: raphaelm Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 1adf24615e8be8049f68db37513e37dc631d49d1 Reviewer: samesch -->

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -102,19 +102,12 @@
      </thead>
      <tbody>
       <row>
-       <entry>7.2.0</entry>
-       <entry>
-        Die Verwendung von nicht-kryptografischen Hashfunktionen (adler32,
-        crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) ist nicht mehr
-        möglich.
-       </entry>
-      <row>
        <entry>8.0.0</entry>
        <entry>
-          Es wird nun eine <classname>ValueError</classname>-Exception geworfen,
-          wenn <parameter>algo</parameter> unbekannt ist oder eine
-          nicht-kryptografische Hash-Funktion darstellt; zuvor wurde &false;
-          zurückgegeben und eine <constant>E_WARNING</constant>-Meldung ausgegeben.
+        Es wird nun eine <classname>ValueError</classname>-Exception geworfen,
+        wenn <parameter>algo</parameter> unbekannt ist oder eine
+        nicht-kryptografische Hash-Funktion darstellt; zuvor wurde &false;
+        zurückgegeben und eine <constant>E_WARNING</constant>-Meldung ausgegeben.
        </entry>
       </row>
       <row>

--- a/reference/hash/functions/hash-hmac-file.xml
+++ b/reference/hash/functions/hash-hmac-file.xml
@@ -108,6 +108,14 @@
         crc32, crc32b, fnv132, fnv1a32, fnv164, fnv1a64, joaat) ist nicht mehr
         möglich.
        </entry>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+          Es wird nun eine <classname>ValueError</classname>-Exception geworfen,
+          wenn <parameter>algo</parameter> unbekannt ist oder eine
+          nicht-kryptografische Hash-Funktion darstellt; zuvor wurde &false;
+          zurückgegeben und eine <constant>E_WARNING</constant>-Meldung ausgegeben.
+       </entry>
       </row>
       <row>
        <entry>7.2.0</entry>

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: raphaelm Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: ac6b36357e5f5294a2c0577b85d193d84f0017ff Reviewer: samesch -->

--- a/reference/hash/functions/hash-hmac.xml
+++ b/reference/hash/functions/hash-hmac.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 539a9823a805ac29cab7fa4baf3ae3a28116a2f5 Maintainer: raphaelm Status: ready -->
+<!-- EN-Revision: df2a77acbbb9d381426b863fcfa4d66ac7f5ab6d Maintainer: raphaelm Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: ac6b36357e5f5294a2c0577b85d193d84f0017ff Reviewer: samesch -->
 <refentry xml:id="function.hash-hmac" xmlns="http://docbook.org/ns/docbook">
@@ -104,8 +104,9 @@
        <entry>
         Löst nun eine <classname>ValueError</classname>-Exception aus, wenn
         <parameter>algo</parameter> nicht bekannt ist oder eine
-        nicht-kryptographische Hash-Funktion ist; zuvor wurde stattdessen
-        &false; zurückgegeben.
+        nicht-kryptographische Hash-Funktion ist; zuvor wurde &false;
+        zurückgegeben und eine <constant>E_WARNING</constant>-Meldung wurde
+        ausgegeben.
        </entry>
       </row>
       <row>

--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: cmb Status: ready -->
 <refentry xml:id="function.assert-options" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/info/functions/assert-options.xml
+++ b/reference/info/functions/assert-options.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ada1d79de35239334b68d0120b011530e31244ff Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: cmb Status: ready -->
 <refentry xml:id="function.assert-options" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>assert_options</refname>
@@ -207,7 +207,7 @@
       <row>
        <entry>8.3.0</entry>
        <entry>
-        <function>assert_option</function> ist nun veraltet.
+        <function>assert_options</function> ist nun veraltet.
        </entry>
       </row>
       <row>

--- a/reference/mysqli/mysqli_stmt/error-list.xml
+++ b/reference/mysqli/mysqli_stmt/error-list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d31ab6f26d3bb116298aed86cf1daba2bfb78b6b Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-stmt.error-list" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -111,7 +111,7 @@ if ($stmt = mysqli_prepare($link, $query)) {
     mysqli_stmt_execute($stmt);
 
     echo "Fehler:\n";
-    print_r(mysql_stmt_error_list($stmt));
+    print_r(mysqli_stmt_error_list($stmt));
 
     /* Anweisung schließen */
     mysqli_stmt_close($stmt);

--- a/reference/mysqli/mysqli_stmt/error-list.xml
+++ b/reference/mysqli/mysqli_stmt/error-list.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="mysqli-stmt.error-list" xmlns="http://docbook.org/ns/docbook">

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">

--- a/reference/pdo/pdo/quote.xml
+++ b/reference/pdo/pdo/quote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 661e6858acade9f5a08fc8f9c07b605f42f4a700 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: c142be811735a5542c8a2e4c4ed2f81e8cc3acc6 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdo.quote" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -15,11 +15,11 @@
   <methodsynopsis role="PDO">
    <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>PDO::quote</methodname>
    <methodparam><type>string</type><parameter>string</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>PDO::PARAM_STR</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer><constant>PDO::PARAM_STR</constant></initializer></methodparam>
   </methodsynopsis>
   <para>
    <methodname>PDO::quote</methodname> schließt die angegebene Zeichenkette
-   (falls erforderlich) in Anführungszeichen ein und maskiert Sonderzeichen
+   in Anführungszeichen ein und maskiert Sonderzeichen
    innerhalb der Zeichenkette, wobei ein für den zugrundeliegenden Treiber
    geeigneter Stil der Anführungszeichen verwendet wird.
   </para>

--- a/reference/pgsql/functions/pg-escape-bytea.xml
+++ b/reference/pgsql/functions/pg-escape-bytea.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id='function.pg-escape-bytea' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_escape_bytea</refname>
@@ -14,10 +14,10 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_bytea</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
-   <function>pg_escape_bytea</function> maskiert <parameter>data</parameter>
+   <function>pg_escape_bytea</function> maskiert <parameter>string</parameter>
    für den Datentyp bytea und gibt den maskierten String zurück.
   </para>
   <note>
@@ -51,7 +51,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Ein <type>string</type>, der Text oder Binärdaten enthält, die in eine

--- a/reference/pgsql/functions/pg-escape-bytea.xml
+++ b/reference/pgsql/functions/pg-escape-bytea.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id='function.pg-escape-bytea' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id='function.pg-escape-string' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pgsql/functions/pg-escape-string.xml
+++ b/reference/pgsql/functions/pg-escape-string.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id='function.pg-escape-string' xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_escape_string</refname>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>string</type><methodname>pg_escape_string</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_escape_string</function> maskiert einen String für
@@ -38,7 +38,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>string</parameter></term>
      <listitem>
       <para>
        Ein <type>string</type> mit den Daten, die maskiert werden müssen.

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: 5f1a92089fa4efe81e9777f87f9ed93f4853898b Maintainer: conni Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_execute</refname>
@@ -15,7 +15,7 @@
   <methodsynopsis>
    <type class="union"><type>PgSql\Result</type><type>false</type></type><methodname>pg_execute</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>stmtname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>statement_name</parameter></methodparam>
    <methodparam><type>array</type><parameter>params</parameter></methodparam>
   </methodsynopsis>
   <para>
@@ -49,7 +49,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>stmtname</parameter></term>
+     <term><parameter>statement_name</parameter></term>
      <listitem>
       <para>
        Der Name der vorbereiteten Abfrage, die ausgeführt werden soll. Falls

--- a/reference/pgsql/functions/pg-execute.xml
+++ b/reference/pgsql/functions/pg-execute.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-execute" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pgsql/functions/pg-lo-export.xml
+++ b/reference/pgsql/functions/pg-lo-export.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-lo-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_lo_export</refname>
@@ -13,7 +13,7 @@
    <type>bool</type><methodname>pg_lo_export</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>oid</parameter></methodparam>
-   <methodparam><type>string</type><parameter>pathname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_lo_export</function> liest die Inhalte eines Large Objects
@@ -49,7 +49,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>pathname</parameter></term>
+     <term><parameter>filename</parameter></term>
      <listitem>
       <para>
        Der vollständige Pfad und Dateiname der Datei, in der die Inhalte des 

--- a/reference/pgsql/functions/pg-lo-export.xml
+++ b/reference/pgsql/functions/pg-lo-export.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-lo-export" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pgsql/functions/pg-put-line.xml
+++ b/reference/pgsql/functions/pg-put-line.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-put-line" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pgsql/functions/pg-put-line.xml
+++ b/reference/pgsql/functions/pg-put-line.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-put-line" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_put_line</refname>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <type>bool</type><methodname>pg_put_line</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
-   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+   <methodparam><type>string</type><parameter>query</parameter></methodparam>
   </methodsynopsis>
   <para>
    <function>pg_put_line</function> sendet eine NULL-terminierte
@@ -60,7 +60,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><parameter>data</parameter></term>
+     <term><parameter>query</parameter></term>
      <listitem>
       <para>
        Eine Textzeile, die direkt an den PostgreSQL Datenbankserver

--- a/reference/pgsql/functions/pg-set-error-verbosity.xml
+++ b/reference/pgsql/functions/pg-set-error-verbosity.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
 <!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-set-error-verbosity" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>

--- a/reference/pgsql/functions/pg-set-error-verbosity.xml
+++ b/reference/pgsql/functions/pg-set-error-verbosity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: c2eca73ef79ebe78cebb34053e41b565af504c4f Maintainer: conni Status: ready -->
+<!-- EN-Revision: c43a3cd9b49627b8d42a4b6ad530e10e26ca30dd Maintainer: conni Status: ready -->
 <refentry xml:id="function.pg-set-error-verbosity" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>pg_set_error_verbosity</refname>
@@ -13,7 +13,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <type>int</type><methodname>pg_set_error_verbosity</methodname>
+   <type class="union"><type>int</type><type>false</type></type><methodname>pg_set_error_verbosity</methodname>
    <methodparam choice="opt"><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
    <methodparam><type>int</type><parameter>verbosity</parameter></methodparam>
   </methodsynopsis>
@@ -64,7 +64,8 @@
   &reftitle.returnvalues;
   <para>
    Der vorher eingestellte Detaillierungsgrad: <constant>PGSQL_ERRORS_TERSE</constant>,
-   <constant>PGSQL_ERRORS_DEFAULT</constant> oder <constant>PGSQL_ERRORS_VERBOSE</constant>.
+   <constant>PGSQL_ERRORS_DEFAULT</constant> oder <constant>PGSQL_ERRORS_VERBOSE</constant>,
+   oder &false; im Fehlerfall.
   </para>
  </refsect1>
  


### PR DESCRIPTION
Holt 38 doc-de-Dateien nach, die laut [revcheck](https://doc.php.net/revcheck.php?p=files&lang=de) leicht hinter upstream doc-en zurücklagen (Diff jeweils zwischen +1 -1 und +7 -5 Zeilen). Jede Datei wird auf den letzten Commit gehoben, der sie in doc-en berührt hat.

Inhalt:

- Reine `EN-Revision`-Bumps, wenn die deutsche Übersetzung den englischen Typo nicht enthielt.
- Gespiegelte `<para>` → `<simpara>`-Tag-Wechsel.
- Kleine Real-Fixes, die echte EN-Korrekturen nachziehen (z. B. `Systen V` → `System V`, `F_SETLLW` → `F_SETLKW`, `assert_option` → `assert_options`, pgsql-Parameterumbenennungen).
- Eine DateTime-Beispielumbenennung (`DateMalformedStringException` → `DateMalformedIntervalStringException`).
- Wenige neue Prosa-Stellen übersetzt (`apache/book`, `filter/filter-input`, `classobj/class-alias`, `datetimeinterface/format`, `language/predefined/attributes`).

Die bestehenden `Maintainer:`-Einträge wurden beibehalten.