### PR TITLE
Translate ldap_exop and ldap_exop_sync (PHP 8.4)

### DIFF
--- a/reference/ldap/functions/ldap-exop-sync.xml
+++ b/reference/ldap/functions/ldap-exop-sync.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.ldap-exop-sync" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ldap_exop_sync</refname>
+  <refpurpose>Führt eine erweiterte LDAP-Operation aus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>LDAP\Result</type><type>bool</type></type><methodname>ldap_exop_sync</methodname>
+   <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
+   <methodparam><type>string</type><parameter>request_oid</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Führt eine erweiterte Operation auf der angegebenen
+   <parameter>ldap</parameter>-Verbindung aus, wobei <parameter>request_oid</parameter>
+   die <acronym>OID</acronym> der Operation und <parameter>request_data</parameter>
+   die Daten enthält.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <simpara>
+      &ldap.parameter.ldap;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_oid</parameter></term>
+    <listitem>
+     <simpara>
+      Die <acronym>OID</acronym> der erweiterten Operation. Es kann eine der
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>-Konstanten
+      oder ein String mit der <acronym>OID</acronym> der Operation sein.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_data</parameter></term>
+    <listitem>
+     <simpara>
+      Die Daten der Anfrage zur erweiterten Operation. Bei einigen Operationen
+      wie <constant>LDAP_EXOP_WHO_AM_I</constant> kann dieser Parameter
+      &null; sein; gegebenenfalls müssen die Daten
+      <acronym>BER</acronym>-kodiert vorliegen.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>controls</parameter></term>
+    <listitem>
+     <simpara>
+      Ein Array von <link linkend="ldap.controls">LDAP-Controls</link>, das mit
+      der Anfrage gesendet wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_data</parameter></term>
+    <listitem>
+     <simpara>
+      Wird, falls angegeben, mit den Antwortdaten der erweiterten Operation
+      befüllt. Andernfalls kann <function>ldap_parse_exop</function> später auf
+      dem Ergebnisobjekt aufgerufen werden, um diese Daten zu erhalten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_oid</parameter></term>
+    <listitem>
+     <simpara>
+      Wird, falls angegeben, mit der Antwort-<acronym>OID</acronym> befüllt,
+      die in der Regel der Anfrage-<acronym>OID</acronym> entspricht.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Wird der Parameter <parameter>response_data</parameter> verwendet, gibt die
+   Funktion bei Erfolg &true; und im Fehlerfall &false; zurück.
+   Wird er nicht verwendet, gibt sie eine Ergebniskennung oder im Fehlerfall
+   &false; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ldap_exop</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9faf0215daa7a2b5d84525d7d2b3d6b066cc85ec Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.ldap-exop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ldap_exop</refname>
+  <refpurpose>Führt eine erweiterte LDAP-Operation aus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>ldap_exop</methodname>
+   <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
+   <methodparam><type>string</type><parameter>request_oid</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>request_data</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>controls</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter role="reference">response_data</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter role="reference">response_oid</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Führt eine erweiterte Operation auf der angegebenen
+   <parameter>ldap</parameter>-Verbindung aus, wobei <parameter>request_oid</parameter>
+   die <acronym>OID</acronym> der Operation und <parameter>request_data</parameter>
+   die Daten enthält.
+  </simpara>
+  <warning>
+   <simpara>
+    Die Verwendung von mehr als 4 Parametern ist veraltet. Stattdessen sollte
+    <function>ldap_exop_sync</function> verwendet werden.
+   </simpara>
+  </warning>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <simpara>
+      &ldap.parameter.ldap;
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_oid</parameter></term>
+    <listitem>
+     <simpara>
+      Die <acronym>OID</acronym> der erweiterten Operation. Es kann eine der
+      <constant>LDAP_EXOP_<replaceable>*</replaceable></constant>-Konstanten
+      oder ein String mit der <acronym>OID</acronym> der Operation sein.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>request_data</parameter></term>
+    <listitem>
+     <simpara>
+      Die Daten der Anfrage zur erweiterten Operation. Bei einigen Operationen
+      wie <constant>LDAP_EXOP_WHO_AM_I</constant> kann dieser Parameter
+      &null; sein; gegebenenfalls müssen die Daten
+      <acronym>BER</acronym>-kodiert vorliegen.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>controls</parameter></term>
+    <listitem>
+     <simpara>
+      Ein Array von <link linkend="ldap.controls">LDAP-Controls</link>, das mit
+      der Anfrage gesendet wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_data</parameter></term>
+    <listitem>
+     <simpara>
+      Wird, falls angegeben, mit den Antwortdaten der erweiterten Operation
+      befüllt. Andernfalls kann <function>ldap_parse_exop</function> später auf
+      dem Ergebnisobjekt aufgerufen werden, um diese Daten zu erhalten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>response_oid</parameter></term>
+    <listitem>
+     <simpara>
+      Wird, falls angegeben, mit der Antwort-<acronym>OID</acronym> befüllt,
+      die in der Regel der Anfrage-<acronym>OID</acronym> entspricht.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Wird der Parameter <parameter>response_data</parameter> verwendet, gibt die
+   Funktion bei Erfolg &true; und im Fehlerfall &false; zurück.
+   Wird er nicht verwendet, gibt sie eine Ergebniskennung oder im Fehlerfall
+   &false; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Die Verwendung von mehr als 4 Parametern ist veraltet. Stattdessen
+       sollte <function>ldap_exop_sync</function> verwendet werden.
+      </entry>
+     </row>
+     &ldap.changelog.ldap-object;
+     <row>
+      <entry>7.3.0</entry>
+      <entry>
+       Unterstützung für <parameter>controls</parameter> hinzugefügt.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+    <title>Whoami-Erweiterungsoperation</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$ds = ldap_connect("localhost");  // Es wird angenommen, dass der LDAP-Server auf diesem Host läuft
+
+if ($ds) {
+    // Mit einem geeigneten DN binden, das Schreibrechte besitzt
+    $bind = ldap_bind($ds, "cn=root, o=My Company, c=US", "secret");
+    if (!$bind) {
+      echo "Unable to bind to LDAP server";
+      exit;
+    }
+
+    // WHOAMI-EXOP aufrufen
+    $r = ldap_exop($ds, LDAP_EXOP_WHO_AM_I);
+
+    // Das Ergebnisobjekt auswerten
+    ldap_parse_exop($ds, $r, $retdata);
+    // Ausgabe: string(31) "dn:cn=root, o=My Company, c=US"
+    var_dump($retdata);
+
+    // Dasselbe mit dem $response_data-Parameter
+    $success = ldap_exop($ds, LDAP_EXOP_WHO_AM_I, NULL, NULL, $retdata, $retoid);
+    if ($success) {
+      var_dump($retdata);
+    }
+
+    ldap_close($ds);
+} else {
+    echo "Unable to connect to LDAP server";
+}
+?>
+]]>
+    </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>ldap_exop_sync</function></member>
+   <member><function>ldap_exop_whoami</function></member>
+   <member><function>ldap_exop_refresh</function></member>
+   <member><function>ldap_exop_passwd</function></member>
+   <member><function>ldap_parse_result</function></member>
+   <member><function>ldap_parse_exop</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ldap/functions/ldap-exop.xml
+++ b/reference/ldap/functions/ldap-exop.xml
@@ -21,8 +21,8 @@
   <simpara>
    Führt eine erweiterte Operation auf der angegebenen
    <parameter>ldap</parameter>-Verbindung aus, wobei <parameter>request_oid</parameter>
-   die <acronym>OID</acronym> der Operation und <parameter>request_data</parameter>
-   die Daten enthält.
+   die <acronym>OID</acronym> der Operation enthält und <parameter>request_data</parameter>
+   die Daten.
   </simpara>
   <warning>
    <simpara>


### PR DESCRIPTION
Translate the two LDAP extended-operation functions from upstream PR #4066: `ldap_exop` (existing function, gains the PHP 8.4 deprecation note for >4 arguments) and `ldap_exop_sync` (new in 8.4, the recommended alternative). Both pinned to EN-Revision `9faf0215da`, `Maintainer: lacatoire`, `Status: ready`, impersonal style.

Closes #246.