### PR TITLE
[Sync EN] sscanf/fscanf: Clarify negative -1 return value (#5580)

### DIFF
--- a/reference/filesystem/functions/fscanf.xml
+++ b/reference/filesystem/functions/fscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: nikic Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: nikic Status: ready -->
 <refentry xml:id="function.fscanf" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>fscanf</refname>
@@ -16,69 +15,71 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Die Funktion <function>fscanf</function> ist ähnlich zu
    <function>sscanf</function>, wobei sie ihren Input aus
    der mit <parameter>stream</parameter> angegebenen Datei liest, und
    entsprechend dem angegebenen <parameter>format</parameter>
    interpretiert.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Beliebige Whitespace-Zeichen (&zb; Leerzeichen, Tabulator etc.)
    im Format String gelten mit beliebigen Whitespace-Zeichen des
    Input-Streams als übereinstimmend. Das heißt, dass auch ein
    Tabulator (<literal>\t</literal>) im Formatstring mit einem einzigen
    Leerzeichen im Input-Stream als übereinstimmend gelten kann.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Jeder <function>fscanf</function>-Aufruf liest eine Zeile aus der Datei aus.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>stream</parameter></term>
-     <listitem>
-      &fs.file.pointer;
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Die optional zugewiesenen Werte.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     &fs.file.pointer;
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Die optional zugewiesenen Werte.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Wenn nur zwei Parameter an die Funktion übergeben wurden, werden die geparseten
-   Werte in einem Array zurückgegeben. Andernfalls gibt die Funktion die Anzahl
+   Werte als <type>array</type> zurückgegeben. Andernfalls gibt die Funktion die Anzahl
    der zugewiesenen Werte zurück. Die optionalen Parameter müssen per Referenz
    übergeben werden.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Wenn im <parameter>format</parameter> mehr Teilstrings erwartet werden,
    als in <parameter>string</parameter> verfügbar sind, wird &null; zurückgegeben.
    Bei anderen Fehlern wird &false; zurückgegeben.
-  </para>
+  </simpara>
+  <simpara>
+   Wenn optionale Parameter verwendet werden und das Ende des aus
+   <parameter>stream</parameter> gelesenen Inputs erreicht wird, bevor ein
+   Wert geparst werden konnte, wird <literal>-1</literal> zurückgegeben.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>fscanf</function>-Beispiel</title>
-    <programlisting role="php">
+  <example>
+   <title><function>fscanf</function>-Beispiel</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 $handle = fopen("users.txt", "r");
@@ -89,36 +90,31 @@ while ($userinfo = fscanf($handle, "%s\t%s\t%s\n")) {
 fclose($handle);
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
-   <example>
-    <title>Inhalt der Datei users.txt</title>
-    <programlisting role="txt">
+   </programlisting>
+  </example>
+  <example>
+   <title>Inhalt der Datei users.txt</title>
+   <programlisting role="txt">
 <![CDATA[
 javier  argonaut        pe
 hiroshi sculptor        jp
 robert  slacker us
 luigi   florist it
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>fread</function></member>
-    <member><function>fgets</function></member>
-    <member><function>fgetss</function></member>
-    <member><function>sscanf</function></member>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>fread</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>SplFileObject::fscanf</refname>
+  <refpurpose>Analysiert Input aus einer Datei entsprechend einem Format</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="SplFileObject">
+   <modifier>public</modifier> <type class="union"><type>array</type><type>int</type><type>null</type></type><methodname>SplFileObject::fscanf</methodname>
+   <methodparam><type>string</type><parameter>format</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Liest eine Zeile aus der Datei und interpretiert sie entsprechend dem
+   angegebenen <parameter>format</parameter>.
+  </simpara>
+  <simpara>
+   Beliebige Whitespace-Zeichen im <parameter>format</parameter>-String
+   entsprechen beliebigen Whitespace-Zeichen in der aus der Datei gelesenen
+   Zeile. Das heißt, dass auch ein Tabulator (<literal>\t</literal>) im
+   Formatstring einem einzelnen Leerzeichen im Input-Stream entsprechen kann.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Die optional zugewiesenen Werte.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Wenn nur ein Parameter an diese Methode übergeben wird, werden die geparsten
+   Werte als <type>array</type> zurückgegeben. Andernfalls, wenn optionale
+   Parameter übergeben werden, gibt die Methode die Anzahl der zugewiesenen
+   Werte zurück. Die optionalen Parameter müssen per Referenz übergeben werden.
+  </simpara>
+  <simpara>
+   Werden mehr Teilstrings in <parameter>format</parameter> erwartet, als in
+   der aus der Datei gelesenen Zeile verfügbar sind, wird &null; zurückgegeben.
+  </simpara>
+  <simpara>
+   Wenn optionale Parameter verwendet werden und das Ende der aus der Datei
+   gelesenen Zeile erreicht wird, bevor ein Wert geparst werden konnte, wird
+   <literal>-1</literal> zurückgegeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel mit <methodname>SplFileObject::fscanf</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$file = new SplFileObject("misc.txt");
+while ($userinfo = $file->fscanf("%s %s %s")) {
+   list ($name, $profession, $countrycode) = $userinfo;
+   // Tue etwas mit $name $profession $countrycode
+}
+?>
+]]>
+   </programlisting>
+   <simpara>Inhalt der Datei users.txt</simpara>
+   <programlisting role="txt">
+<![CDATA[
+javier   argonaut    pe
+hiroshi  sculptor    jp
+robert   slacker     us
+luigi    florist     it
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>fscanf</function></member>
+   <member><function>sscanf</function></member>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/spl/splfileobject/fscanf.xml
+++ b/reference/spl/splfileobject/fscanf.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="splfileobject.fscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>SplFileObject::fscanf</refname>
-  <refpurpose>Analysiert Input aus einer Datei entsprechend einem Format</refpurpose>
+  <refpurpose>Analysiert die Daten aus einer Datei entsprechend einem Format</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/strings/functions/sscanf.xml
+++ b/reference/strings/functions/sscanf.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 4225e50bc391ddba99e367c231463da0dc04357d Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 9947012f745f0fb6e083bce5a8c920213ff468b7 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.sscanf" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>sscanf</refname>
@@ -15,66 +14,68 @@
    <methodparam><type>string</type><parameter>format</parameter></methodparam>
    <methodparam rep="repeat"><type>mixed</type><parameter role="reference">vars</parameter></methodparam>
   </methodsynopsis>
-  <para>
+  <simpara>
    Die Funktion <function>sscanf</function> ist das Eingabegegenstück zu
    <function>printf</function>. <function>sscanf</function> liest den String
    <parameter>string</parameter> und interpretiert ihn entsprechend dem
    übergegebenen <parameter>format</parameter>-Parameter.
-  </para>
-  <para>
+  </simpara>
+  <simpara>
    Beliebige Whitespaces im Formatstring entsprechen beliebigen Whitespaces im
    Inputstring. Das heißt, dass auch ein Tabulator (<literal>\t</literal>) im
    Formatstring einem einzelnen Leerzeichen des Inputstrings entsprechen kann.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="parameters">
   &reftitle.parameters;
-  <para>
-   <variablelist>
-    <varlistentry>
-     <term><parameter>string</parameter></term>
-     <listitem>
-      <para>
-       Der zu parsende Eingabe<type>string</type>.
-      </para>
-     </listitem>
-    </varlistentry>
-    &strings.scanf.parameter.format;
-    <varlistentry>
-     <term><parameter>vars</parameter></term>
-     <listitem>
-      <para>
-       Optionale als Referenz übergebene Variablen, die die geparsten Werte
-       enthalten.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </para>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      Der zu parsende Eingabe<type>string</type>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   &strings.scanf.parameter.format;
+   <varlistentry>
+    <term><parameter>vars</parameter></term>
+    <listitem>
+     <simpara>
+      Optionale als Referenz übergebene Variablen, die die geparsten Werte
+      enthalten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </refsect1>
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Werden nur 2 Parameter an die Funktion übergeben, werden die analysierten
-   Werte als Array zurückgegeben. Andernfalls, wenn optionale Parameter
-   übergeben wurden, gibt die Funktion die Anzahl der ermittelten Werte zurück.
-   Die optionalen Parameter müssen als Referenz übergeben werden.
-  </para>
-  <para>
+   Werte als <type>array</type> zurückgegeben. Andernfalls, wenn optionale
+   Parameter übergeben wurden, gibt die Funktion die Anzahl der ermittelten
+   Werte zurück. Die optionalen Parameter müssen als Referenz übergeben werden.
+  </simpara>
+  <simpara>
    Werden mehr Teilzeichenketten in <parameter>format</parameter> erwartet
    als in <parameter>string</parameter> verfügbar sind, wird &null;
    zurückgegeben.
-  </para>
+  </simpara>
+  <simpara>
+   Wenn optionale Parameter verwendet werden und das Ende des Eingabestrings
+   <parameter>string</parameter> erreicht wird, bevor ein Wert geparst werden
+   konnte, wird <literal>-1</literal> zurückgegeben.
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">
   &reftitle.examples;
-  <para>
-   <example>
-    <title><function>sscanf</function>-Beispiel</title>
-    <programlisting role="php">
+  <example>
+   <title><function>sscanf</function>-Beispiel</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Ermittlung der Serien-Nr.
@@ -86,17 +87,15 @@ echo "Das Teil $serial wurde hergestellt am: "
      . "$jahr-" . substr($monat, 0, 3) . "-$tag\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
-  <para>
+   </programlisting>
+  </example>
+  <simpara>
    Werden optionale Parameter übergeben, gibt die Funktion die Anzahl
    der ermittelten Werte zurück.
-  </para>
-  <para>
-   <example>
-    <title><function>sscanf</function> - Verwendung optionaler Parameter</title>
-    <programlisting role="php">
+  </simpara>
+  <example>
+   <title><function>sscanf</function> - Verwendung optionaler Parameter</title>
+   <programlisting role="php">
 <![CDATA[
 <?php
 // Auslesen der Autoren-Info und Erzeugung eines DocBook-Eintrages
@@ -108,26 +107,23 @@ echo "<author id='$id'>
 </author>\n";
 ?>
 ]]>
-    </programlisting>
-   </example>
-  </para>
+   </programlisting>
+  </example>
  </refsect1>
 
  <refsect1 role="seealso">
   &reftitle.seealso;
-  <para>
-   <simplelist>
-    <member><function>printf</function></member>
-    <member><function>sprintf</function></member>
-    <member><function>fprintf</function></member>
-    <member><function>vprintf</function></member>
-    <member><function>vsprintf</function></member>
-    <member><function>vfprintf</function></member>
-    <member><function>fscanf</function></member>
-    <member><function>number_format</function></member>
-    <member><function>date</function></member>
-   </simplelist>
-  </para>
+  <simplelist>
+   <member><function>printf</function></member>
+   <member><function>sprintf</function></member>
+   <member><function>fprintf</function></member>
+   <member><function>vprintf</function></member>
+   <member><function>vsprintf</function></member>
+   <member><function>vfprintf</function></member>
+   <member><function>fscanf</function></member>
+   <member><function>number_format</function></member>
+   <member><function>date</function></member>
+  </simplelist>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Apply upstream PR #5580 to doc-de: the new `-1` return value paragraph and the structural `<para>` → `<simpara>` cleanup on the two existing files, plus a translated `SplFileObject::fscanf` page (new file). Maintainers `nikic` and `sammywg` kept on the existing files; `lacatoire` on the new one.

Closes #254.