### PR TITLE
[Sync EN] Update tutorial chapter to match upstream rewrite

### DIFF
--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -445,7 +445,7 @@ Hallo Joe. Sie sind 22 Jahre alt.
    <para>
     Insbesondere könnten folgende Funktionalitäten interessant sein:
     <simplelist>
-     <member>Dateien lesen und schreiben mit den <link linkend="book.filesystem">Filesystem-Funktionen</link></member>
+     <member>Dateien lesen und schreiben mit den <link linkend="book.filesystem">Dateisystem-Funktionen</link></member>
      <member><link linkend="features.file-upload">Datei-Uploads verarbeiten</link></member>
      <member>Entfernte Seiten und Dateien mit <link linkend="book.curl">Curl</link> abrufen</member>
      <member>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -512,7 +512,7 @@ Hallo Joe. Sie sind 22 Jahre alt.
     </itemizedlist>
    </para>
    <simpara>
-    Wenn Sie nichts Bestimmtes bauen möchten, können Sie nach Coding-Übungen wie Katas, Challenges oder
+    Wenn Sie nichts Bestimmtes entwickeln möchten, können Sie nach Coding-Übungen wie Katas, Challenges oder
     "Code Golf" suchen. Auch wenn sie nicht speziell auf PHP ausgerichtet sind, lassen sich die meisten
     umsetzen und werden Ihr Wissen und Denken herausfordern.
    </simpara>

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 1fd637525fd3bbaec04f6fff80eeb33fce880b10 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 1340d3595bde8489ea1385868ffd75471a56999b Maintainer: cmb Status: ready -->
  <chapter xml:id="tutorial" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <info><title>Ein kleines Tutorial</title></info>
 
@@ -16,58 +15,16 @@
    können sie genauso wie normale HTML-Seiten erstellen und bearbeiten.
   </para>
 
-  <section xml:id="tutorial.requirements">
-   <info><title>Was brauche ich?</title></info>
-   <para>
-    In diesem Tutorial gehen wir davon aus, dass auf Ihrem Server die
-    PHP-Unterstützung aktiviert ist und dass die Dateiendung
-    <filename class="extension">.php</filename> PHP zugeordnet ist. Auf den
-    meisten Servern ist dies die Standardeinstellung für PHP-Dateien, aber
-    fragen Sie bitte Ihren Server-Administrator, um sicherzugehen. Wenn Ihr
-    Server PHP unterstützt, müssen Sie nichts machen. Erstellen Sie einfach
-    Ihre <filename class="extension">.php</filename>-Dateien und legen Sie
-    diese in Ihr Web-Verzeichnis - der Server wird sie dann für Sie parsen. Sie
-    müssen nichts kompilieren und auch keine Zusatz-Tools installieren. Stellen
-    Sie sich diese PHP-erweiterten Dateien wie normale HTML-Seiten mit einer
-    ganzen Familie von "magischen" Tags vor, die Sie verschiedenste Dinge tun
-    lassen.
-   </para>
-   <para>
-    Angenommen, Sie möchten Bandbreite sparen und lokal entwickeln. In diesem
-    Fall müssen Sie einen Webserver wie &zb;
-    <link xlink:href="&url.apache;">Apache</link> und natürlich
-    <link xlink:href="&url.php.downloads;">PHP</link> installieren. Sehr
-    empfehlenswert ist auch die Installation einer Datenbank wie &zb;
-    <link xlink:href="&url.mysql.docs;">MySQL</link>.
-   </para>
-   <para>
-    Sie können diese Programme entweder eins nach dem anderen selbst
-    installieren oder den folgenden einfacheren Weg gehen. Unser Handbuch
-    bietet ausführliche
-    <link linkend="install">Installationsanweisungen für PHP</link> (dabei
-    gehen wir davon aus, dass Sie schon einen Webserver installiert haben).
-    Falls Sie Probleme bei der Installation von PHP haben, dann empfehlen wir
-    Ihnen, dass Sie Ihre Fragen auf unserer
-    <link xlink:href="&url.php.mailing-lists;">Installations-Mailingliste</link>
-    stellen. Noch einfacher ist es,
-    <link xlink:href="&url.installkits;">vorkonfigurierte Pakete</link> für
-    Ihr Betriebssystem zu verwenden, die alle oben genannten Programme mit
-    einigen wenigen Mausklicks installieren. Es ist ziemlich einfach, einen
-    Webserver mit PHP-Unterstützung auf jedem Betriebssystem, wie macOS, Linux
-    oder Windows, aufzusetzen. Unter Linux sind
-    <link xlink:href="&url.rpmfind;">rpmfind</link> und
-    <link xlink:href="&url.rpmfind.pbone;">PBone</link> hilfreich, wenn Sie
-    RPM-Pakete suchen. Wenn Sie Pakete für Debian suchen, dann besuchen Sie
-    bitte <link xlink:href="&url.apt-get;">apt-get</link>.
-   </para>
-  </section>
-
   <section xml:id="tutorial.firstpage">
    <info><title>Ihre erste PHP-erweiterte Seite</title></info>
+   <simpara>
+    Dieses Tutorial setzt voraus, dass PHP bereits installiert ist.
+    Installationsanweisungen finden Sie auf der
+    <link xlink:href="&url.php.downloads;">Download-Seite</link>.
+   </simpara>
    <para>
-    Erstellen Sie eine Datei mit dem Namen <filename>hallo.php</filename> und
-    speichern Sie diese im Wurzelverzeichnis Ihres Webservers
-    (<varname>DOCUMENT_ROOT</varname>) mit dem folgenden Inhalt:
+    Erstellen Sie eine Datei mit dem Namen <filename>hallo.php</filename> mit
+    dem folgenden Inhalt:
    </para>
    <para>
     <example>
@@ -82,14 +39,21 @@ echo "Hello World!";
 ]]>
      </programlisting>
      <simpara>
+      Navigieren Sie im Terminal in das Verzeichnis, das diese Datei enthält,
+      und starten Sie mit folgendem Befehl einen Entwicklungsserver:
+     </simpara>
+     <programlisting role="shell">
+<![CDATA[
+php -S localhost:8000
+]]>
+     </programlisting>
+     <simpara>
       Verwenden Sie Ihren Browser, um die Datei über die Webserver-URL
-      aufzurufen. Die URL muss mit <literal>/hallo.php</literal> enden. Wenn
-      Sie lokal entwickeln, sieht die URL &zb; so aus:
-      <literal>http://localhost/hallo.php</literal> oder so:
-      <literal>http://127.0.0.1/hallo.php</literal> - andere Adressen sind
-      aber, abhängig vom Webserver, auch möglich. Wenn alles korrekt
-      konfiguriert ist, wird die Datei von PHP geparst und Sie sehen die
-      Ausgabe "Hallo Welt" in Ihrem Browser.
+      aufzurufen. Die URL muss mit <literal>/hallo.php</literal> enden.
+      Gemäß dem zuvor ausgeführten Befehl lautet die URL
+      <literal>http://localhost:8000/hallo.php</literal>.
+      Wenn alles korrekt konfiguriert ist, wird die Datei von PHP geparst und
+      Sie sehen die Ausgabe "Hello World!" in Ihrem Browser.
      </simpara>
      <simpara>
       PHP kann in eine normale HTML-Webseite eingebettet werden. Das bedeutet,
@@ -137,21 +101,7 @@ echo "Hello World!";
     eine normale HTML-Datei vor, die eine Menge von speziellen Tags enthält,
     mit denen Sie einige interessante Dinge tun können.
    </para>
-   <para>
-    Wenn Sie dieses Beispiel ausprobiert haben und Sie aber keine Ausgabe
-    erhalten haben oder zum Download aufgefordert worden sind oder die
-    komplette Datei als Text erhalten haben, dann ist es sehr wahrscheinlich,
-    dass auf Ihrem Server PHP nicht aktiviert oder falsch konfiguriert ist.
-    Fragen Sie in diesem Fall Ihren Administrator und weisen Sie ihn auf das
-    <link linkend="install">Installations-Kapitel</link> hin. Wenn Sie lokal
-    entwickeln, lesen Sie bitte das Installations-Kapitel, um festzustellen,
-    ob alles richtig konfiguriert wurde. Stellen Sie sicher, dass Sie die
-    Datei über das HTTP-Protokoll aufrufen können. Wenn Sie die Datei direkt
-    aus Ihrem Dateisystem aufrufen, wird sie nicht durch PHP geparst. Sollten
-    Ihre Probleme nach Lesen dieses Kapitels immer noch bestehen, zögern Sie
-    nicht und nutzen Sie eines der vielen
-    <link xlink:href="&url.php.support;">Support</link>-Angebote.
-   </para>
+
    <para>
     Der Sinn des Beispiels ist es, Ihnen das spezielle PHP Tag-Format zu
     zeigen. Im Beispiel wurde <literal>&lt;?php</literal> verwendet, um den
@@ -223,7 +173,11 @@ echo "Hello World!";
      <info><title>Anzeigen von Systeminformationen mit PHP</title></info>
      <programlisting role="php">
 <![CDATA[
-<?php phpinfo(); ?>
+<?php
+
+phpinfo();
+
+?>
 ]]>
      </programlisting>
     </example>
@@ -259,7 +213,9 @@ echo "Hello World!";
      <programlisting role="php">
 <![CDATA[
 <?php
+
 echo $_SERVER['HTTP_USER_AGENT'];
+
 ?>
 ]]>
      </programlisting>
@@ -303,9 +259,11 @@ Mozilla/5.0 (Linux) Firefox/112.0
      <programlisting role="php">
 <![CDATA[
 <?php
+
 if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
     echo 'Sie verwenden Firefox.';
 }
+
 ?>
 ]]>
      </programlisting>
@@ -364,15 +322,15 @@ Sie verwenden Firefox.
 <![CDATA[
 <?php
 if (str_contains($_SERVER['HTTP_USER_AGENT'], 'Firefox')) {
-?>
-<h3>str_contains() hat true zurückgegeben</h3>
-<p>Sie verwenden Firefox</p>
-<?php
+    ?>
+    <h3>str_contains() hat true zurückgegeben</h3>
+    <p>Sie verwenden Firefox</p>
+    <?php
 } else {
-?>
-<h3>str_contains() hat false zurückgegeben</h3>
-<p>Sie verwenden nicht Firefox</p>
-<?php
+    ?>
+    <h3>str_contains() hat false zurückgegeben</h3>
+    <p>Sie verwenden nicht Firefox</p>
+    <?php
 }
 ?>
 ]]>
@@ -480,16 +438,84 @@ Hallo Joe. Sie sind 22 Jahre alt.
 
   <section xml:id="tutorial.whatsnext">
    <info><title>Und weiter?</title></info>
+   <simpara>
+    Mit dem neuen Wissen sollten Sie das meiste aus diesem Handbuch verstehen
+    können.
+   </simpara>
    <para>
-    Mit dem neuen Wissen sollte es Ihnen möglich sein, das meiste aus diesem
-    Handbuch und die vielen Beispiel-Skripte in den Beispiel-Archiven zu
-    verstehen.
+    Insbesondere könnten folgende Funktionalitäten interessant sein:
+    <simplelist>
+     <member>Dateien lesen und schreiben mit den <link linkend="book.filesystem">Filesystem-Funktionen</link></member>
+     <member><link linkend="features.file-upload">Datei-Uploads verarbeiten</link></member>
+     <member>Entfernte Seiten und Dateien mit <link linkend="book.curl">Curl</link> abrufen</member>
+     <member>
+      Daten in einer Datenbank speichern und auswerten mit <link linkend="book.pdo">PDO</link>
+      (<link linkend="ref.pdo-sqlite">SQLite</link> kann ohne laufenden Datenbankserver verwendet werden)
+     </member>
+     <member>Daten über mehrere Requests hinweg persistieren mit <link linkend="book.session">Sessions</link></member>
+    </simplelist>
    </para>
+   <simpara>
+    Im <link xlink:href="&url.packagist;">Packagist-Repository</link> findet sich für nahezu jeden Anwendungsfall
+    eine Vielzahl von Bibliotheken und <link xlink:href="&url.packagist;/search/?tags=framework">Frameworks</link>,
+    die alle über den <link linkend="install.composer.intro">Composer-Paketmanager</link> installiert werden können.
+   </simpara>
+   <simpara>
+    Hilfe und Rat aus der Community gibt es auf der <link xlink:href="&url.php.support;">Hilfe-Seite</link>.
+   </simpara>
+   <simpara>
+    Eine Auswahl an Podcasts, Präsentationen und weiteren Videos findet sich auf dem
+    <link xlink:href="&url.phpctv;">Community-PeerTube</link>.
+   </simpara>
+   <simpara>
+    Weitere Community-Ressourcen, die hilfreich sein können, sind sogenannte "awesome lists" (kuratierte
+    Linksammlungen) und "developer roadmaps" (Listen verwandter Themen).
+   </simpara>
    <para>
-    Wenn Sie an verschiedenen Präsentationen, die Ihnen zeigen, was PHP alles
-    tun kann, interessiert sind, dann besuchen Sie doch folgende Seite:
-    <link xlink:href="&url.php.talks;">&url.php.talks;</link>.
+    Wenn Sie nicht wissen, wo Sie anfangen sollen, hilft es oft, das Projekt oder Problem in kleinere Teile zu
+    zerlegen. So lässt sich leichter erkennen, was Sie bereits können und was Sie noch lernen müssen. Die Liste
+    darf so detailliert werden, wie nötig. Der Bau eines Blogs ließe sich zum Beispiel folgendermaßen aufgliedern:
+    <itemizedlist>
+     <listitem>
+      <simpara>Auflisten und Anzeigen von Seiten</simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>Datensätze (Seiten) aus einer Datenbank lesen</simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+     <listitem>
+      <simpara>Seiten erstellen</simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>Formularübermittlung verarbeiten</simpara>
+       </listitem>
+       <listitem>
+        <simpara>Datensätze (Seiten) in eine Datenbank schreiben</simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+     <listitem>
+      <simpara>Admin-Login</simpara>
+      <itemizedlist>
+       <listitem>
+        <simpara>Datensätze (Benutzer) aus einer Datenbank lesen</simpara>
+       </listitem>
+       <listitem>
+        <simpara>Mit Passwörtern umgehen</simpara>
+       </listitem>
+       <listitem>
+        <simpara>Daten (Benutzer-Login) über Requests und Seiten hinweg persistieren (Sessions)</simpara>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+    </itemizedlist>
    </para>
+   <simpara>
+    Wenn Sie nichts Bestimmtes bauen möchten, können Sie nach Coding-Übungen wie Katas, Challenges oder
+    "Code Golf" suchen. Auch wenn sie nicht speziell auf PHP ausgerichtet sind, lassen sich die meisten
+    umsetzen und werden Ihr Wissen und Denken herausfordern.
+   </simpara>
   </section>
  </chapter>
 

--- a/chapters/tutorial.xml
+++ b/chapters/tutorial.xml
@@ -452,7 +452,7 @@ Hallo Joe. Sie sind 22 Jahre alt.
       Daten in einer Datenbank speichern und auswerten mit <link linkend="book.pdo">PDO</link>
       (<link linkend="ref.pdo-sqlite">SQLite</link> kann ohne laufenden Datenbankserver verwendet werden)
      </member>
-     <member>Daten über mehrere Requests hinweg persistieren mit <link linkend="book.session">Sessions</link></member>
+     <member>Daten über mehrere Requests hinweg beibehalten mit <link linkend="book.session">Sessions</link></member>
     </simplelist>
    </para>
    <simpara>


### PR DESCRIPTION
Bringt `chapters/tutorial.xml` auf den Stand von upstream doc-en (`1340d3595b`). Die englische Seite wurde grundlegend überarbeitet:

- Entfernt: die veraltete Sektion `Was brauche ich?` mit Apache/MySQL/RPM-Installationsanweisungen.
- Ersetzt: der `DOCUMENT_ROOT`-basierte Ablauf durch den modernen Entwicklungsserver `php -S localhost:8000`.
- Entfernt: der Troubleshooting-Absatz, der nicht mehr zutrifft.
- Reformatiert: Leerzeilen rund um die Inline-PHP-Beispiele, Einrückung im HTML-/PHP-Mix-Beispiel.
- Neu geschriebene Sektion `Und weiter?`: Einstiegspunkte zu Filesystem, Curl, PDO, Sessions; Packagist und Composer; Community-PeerTube; eine Beispielzerlegung (Blog) als Lernhilfe.

Der bestehende `Maintainer:` (cmb) wurde beibehalten.