### PR TITLE
[Sync EN] Sync enumerations chapter (interactive samples, error message updates)

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 5744be5a4d239c18d4610581bd32b69a7d82947e Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
- <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook">
+ <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Aufzählungen (Enum)</title>
   <sect1 xml:id="language.enumerations.overview">
    <title>Übersicht über Aufzählungen</title>
@@ -41,10 +41,9 @@
    </para>
 
 
-   <programlisting role="php">
+   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum Suit
 {
     case Hearts;
@@ -52,7 +51,6 @@ enum Suit
     case Clubs;
     case Spades;
 }
-?>
 ]]>
    </programlisting>
 
@@ -66,13 +64,21 @@ enum Suit
     dürfen nur Werte dieses Typs übergeben werden.
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 function pick_a_card(Suit $suit)
 {
-    /* ... */
+    var_dump($suit);
 }
 
 $val = Suit::Diamonds;
@@ -85,9 +91,9 @@ pick_a_card(Suit::Clubs);
 
 // TypeError: pick_a_card(): Argument #1 ($suit) must be of type Suit, string given
 pick_a_card('Spades');
-?>
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Eine Aufzählung kann null oder mehr <literal>case</literal>-Definitionen
@@ -109,21 +115,35 @@ pick_a_card('Spades');
     veranschaulicht dies:
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 $a = Suit::Spades;
 $b = Suit::Spades;
 
-$a === $b; // true
+if ($a === $b) {
+    print "Suits match using ===\n";
+}
 
-$a instanceof Suit;  // true
+if ($a instanceof Suit) {
+    print "Suits match using instanceof\n";
+}
 
-$a !== 'Spades'; // true
-?>
+if ($a !== 'Spades') {
+    print "Suit does not match the string\n";
+}
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Es bedeutet auch, dass Enum-Werte niemals <literal>&lt;</literal> oder
@@ -149,15 +169,23 @@ $a !== 'Spades'; // true
     zwischen Groß- und Kleinschreibung unterschieden wird.
    </para>
 
-   <programlisting role="php">
+   <informalexample>
+    <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
 print Suit::Spades->name;
 // Gibt "Spades" aus
-?>
 ]]>
-   </programlisting>
+    </programlisting>
+   </informalexample>
 
    <para>
     Wenn der Name eines Enum-Falls dynamisch ermittelt wird, ist es auch
@@ -188,10 +216,9 @@ print Suit::Spades->name;
    folgende Syntax verwendet:
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum Suit: string
 {
     case Hearts = 'H';
@@ -199,7 +226,6 @@ enum Suit: string
     case Clubs = 'C';
     case Spades = 'S';
 }
-?>
 ]]>
   </programlisting>
 
@@ -240,15 +266,23 @@ enum Suit: string
    <literal>value</literal>, die der in der Definition angegebene Wert ist.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 print Suit::Clubs->value;
 // Gibt "C" aus
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Um sicherzustellen, dass die Eigenschaft <literal>value</literal>
@@ -256,16 +290,24 @@ print Suit::Clubs->value;
    werden. Das bedeutet, dass Folgendes einen Fehler auslöst:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 $suit = Suit::Clubs;
 $ref = &$suit->value;
-// Error: Cannot acquire reference to property Suit::$value
-?>
+// Fatal Error: Cannot indirectly modify readonly property Suit::$value
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Backed Enums implementieren die interne Schnittstelle
@@ -305,24 +347,37 @@ $ref = &$suit->value;
    Bei allen anderen Typen wird in beiden Modi ein TypeError ausgelöst.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
-$record = get_stuff_from_database($id);
-print $record['suit'];
+function get_stuff_from_database($id) {
+    return [
+        'suit' => 'S',
+    ];
+}
 
-$suit =  Suit::from($record['suit']);
-// Ungültige Daten führen zu einem ValueError:
-// "X" is not a valid scalar value for enum "Suit"
-print $suit->value;
+$record = get_stuff_from_database(42);
+print $record['suit'] . "\n";
 
 $suit = Suit::tryFrom('A') ?? Suit::Spades;
 // Ungültige Daten ergeben null, also wird stattdessen Suit::Spades verwendet.
-print $suit->value;
-?>
+print $suit->value . "\n";
+
+$suit =  Suit::from('X');
+// Ungültige Daten führen zu einem ValueError: "X" is not a valid backing scalar value for enum Suit
+print $suit->value . "\n";
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Die manuelle Definition der Methoden <literal>cases()</literal> oder
@@ -341,10 +396,10 @@ print $suit->value;
    auch alle Fälle dieser Enum.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -375,15 +430,15 @@ enum Suit implements Colorful
 
 function paint(Colorful $c)
 {
-   /* ... */
+   print $c->color() . "\n";
 }
 
 paint(Suit::Clubs);  // funktioniert
 
 print Suit::Diamonds->shape(); // gibt "Rectangle" aus
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    In diesem Beispiel haben alle vier Instanzen von <literal>Suit</literal>
@@ -397,10 +452,9 @@ print Suit::Diamonds->shape(); // gibt "Rectangle" aus
    Deklaration des zugehörigen Typs.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
    <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -422,7 +476,6 @@ enum Suit: string implements Colorful
         };
     }
 }
-?>
 ]]>
   </programlisting>
 
@@ -450,10 +503,9 @@ enum Suit: string implements Colorful
    dies nicht der tatsächlich ausgeführte Code ist):
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -487,7 +539,6 @@ final class Suit implements UnitEnum, Colorful
         // Siehe auch Abschnitt "Werteliste".
     }
 }
-?>
 ]]>
   </programlisting>
 
@@ -507,10 +558,10 @@ final class Suit implements UnitEnum, Colorful
    &zb;:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Size
 {
     case Small;
@@ -526,9 +577,11 @@ enum Size
         };
     }
 }
-?>
+
+var_dump(Size::fromLength(50));
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Statische Methoden können public, private oder protected sein, wobei
@@ -551,10 +604,10 @@ enum Size
    Eine Enum-Konstante kann sich auf einen Enum-Fall beziehen:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Size
 {
     case Small;
@@ -563,9 +616,11 @@ enum Size
 
     public const Huge = self::Large;
 }
-?>
+
+var_dump(Size::Huge);
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.traits">
@@ -579,10 +634,10 @@ enum Size
    Fehler.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 interface Colorful
 {
     public function color(): string;
@@ -612,9 +667,13 @@ enum Suit implements Colorful
         };
     }
 }
-?>
+
+$suit = Suit::Spades;
+var_dump($suit->color());
+var_dump($suit->shape());
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.expressions">
@@ -639,10 +698,9 @@ enum Suit implements Colorful
    erlaubt.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 // Dies ist eine völlig zulässige Definition einer Enum.
 enum Direction implements ArrayAccess
 {
@@ -685,7 +743,6 @@ $x = Direction::Up['short'];
 var_dump("\$x is " . var_export($x, true));
 
 $foo = new Foo();
-?>
 ]]>
   </programlisting>
  </sect1>
@@ -747,16 +804,14 @@ $foo = new Foo();
    instanziiert werden. Beides führt zu einem Fehler.
   </para>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 $clovers = new Suit();
 // Error: Cannot instantiate enum Suit
 
 $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor()
 // Error: Cannot instantiate enum Suit
-?>
 ]]>
   </programlisting>
  </sect1>
@@ -773,15 +828,32 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
    deklariert wurden.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit
+{
+    case Hearts;
+    case Diamonds;
+    case Clubs;
+    case Spades;
+}
 
-Suit::cases();
-// Produces: [Suit::Hearts, Suit::Diamonds, Suit::Clubs, Suit::Spades]
-?>
+var_dump(Suit::cases());
+
+enum SuitBacked: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+
+var_dump(SuitBacked::cases());
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Die manuelle Definition der Methode <literal>cases()</literal> führt bei
@@ -800,17 +872,25 @@ Suit::cases();
    Singleton-Wert zu setzen. Dadurch ist Folgendes gewährleistet:
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
 
 Suit::Hearts === unserialize(serialize(Suit::Hearts));
 
 print serialize(Suit::Hearts);
 // E:11:"Suit:Hearts";
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
 
   <para>
    Wenn bei der Deserialisierung kein Enum und kein Fall gefunden wird, der
@@ -831,10 +911,10 @@ print serialize(Suit::Hearts);
    <function>print_r</function> leicht von der bei Objekten.
   </para>
 
-  <programlisting role="php">
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
-
 enum Foo {
     case Bar;
 }
@@ -856,9 +936,9 @@ Baz Enum:int {
     [value] => 5
 }
 */
-?>
 ]]>
-  </programlisting>
+   </programlisting>
+  </informalexample>
  </sect1>
 
  <sect1 xml:id="language.enumerations.object-differences.inheritance">
@@ -869,10 +949,9 @@ Baz Enum:int {
    Klassen haben Vereinbarungen bezüglich ihrer Methoden:
   </simpara>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 class A {}
 class B extends A {}
 
@@ -881,7 +960,6 @@ function foo(A $a) {}
 function bar(B $b) {
     foo($b);
 }
-?>
 ]]>
  </programlisting>
 
@@ -895,10 +973,9 @@ function bar(B $b) {
    Enums haben Vereinbarungen über ihre Fälle, nicht über ihre Methoden:
   </simpara>
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum ErrorCode {
     case SOMETHING_BROKE;
 }
@@ -908,10 +985,8 @@ function quux(ErrorCode $errorCode)
     // Mit diesem Code werden offenbar alle Fälle abgedeckt
     match ($errorCode) {
         ErrorCode::SOMETHING_BROKE => true,
-    }
+    };
 }
-
-?>
 ]]>
   </programlisting>
 
@@ -925,10 +1000,9 @@ function quux(ErrorCode $errorCode)
   </simpara>
 
 
-  <programlisting role="php">
+  <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 // Ein gedankliches Code-Experiment, bei dem Enums nicht final sind.
 // Es ist zu beachten, dass dies in PHP nicht funktioniert.
 enum MoreErrorCode extends ErrorCode {
@@ -940,10 +1014,8 @@ function fot(MoreErrorCode $errorCode) {
 }
 
 fot(MoreErrorCode::PEBKAC);
-
-?>
 ]]>
- </programlisting>
+  </programlisting>
 
   <simpara>
    Nach den normalen Vererbungsregeln besteht eine Klasse, die eine andere
@@ -968,10 +1040,9 @@ fot(MoreErrorCode::PEBKAC);
   <para>
    <example>
     <title>Grundlegende eingeschränkte Werte</title>
-    <programlisting role="php">
+    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-
 enum SortOrder
 {
     case Asc;
@@ -982,7 +1053,6 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
 {
      /* ... */
 }
-?>
 ]]>
     </programlisting>
     <para>
@@ -1004,7 +1074,6 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <programlisting role="php">
 <![CDATA[
 <?php
-
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -1022,7 +1091,9 @@ enum UserStatus: string
         };
     }
 }
-?>
+
+$status = UserStatus::Suspended;
+var_dump($status->label());
 ]]>
     </programlisting>
 
@@ -1047,11 +1118,31 @@ enum UserStatus: string
     <programlisting role="php">
 <![CDATA[
 <?php
+enum UserStatus: string
+{
+    case Pending = 'P';
+    case Active = 'A';
+    case Suspended = 'S';
+    case CanceledByUser = 'C';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::Pending => 'Pending',
+            self::Active => 'Active',
+            self::Suspended => 'Suspended',
+            self::CanceledByUser => 'Canceled by user',
+        };
+    }
+}
 
 foreach (UserStatus::cases() as $case) {
-    printf('<option value="%s">%s</option>\n', $case->value, $case->label());
+    printf(
+        "<option value=\"%s\">%s</option>\n",
+        htmlentities($case->value),
+        htmlentities($case->label())
+    );
 }
-?>
 ]]>
     </programlisting>
    </example>


### PR DESCRIPTION
Bringt `language/enumerations.xml` auf den Stand von upstream doc-en (`1eb67bea30`). Die englische Seite wurde überwiegend umstrukturiert, um die `Run code`-Funktion auf php.net zu unterstützen.

Änderungen:

- `annotations="interactive"` auf dem `<chapter>`-Element aktiviert das Inline-Ausführen der Codebeispiele auf php.net.
- Die meisten `<programlisting>`-Blöcke sind nun in `<informalexample>` gewrappt; die jeweilige Enum-Definition (`Suit`, `UserStatus`, `Size`) wird vor dem Beispielcode wiederholt, damit jedes Beispiel eigenständig läuft.
- Beispiele, die nicht eigenständig laufen können, sind mit `annotations="non-interactive"` markiert.
- Einzeiler-Platzhalter (`$a === $b; // true`) wurden durch sichtbar ausgebende Varianten ersetzt (`if (...) { print ...; }`, `var_dump`, `printf` mit `htmlentities`); die `get_stuff_from_database`-Stelle hat jetzt einen vollständigen Stub.
- Fehlermeldung aktualisiert: `Cannot acquire reference to property Suit::$value` → `Cannot indirectly modify readonly property Suit::$value`.
- Fehlermeldung aktualisiert: `is not a valid scalar value for enum "Suit"` → `is not a valid backing scalar value for enum Suit`.
- Reihenfolge des `from()`/`tryFrom()`-Beispiels gemäß EN angepasst.

Deutsche Prosa und übersetzte Code-Kommentare wurden bewusst beibehalten. Bestehender `Maintainer:` (samesch) wurde beibehalten.

Schließt indirekt #88 (der ursprüngliche `static`/`self`-Fix war bereits via `Sync with EN` in `bff9d5eb87` enthalten; mit diesem Sync ist die Datei jetzt vollständig auf dem aktuellen Stand).