### PR TITLE
[Sync EN] Major rewrite of the setcookie reference page

### DIFF
--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -314,7 +314,7 @@ setcookie("TestCookie", $value, time()+3600, "/~rasmus/", "example.com", true);
 // ein bestimmtes Cookie ausgeben
 echo $_COOKIE["TestCookie"];
 
-// Ein anderer Weg zu Debuggen/Testen ist, alle Cookies anzuzeigen
+// Eine weitere Möglichkeit zum Debuggen/Testen ist, alle Cookies anzuzeigen
 print_r($_COOKIE);
 ?>
 ]]>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -311,7 +311,7 @@ setcookie("TestCookie", $value, time()+3600, "/~rasmus/", "example.com", true);
    <programlisting role="php">
 <![CDATA[
 <?php
-// ein bestimmtes Cookie ausgeben
+// Ein bestimmtes Cookie ausgeben
 echo $_COOKIE["TestCookie"];
 
 // Eine weitere Möglichkeit zum Debuggen/Testen ist, alle Cookies anzuzeigen

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -99,7 +99,7 @@
      <term><parameter>path</parameter></term>
      <listitem>
       <simpara>
-       Der Pfad auf dem Server, innerhalb dem das Cookie verfügbar sein wird.
+       Der Pfad auf dem Server, in dem das Cookie verfügbar sein wird.
        Ist er auf <literal>'/'</literal> gesetzt, wird das Cookie innerhalb
        der gesamten <parameter>domain</parameter> verfügbar. Ist er auf
        <literal>'/foo/'</literal> gesetzt, wird das Cookie nur innerhalb des

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -333,7 +333,7 @@ print_r($_COOKIE);
    <programlisting role="php">
 <![CDATA[
 <?php
-// Setzen des Verfalls-Zeitpunktes auf 1 Stunde in der Vergangenheit
+// Setzen des Verfallszeitpunktes auf 1 Stunde in der Vergangenheit
 setcookie("TestCookie", "", time() - 3600);
 setcookie("TestCookie", "", time() - 3600, "/~rasmus/", "example.com", 1);
 ?>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -343,7 +343,7 @@ setcookie("TestCookie", "", time() - 3600, "/~rasmus/", "example.com", 1);
   <example>
    <title><function>setcookie</function> und Arrays</title>
    <simpara>
-    Mit der Array-Schreibweise im Cookienamen kann ein „Array von Cookies“
+    Mit der Array-Schreibweise im Cookienamen kann ein "Array von Cookies"
     gesetzt werden. Dadurch werden so viele Cookies gesetzt, wie das Array
     Elemente hat, aber wenn das Cookie vom Skript empfangen wird, werden alle
     Werte in ein einziges Array mit dem Cookienamen eingelesen:

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 1ad4e2d550953000e2441b663226300596962ef2 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 6122a8317ca0068fc71f6a5167e0a2d99166ec7c Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 7f99d5e488d161ce3b12d1dae405a283728933c3 Reviewer: samesch -->
 <refentry xml:id="function.setcookie" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -21,17 +20,14 @@
    <methodparam choice="opt"><type>bool</type><parameter>secure</parameter><initializer>&false;</initializer></methodparam>
    <methodparam choice="opt"><type>bool</type><parameter>httponly</parameter><initializer>&false;</initializer></methodparam>
   </methodsynopsis>
-  <para>
-   Alternative Signatur, verfügbar ab PHP 7.3.0 (benannte Parameter werden
-   nicht unterstützt):
-  </para>
+  <simpara>Alternative Signatur, verfügbar ab PHP 7.3.0 (benannte Parameter werden nicht unterstützt):</simpara>
   <methodsynopsis>
    <type>bool</type><methodname>setcookie</methodname>
    <methodparam><type>string</type><parameter>name</parameter></methodparam>
    <methodparam choice="opt"><type>string</type><parameter>value</parameter><initializer>""</initializer></methodparam>
    <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    <function>setcookie</function> definiert ein mit den
    HTTP-Header-Informationen zu übertragendes Cookie. Wie andere Header auch,
    müssen Cookies <emphasis>vor</emphasis> jeglicher Ausgabe des Skripts
@@ -39,12 +35,12 @@
    dass diese Funktion vor jeglicher Ausgabe, einschließlich der Ausgabe von
    <literal>&lt;html&gt;</literal>- oder <literal>&lt;head&gt;</literal>-Tags
    sowie jeder Art von Whitespace, aufgerufen werden muss.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Sind die Cookies einmal gesetzt, kann beim nächsten Seitenaufruf anhand des
    <varname>$_COOKIE</varname>-Arrays auf diese zugegriffen werden. Die
    Cookie-Werte können auch in <varname>$_REQUEST</varname> vorhanden sein.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
@@ -57,27 +53,27 @@
     <varlistentry>
      <term><parameter>name</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Der Name des Cookies.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>value</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Der Wert des Cookies. Dieser Wert wird auf dem Computer des Benutzers
        gespeichert, weshalb darin keine sensiblen Informationen gespeichert
        werden sollten. Angenommen der Parameter <parameter>name</parameter>
        ist 'cookiename', so erhält man seinen Wert mittels
        <varname>$_COOKIE['cookiename']</varname>.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>expires_or_options</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Der Zeitpunkt, an dem das Cookie ungültig wird. Dies ist ein
        Unix-Timestamp, also die Anzahl Sekunden seit Beginn der Unix-Epoche
        (1. Januar 1970). Eine Möglichkeit, diesen festzulegen, besteht darin,
@@ -88,24 +84,21 @@
        <function>mktime</function> zu verwenden. Wenn dieser Parameter auf
        <literal>0</literal> gesetzt oder weggelassen wird, verfällt das Cookie
        am Ende der Session (wenn der Browser geschlossen wird).
-      </para>
-      <para>
-       <note>
-        <para>
-         Wie bestimmt aufgefallen ist, wird der Parameter
-         <parameter>expires_or_options</parameter> als Unix-Timestamp
-         übergeben und nicht im Datumsformat <literal>Wdy, DD-Mon-YYYY
-         HH:MM:SS GMT</literal>. Die Konvertierung wird von PHP intern
-         durchgeführt.
-        </para>
-       </note>
-      </para>
+      </simpara>
+      <note>
+       <simpara>
+        Der Parameter <parameter>expires_or_options</parameter> erwartet einen
+        Unix-Timestamp und nicht das Datumsformat <literal>Wdy, DD-Mon-YYYY
+        HH:MM:SS GMT</literal>, da die Konvertierung von PHP intern
+        durchgeführt wird.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>path</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Der Pfad auf dem Server, innerhalb dem das Cookie verfügbar sein wird.
        Ist er auf <literal>'/'</literal> gesetzt, wird das Cookie innerhalb
        der gesamten <parameter>domain</parameter> verfügbar. Ist er auf
@@ -114,13 +107,13 @@
        wie &zb; <literal>/foo/bar/</literal> von <parameter>domain</parameter>
        verfügbar. Der Standardwert ist das aktuelle Verzeichnis, in dem das
        Cookie gesetzt wurde.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>domain</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Die (Sub)-Domain, der das Cookie zur Verfügung steht. Wird dies auf
        eine Subdomain (wie <literal>'www.example.com'</literal>) gesetzt, dann
        steht dieser Subdomain und allen anderen Subdomains davon (&zb;
@@ -128,19 +121,19 @@
        Domain zur Verfügung zu stellen (einschließlich aller Subdomains
        davon), muss der Wert einfach auf den Domainnamen (in diesem Fall
        <literal>'example.com'</literal>) gesetzt werden.
-      </para>
-      <para>
+      </simpara>
+      <simpara>
        Ältere Browser, die noch immer das veraltete
        <link xlink:href="&url.rfc;2109">RFC 2109</link> implementieren, können
        ein führendes <literal>.</literal> benötigen, um alle Subdomains
        abzudecken.
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>secure</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Gibt an, dass das Cookie vom Client nur über eine sichere
        HTTPS-Verbindung übertragen werden soll. Ist der Wert auf &true;
        gesetzt, wird das Cookie nur gesendet, wenn eine sichere Verbindung
@@ -148,13 +141,13 @@
        achten, dass entsprechende Cookies über eine sichere Verbindung
        gesendet werden (&zb; unter Berücksichtigung von
        <varname>$_SERVER["HTTPS"]</varname>).
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>httponly</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Wenn auf &true; gesetzt, ist das Cookie nur via HTTP-Protokoll
        zugänglich. Das bedeutet, dass das Cookie nicht mehr für Skriptsprachen
        wie &zb; JavaScript, auslesbar/veränderbar ist. Es wird vermutet, dass
@@ -162,36 +155,43 @@
        Identitätsdiebstahl per XSS-Angriff zu vermindern (obwohl sie nicht von
        allen Browsern unterstützt wird), diese Behauptung wird jedoch oft
        angezweifelt. &true; oder &false;
-      </para>
+      </simpara>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term><parameter>options</parameter></term>
      <listitem>
-      <para>
+      <simpara>
        Ein assoziatives <type>&array;</type>, das die Schlüssel
        <literal>expires</literal>, <literal>path</literal>,
        <literal>domain</literal>, <literal>secure</literal>,
        <literal>httponly</literal> und <literal>samesite</literal> enthalten
-       kann. Ist irgendein anderer Schlüssel vorhanden, wird ein Fehler der
-       Stufe <constant>E_WARNING</constant> generiert. Die Werte haben
-       dieselbe Bedeutung wie für die gleichnamigen Parameter beschrieben. Der
-       Wert des <literal>samesite</literal>-Elements sollte entweder
-       <literal>None</literal>, <literal>Lax</literal> oder
+       kann.
+      </simpara>
+      <simpara>
+       Die Werte haben dieselbe Bedeutung wie für die gleichnamigen Parameter
+       beschrieben. Der Wert des <literal>samesite</literal>-Elements sollte
+       entweder <literal>None</literal>, <literal>Lax</literal> oder
        <literal>Strict</literal> sein. Ist eine der erlaubten Optionen nicht
        angegeben, dann ist ihr Standardwert derselbe wie für den expliziten
        Parameter. Wird das <literal>samesite</literal>-Element nicht
        angegeben, dann wird kein SameSite-Cookie-Attribut gesetzt.
-      </para>
-      <para>
-       <note>
-        <para>
-         Um ein Cookie mit Attributen zu setzen, die nicht unter den
-         aufgelisteten Schlüsseln sind, kann die Funktion
-         <function>header</function> verwendet werden.
-        </para>
-       </note>
-      </para>
+      </simpara>
+
+      <note>
+       <simpara>
+        Um ein Cookie mit Attributen zu setzen, die nicht unter den
+        aufgelisteten Schlüsseln sind, kann die Funktion
+        <function>header</function> verwendet werden.
+       </simpara>
+      </note>
+      <note>
+       <simpara>
+        Wenn <literal>samesite</literal> auf <literal>"None"</literal> gesetzt
+        ist, muss auch <literal>secure</literal> aktiviert sein, da das Cookie
+        sonst vom Client blockiert wird.
+       </simpara>
+      </note>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -200,83 +200,115 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Erfolgt eine Ausgabe vor dem Aufruf dieser Funktion, wird
    <function>setcookie</function> fehlschlagen und &false; zurückgeben. Wenn
    <function>setcookie</function> erfolgreich durchgeführt wird, wird &true;
    zurückgegeben. Dies sagt jedoch nichts darüber aus, ob der Benutzer das
    Cookie auch akzeptiert hat.
-  </para>
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Wenn das <parameter>options</parameter>-Array nicht unterstützte Schlüssel
+   enthält:
+  </simpara>
+  <itemizedlist>
+   <listitem>
+    <simpara>
+     Vor PHP 8.0.0 wurde ein <constant>E_WARNING</constant> erzeugt.
+    </simpara>
+   </listitem>
+   <listitem>
+    <simpara>
+     Ab PHP 8.0.0 wird ein <exceptionname>ValueError</exceptionname> geworfen.
+    </simpara>
+   </listitem>
+  </itemizedlist>
  </refsect1>
 
  <refsect1 role="changelog">
   &reftitle.changelog;
-  <para>
-   <informaltable>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>&Version;</entry>
-       <entry>&Description;</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>8.2.0</entry>
-       <entry>
-        Das Datumsformat des gesendeten Cookies ist nun
-        <literal>'D, d M Y H:i:s \G\M\T'</literal>; vorher war es
-        <literal>'D, d-M-Y H:i:s T'</literal>.
-       </entry>
-      </row>
-      <row>
-       <entry>7.3.0</entry>
-       <entry>
-        Eine alternative Signatur, die ein
-        <parameter>options</parameter>-Array unterstützt, wurde hinzugefügt.
-        Diese Signatur unterstützt auch das Setzen des
-        SameSite-Cookie-Attributs.
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </para>
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.2.0</entry>
+      <entry>
+       Das Datumsformat des gesendeten Cookies ist nun
+       <literal>'D, d M Y H:i:s \G\M\T'</literal>; vorher war es
+       <literal>'D, d-M-Y H:i:s T'</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Die Übergabe nicht unterstützter Schlüssel wirft nun einen
+       <exceptionname>ValueError</exceptionname>, anstatt ein
+       <constant>E_WARNING</constant> auszulösen.
+      </entry>
+     </row>
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Eine alternative Signatur, die ein
+       <parameter>options</parameter>-Array unterstützt, wurde hinzugefügt.
+       Diese Signatur unterstützt auch das Setzen des
+       SameSite-Cookie-Attributs.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   Die folgenden Beispiele zeigen einige Möglichkeiten, Cookies zu senden.
-   <example>
-    <title><function>setcookie</function>-Beispiele</title>
-    <programlisting role="php">
+  <simpara>
+   Die Auswirkungen der folgenden Beispiele lassen sich in der Cookie-Liste
+   der Entwicklerwerkzeuge des Browsers beobachten (in der Regel im Tab
+   Speicher oder Anwendung).
+  </simpara>
+  <example>
+   <title><function>setcookie</function>-Beispiele</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 
 $value = 'irgendetwas von irgendwo';
 
+// Setzt ein "Session-Cookie", das beim Schließen des Browsers verfällt
 setcookie("TestCookie", $value);
-setcookie("TestCookie", $value, time()+3600);  /* verfällt in 1 Stunde */
+// Setzt ein Cookie, das in 1 Stunde verfällt
+setcookie("TestCookie", $value, time()+3600);
+// Setzt ein Cookie, das nur für einen bestimmten Pfad einer bestimmten Domain gilt
+// Es ist zu beachten, dass die verwendete Domain mit der Site-Domain übereinstimmen sollte
 setcookie("TestCookie", $value, time()+3600, "/~rasmus/", "example.com", true);
 
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   Zu beachten ist, dass der Wertebereich des Cookies automatisch URL-konform
-   kodiert (urlencoded) wird, sobald das Cookie gesendet wird, und es beim
-   Erhalt automatisch dekodiert und einer Variablen zugewiesen wird, die
-   denselben Namen wie das Cookie trägt. Wenn dies nicht gewünscht ist, kann
-   stattdessen <function>setrawcookie</function> verwendet werden. Um die
-   Inhalte unseres Test-Cookies in einem Skript sichtbar zu machen, kann
-   einfach eines der folgenden Beispiele verwendet werden:
-  </para>
-  <para>
-   <informalexample>
-    <programlisting role="php">
+   </programlisting>
+  </example>
+  <simpara>
+   Zu beachten ist, dass der Wertebereich des Cookies automatisch von PHP
+   URL-konform kodiert (urlencoded) und wieder dekodiert wird. Dies kann
+   vermieden werden, indem stattdessen <function>setrawcookie</function>
+   verwendet wird.
+  </simpara>
+  <simpara>
+   Um den Inhalt der im obigen Beispiel gesetzten Cookies in einem späteren
+   Request zu sehen:
+  </simpara>
+  <informalexample>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // ein bestimmtes Cookie ausgeben
@@ -286,19 +318,19 @@ echo $_COOKIE["TestCookie"];
 print_r($_COOKIE);
 ?>
 ]]>
-    </programlisting>
-   </informalexample>
-  </para>
-  <para>
-   <example>
-    <title><function>setcookie</function>-Beispiele zum Löschen</title>
-    <para>
-     Beim Löschen eines Cookies sollte sichergestellt werden, dass das
-     Verfallsdatum in der Vergangenheit liegt, um den Mechanismus zum Löschen
-     des Cookies im Browser auszulösen. Die folgenden Beispiele zeigen, wie
-     die im vorigen Beispiel gesendeten Cookies wieder gelöscht werden:
-    </para>
-    <programlisting role="php">
+   </programlisting>
+  </informalexample>
+  <example>
+   <title><function>setcookie</function>-Beispiele zum Löschen</title>
+   <simpara>
+    Um ein Cookie zu löschen, muss das Verfallsdatum auf einen Wert in der
+    Vergangenheit gesetzt werden (jedoch nicht auf null, was für
+    Session-Cookies reserviert ist).
+   </simpara>
+   <simpara>
+    Um die im vorigen Beispiel gesetzten Cookies zu löschen:
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Setzen des Verfalls-Zeitpunktes auf 1 Stunde in der Vergangenheit
@@ -306,19 +338,17 @@ setcookie("TestCookie", "", time() - 3600);
 setcookie("TestCookie", "", time() - 3600, "/~rasmus/", "example.com", 1);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title><function>setcookie</function> und Arrays</title>
-    <para>
-     Mit der Array-Schreibweise im Cookienamen kann auch ein Array von Cookies
-     gesetzt werden. Dadurch werden so viele Cookies gesetzt, wie das Array
-     Elemente hat, aber wenn das Cookie vom Skript empfangen wird, werden alle
-     Werte in ein einziges Array mit dem Cookienamen eingelesen:
-    </para>
-    <programlisting role="php">
+   </programlisting>
+  </example>
+  <example>
+   <title><function>setcookie</function> und Arrays</title>
+   <simpara>
+    Mit der Array-Schreibweise im Cookienamen kann ein „Array von Cookies“
+    gesetzt werden. Dadurch werden so viele Cookies gesetzt, wie das Array
+    Elemente hat, aber wenn das Cookie vom Skript empfangen wird, werden alle
+    Werte in ein einziges Array mit dem Cookienamen eingelesen:
+   </simpara>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Setzen der Cookies
@@ -336,40 +366,38 @@ if (isset($_COOKIE['cookie'])) {
 }
 ?>
 ]]>
-    </programlisting>
-    &example.outputs;
-    <screen>
+   </programlisting>
+   &example.outputs;
+   <screen>
 <![CDATA[
 drei : cookiedrei
 zwei : cookiezwei
 eins : cookieeins
 ]]>
-    </screen>
-   </example>
-   <note>
-    <simpara>
-     Die Verwendung von Trennzeichen wie <literal>[</literal> und
-     <literal>]</literal> als Teil des Cookie-Namens ist nicht konform mit RFC
-     6265, Abschnitt 4, soll aber laut RFC 6265, Abschnitt 5, von User-Agents
-     unterstützt werden.
-    </simpara>
-   </note>
-  </para>
+   </screen>
+  </example>
+  <note>
+   <simpara>
+    Die Verwendung von Trennzeichen wie <literal>[</literal> und
+    <literal>]</literal> als Teil des Cookie-Namens ist nicht konform mit RFC
+    6265, Abschnitt 4, soll aber laut RFC 6265, Abschnitt 5, von User-Agents
+    unterstützt werden.
+   </simpara>
+  </note>
  </refsect1>
 
  <refsect1 role="notes">
   &reftitle.notes;
   <note>
-   <para>
-    Sie können den Ausgabepuffer verwenden, um Ausgaben vor dem Aufruf dieser
-    Funktion duchführen zu können. Dies hat allerdings zur Folge, dass alle
-    Ihre Ausgaben zum Browser auf dem Server zwischengespeichert werden, bis
-    Sie diese senden. Sie können dies in Ihrem Skript mittels der Funktionen
-    <function>ob_start</function> und <function>ob_end_flush</function> oder
-    mittels der Konfigurationseinstellung <literal>output_buffering</literal>
-    in Ihrer &php.ini;, oder Sie ändern entsprechende
-    Konfigurationseinstellungen am Server.
-   </para>
+   <simpara>
+    Mit Hilfe der Ausgabepufferung lassen sich Ausgaben vor dem Aufruf dieser
+    Funktion zulassen. Alle Ausgaben werden gepuffert, bis sie geleert werden
+    (entweder explizit oder am Ende der Skriptausführung). Dies wird durch
+    Aufruf von <function>ob_start</function> und
+    <function>ob_end_flush</function> im Skript erreicht oder durch Aktivieren
+    der Konfigurationseinstellung <literal>output_buffering</literal> in der
+    &php.ini; oder in den Serverkonfigurationsdateien.
+   </simpara>
   </note>
   <para>
    Häufige Probleme:
@@ -378,8 +406,8 @@ eins : cookieeins
      <simpara>
       Cookies werden erst beim nächsten Laden einer Seite sichtbar, für die
       das Cookie sichtbar sein soll. Um zu testen, ob ein Cookie erfolgreich
-      gesetzt wurde, prüfen Sie noch vor der Ablaufzeit auf der nächsten
-      geladenen Seite, ob das Cookie vorhanden ist. Die Ablaufzeit wird
+      gesetzt wurde, ist noch vor der Ablaufzeit auf der nächsten geladenen
+      Seite zu prüfen, ob das Cookie vorhanden ist. Die Ablaufzeit wird
       mittels des Parameters <parameter>expires_or_options</parameter>
       gesetzt. Eine gute Möglichkeit, die Existenz von Cookies zu prüfen, ist
       einfach <literal>print_r($_COOKIE);</literal> aufzurufen.
@@ -399,20 +427,20 @@ eins : cookieeins
     <listitem>
      <simpara>
       Da beim Setzen eines Cookies mit dem Wert &false; versucht wird, das
-      entsprechende Cookie zu löschen, sollten Sie keine boolschen Werte
-      verwenden. Nutzen Sie statt dessen <emphasis>0</emphasis> für &false;
-      und <emphasis>1</emphasis> für &true;.
+      entsprechende Cookie zu löschen, sollten keine boolschen Werte
+      verwendet werden. Stattdessen sollte <emphasis>0</emphasis> für &false;
+      und <emphasis>1</emphasis> für &true; verwendet werden.
      </simpara>
     </listitem>
     <listitem>
      <simpara>
       Namen von Cookies können auch als Arraynamen gesetzt werden und stehen
-      dann in Ihren Skripten als Arrays zu Verfügung, während sie auf dem
-      System des Benutzers als separate Cookies abgespeichert werden. Erwägen
-      Sie den Einsatz von <function>explode</function>, um ein Cookie mit
-      mehreren Namen und Werten zu setzen. Es ist nicht empfehlenswert, zu
-      diesem Zweck <function>serialize</function> einzusetzen, da hieraus
-      Sicherheitslöcher erwachsen können.
+      dann in den PHP-Skripten als Arrays zur Verfügung, während sie vom
+      Browser als separate Cookies abgespeichert werden. Es ist der Einsatz
+      von <function>json_encode</function> in Erwägung zu ziehen, um ein
+      Cookie mit mehreren Namen und Werten zu setzen. Es ist nicht
+      empfehlenswert, zu diesem Zweck <function>serialize</function>
+      einzusetzen, da hieraus Sicherheitslöcher erwachsen können.
      </simpara>
     </listitem>
    </itemizedlist>
@@ -425,15 +453,13 @@ eins : cookieeins
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>header</function></member>
-    <member><function>setrawcookie</function></member>
-    <member><link linkend="features.cookies">Cookies</link></member>
-    <member><link xlink:href="&url.rfc;6265">RFC 6265</link></member>
-    <member><link xlink:href="&url.rfc;2109">RFC 2109</link></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>header</function></member>
+   <member><function>setrawcookie</function></member>
+   <member><link linkend="features.cookies">Cookies</link></member>
+   <member><link xlink:href="&url.rfc;6265">RFC 6265</link></member>
+   <member><link xlink:href="&url.rfc;2109">RFC 2109</link></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -275,7 +275,7 @@
   <simpara>
    Die Auswirkungen der folgenden Beispiele lassen sich in der Cookie-Liste
    der Entwicklerwerkzeuge des Browsers beobachten (in der Regel im Tab
-   Speicher oder Anwendung).
+  "Speicher" im Firefox oder "Anwendung" in Chrome).
   </simpara>
   <example>
    <title><function>setcookie</function>-Beispiele</title>

--- a/reference/network/functions/setcookie.xml
+++ b/reference/network/functions/setcookie.xml
@@ -151,10 +151,9 @@
        Wenn auf &true; gesetzt, ist das Cookie nur via HTTP-Protokoll
        zugänglich. Das bedeutet, dass das Cookie nicht mehr für Skriptsprachen
        wie &zb; JavaScript, auslesbar/veränderbar ist. Es wird vermutet, dass
-       diese Einstellung eine effektive Hilfe sein kann, um
-       Identitätsdiebstahl per XSS-Angriff zu vermindern (obwohl sie nicht von
-       allen Browsern unterstützt wird), diese Behauptung wird jedoch oft
-       angezweifelt. &true; oder &false;
+       diese Einstellung helfen kann, Identitätsdiebstahl durch XSS-Angriffe zu
+       vermindern, auch wenn sie nicht von allen Browsern unterstützt wird.
+       Diese Behauptung wird jedoch oft angezweifelt. &true; oder &false;
       </simpara>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Sync `reference/network/functions/setcookie.xml` with upstream `6122a8317c`. Most inline `<para>` switched to `<simpara>`, prose moved to impersonal style, new errors section (`E_WARNING` before PHP 8.0.0, `ValueError` as of 8.0.0 for unrecognised `options` keys) and the matching changelog row, plus the `samesite="None"` requires `secure=true` note. Examples and common pitfalls refreshed. Maintainer `sammywg` and `Reviewed: yes` kept.