### PR TITLE
[Sync EN] fiber/throw.xml Add an example (#4514)

### DIFF
--- a/language/predefined/fiber/throw.xml
+++ b/language/predefined/fiber/throw.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 8fee3ae9715ffa15922469eb7d98f4878917a6ee Maintainer: samesch Status: ready -->
+<!-- EN-Revision: b3a0b9924ba577a3abf246c1bd1a6cf5c4bf14dc Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="fiber.throw" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -46,6 +46,40 @@
    die Fiber einen Rückgabewert liefert. Wenn die Fiber eine Exception wirft,
    bevor sie unterbrochen wird, wird diese beim Aufruf dieser Methode geworfen.
   </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <informalexample>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$fiber = new Fiber(function () {
+   try {
+       // Unterbricht die Ausführung der Fiber und deklariert dabei einen Unterbrechungspunkt
+       Fiber::suspend();
+   } catch (Throwable $e) {
+       echo $e->getMessage();
+   }
+});
+
+$fiber->start();
+
+// Setzt die Ausführung der Fiber fort und übergibt
+// die Exception, die am aktuellen Unterbrechungspunkt geworfen werden soll
+$fiber->throw(new Exception('Message of an exception thrown at the current interrupt point'));
+
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Message of an exception thrown at the current interrupt point
+]]>
+   </screen>
+  </informalexample>
  </refsect1>
 
 </refentry>


### PR DESCRIPTION
Apply upstream PR #4514 to doc-de: add a new `<refsect1 role="examples">` block to `language/predefined/fiber/throw.xml` with a runnable code example showing how `Fiber::throw()` resumes a suspended fiber by re-throwing the given exception at the suspend point. Code comments translated; literal exception message and screen output kept in English. Maintainer `samesch` kept.

Closes #238.