### PR TITLE
[Sync EN] array: Updated notes for example 10 (#5578)

### DIFF
--- a/language/types/array.xml
+++ b/language/types/array.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3061900171d4ae84d532571bfd6eda823726dad4 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: bfdd82f3f6cde571a61de3fcea28a03145374dda Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: c140370c354496b38b97dfafe2e31f3f8df8bb44 Reviewer: samesch -->
 <sect1 xml:id="language.types.array">
@@ -570,13 +570,13 @@ var_dump($arr);
    </example>
 
    <note>
-    <para>
-     Wie vorher bereits erwähnt, wird, wenn kein Schlüssel angegeben ist, das
-     Maximum der bestehenden Schlüssel vom Typ <type>Int</type> verwendet und
-     der neue Schlüssel wird das Maximum plus 1 sein (aber mindestens 0). Wenn
-     noch kein <type>Int</type>-Schlüssel existiert wird der Schlüssel
-     <literal>0</literal> (Null) verwendet.
-    </para>
+    <simpara>
+     Wenn kein Schlüssel angegeben ist, wird als Schlüssel der größte
+     vorhandene Integer-Index + <literal>1</literal> verwendet. Hat das
+     <type>Array</type> noch keine positiven Integer-Indizes, ist der
+     Schlüssel <literal>0</literal>.
+     Seit PHP 8.3.0 darf es auch ein negativer Integer sein.
+    </simpara>
 
     <para>
      Zu beachten ist, dass der Maximalwert der Integer-Schlüssel dafür


### PR DESCRIPTION
Apply upstream PR #5578 to doc-de: rewrite the auto-key note in example 10 of `language/types/array.xml`. The note now states that the new key is the largest existing integer index + 1 (or 0 if there are no positive integer indices) and adds the PHP 8.3.0 mention that it can also be a negative integer. `<para>` switched to `<simpara>` to mirror EN. Maintainer `cmb` kept.

Closes #241.