### PR TITLE
[Sync EN] exit: Add changelog and warning about updated exit code behaviour since PHP 8.4.0 (#5579)

### DIFF
--- a/reference/funchand/functions/register-shutdown-function.xml
+++ b/reference/funchand/functions/register-shutdown-function.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b412bbd26214f7281ac7dd858710e09952a275f2 Maintainer: nikic Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: nikic Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a2be339a6624a85bc98dbfda574e370f17f2ea64 Reviewer: samesch -->
 <refentry xml:id="function.register-shutdown-function" xmlns="http://docbook.org/ns/docbook">
@@ -29,6 +28,15 @@
    aufgerufen wird, bricht die Ausführung vollständig ab und keine weiteren
    registrierten Shutdown-Funktionen werden ausgeführt.
   </para>
+  <caution>
+   <simpara>
+    Seit PHP 8.4.0 setzt ein parameterloser <function>exit</function>-Aufruf
+    innerhalb einer registrierten Shutdown-Funktion den Exit-Code auf
+    <literal>0</literal> zurück. Der Aufruf von <function>exit</function> mit
+    einem expliziten Status überschreibt in allen Versionen den vorherigen
+    Exit-Code.
+   </simpara>
+  </caution>
   <para>
    Shutdown-Funktionen können außerdem selbst
    <function>register_shutdown_function</function> aufrufen, um eine

--- a/reference/misc/functions/exit.xml
+++ b/reference/misc/functions/exit.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 2aaaf1967f2510471b694daf8e41a419fc98b751 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 2312f826e5fdedbef87c6288c2c20f9f904b4d0b Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 2aaaf1967f2510471b694daf8e41a419fc98b751 Reviewer: samesch -->
 <refentry xml:id="function.exit" xmlns="http://docbook.org/ns/docbook">
@@ -113,6 +112,17 @@
        ist von der <link linkend="language.types.declarations.strict"><literal>strict_types</literal></link>-Deklaration
        betroffen, kann mit benannten Argumenten aufgerufen werden und kann eine
        <link linkend="functions.variable-functions">Variablenfunktion</link> sein.
+      </entry>
+     </row>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Ein parameterloser <function>exit</function>-Aufruf innerhalb von
+       <link linkend="function.register-shutdown-function">Shutdown-Funktionen</link>
+       oder <link linkend="language.oop5.decon.destructor">Objekt-Destruktoren</link>
+       setzt nun den Exit-Code auf <literal>0</literal> zurück; zuvor wurde der
+       durch einen früheren <function>exit</function>-Aufruf gesetzte Exit-Code
+       beibehalten.
       </entry>
      </row>
     </tbody>


### PR DESCRIPTION
Sync of upstream PR #5579.

Closes #237.