### PR TITLE
[Sync EN] eio/constants.xml: add dots at the ends of sentences (#3562)

### DIFF
--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -115,7 +115,7 @@
     <listitem>
      <simpara>
       Wenn dieses Flag angegeben ist, werden die Namen in einer Reihenfolge zurückgegeben,
-      in der wahrscheinliche Verzeichnisse zuerst erscheinen, in optimaler stat-Reihenfolge.
+      in der wahrscheinliche Verzeichnisse zuerst erscheinen, also in der statistisch optimalen Reihenfolge.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -645,7 +645,7 @@
  <note xmlns="http://docbook.org/ns/docbook">
   <simpara>
    Die <emphasis>EIO_SYNC_FILE_*</emphasis>-Konstanten haben dieselbe Bedeutung wie ihre
-   Gegenstücke <emphasis>SYNC_FILE_**</emphasis>.
+   <emphasis>SYNC_FILE_**</emphasis>-Entsprechungen.
   </simpara>
  </note>
 

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -95,8 +95,8 @@
     </term>
     <listitem>
      <simpara>
-      Flag für <function>eio_readdir</function>. Wenn angegeben, wird das Result-Argument des Callbacks
-      zu einem Array mit den folgenden Schlüsseln:
+      Flag für <function>eio_readdir</function>. Wenn angegeben, wird das Argument
+      mit dem Ergebnis des Callbacks zu einem Array mit den folgenden Schlüsseln:
       <literal>'names'</literal> - Array der Verzeichnisnamen
       <literal>'dents'</literal> - Array von Arrays im Stil von <literal>struct eio_dirent</literal>,
       die jeweils die folgenden Schlüssel besitzen:

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -231,7 +231,7 @@
     </term>
     <listitem>
      <simpara>
-      Gemultiplextes Blockgerät (v7+coherent).
+      Multiplexiertes Blockgerät (v7+coherent).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -652,7 +652,7 @@
  <note xmlns="http://docbook.org/ns/docbook">
   <simpara>
    Die <emphasis>EIO_O_*</emphasis>-Konstanten haben dieselbe Bedeutung wie ihre
-   POSIX-Gegenstücke <emphasis>O_*</emphasis>.
+   <emphasis>O_*</emphasis>-Entsprechungen in POSIX.
   </simpara>
  </note>
 </appendix>

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -638,7 +638,7 @@
  <note xmlns="http://docbook.org/ns/docbook">
   <simpara>
    Die <emphasis>EIO_S_I*</emphasis>-Konstanten haben dieselbe Bedeutung wie ihre
-   POSIX-Gegenstücke <emphasis>S_I*</emphasis>.
+    <emphasis>S_I*</emphasis>-Entsprechungen in POSIX.
   </simpara>
  </note>
 

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -187,7 +187,7 @@
     </term>
     <listitem>
      <simpara>
-      Knotentyp für ein gemultiplextes Zeichengerät (v7+coherent).
+      Knotentyp für ein multiplexiertes Zeichengerät (v7+coherent).
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/constants.xml
+++ b/reference/eio/constants.xml
@@ -1,0 +1,677 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 2132501990f8e139a75021165634830f1f6a90e1 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="eio.constants">
+ &reftitle.constants;
+ &extension.constants;
+
+ <para>Konstanten für die Priorität von Anfragen:
+  <variablelist>
+<!--{{{ EIO_PRI_* -->
+   <varlistentry xml:id="constant.eio-pri-min">
+    <term>
+     <constant>EIO_PRI_MIN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Minimale Priorität der Anfrage.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-pri-default">
+    <term>
+     <constant>EIO_PRI_DEFAULT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Standardpriorität der Anfrage.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-pri-max">
+    <term>
+     <constant>EIO_PRI_MAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Maximale Priorität der Anfrage.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <!--}}}-->
+  </variablelist>
+ </para>
+
+ <para>Parameter <parameter>whence</parameter> von <function>eio_seek</function>:
+  <variablelist>
+   <varlistentry xml:id="constant.eio-seek-set">
+    <term>
+     <constant>EIO_SEEK_SET</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Die Position wird auf die angegebene Anzahl von Bytes (<parameter>offset</parameter>) gesetzt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-seek-cur">
+    <term>
+     <constant>EIO_SEEK_CUR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Die Position wird auf die aktuelle Stelle plus <parameter>offset</parameter> Bytes gesetzt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-seek-end">
+    <term>
+     <constant>EIO_SEEK_END</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Die Position wird auf die Dateigröße plus <parameter>offset</parameter> Bytes gesetzt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </para>
+
+ <para>
+  Flags für <function>eio_readdir</function>:
+  <variablelist>
+
+<!--{{{ EIO_READDIR_* -->
+   <varlistentry xml:id="constant.eio-readdir-dents">
+    <term>
+     <constant>EIO_READDIR_DENTS</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Flag für <function>eio_readdir</function>. Wenn angegeben, wird das Result-Argument des Callbacks
+      zu einem Array mit den folgenden Schlüsseln:
+      <literal>'names'</literal> - Array der Verzeichnisnamen
+      <literal>'dents'</literal> - Array von Arrays im Stil von <literal>struct eio_dirent</literal>,
+      die jeweils die folgenden Schlüssel besitzen:
+      <literal>'name'</literal> - der Verzeichnisname;
+      <literal>'type'</literal> - eine der <emphasis>EIO_DT_*</emphasis>-Konstanten;
+      <literal>'inode'</literal> - die Inode-Nummer, sofern verfügbar, andernfalls
+      nicht festgelegt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-readdir-dirs-first">
+    <term>
+     <constant>EIO_READDIR_DIRS_FIRST</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Wenn dieses Flag angegeben ist, werden die Namen in einer Reihenfolge zurückgegeben,
+      in der wahrscheinliche Verzeichnisse zuerst erscheinen, in optimaler stat-Reihenfolge.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-readdir-stat-order">
+    <term>
+     <constant>EIO_READDIR_STAT_ORDER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Wenn dieses Flag angegeben ist, werden die Namen in einer Reihenfolge zurückgegeben,
+      die für den Aufruf von <function>stat</function> auf jeden einzelnen Namen geeignet ist. Wenn vorgesehen ist,
+      <function>stat</function> auf alle Dateien im angegebenen Verzeichnis anzuwenden,
+      ist die zurückgegebene Reihenfolge wahrscheinlich
+      die schnellste.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-readdir-found-unknown">
+    <term>
+     <constant>EIO_READDIR_FOUND_UNKNOWN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+<!--}}}-->
+
+<!--{{{ EIO_DT_* -->
+   <varlistentry xml:id="constant.eio-dt-unknown">
+    <term>
+     <constant>EIO_DT_UNKNOWN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Unbekannter Knotentyp (sehr verbreitet). Ein weiterer Aufruf von <function>stat</function> ist erforderlich.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-fifo">
+    <term>
+     <constant>EIO_DT_FIFO</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      FIFO-Knotentyp.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-chr">
+    <term>
+     <constant>EIO_DT_CHR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-mpc">
+    <term>
+     <constant>EIO_DT_MPC</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp für ein gemultiplextes Zeichengerät (v7+coherent).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-dir">
+    <term>
+     <constant>EIO_DT_DIR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp für ein Verzeichnis.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-nam">
+    <term>
+     <constant>EIO_DT_NAM</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp für eine spezielle benannte Xenix-Datei.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-blk">
+    <term>
+     <constant>EIO_DT_BLK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-mpb">
+    <term>
+     <constant>EIO_DT_MPB</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Gemultiplextes Blockgerät (v7+coherent).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-reg">
+    <term>
+     <constant>EIO_DT_REG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-nwk">
+    <term>
+     <constant>EIO_DT_NWK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-cmp">
+    <term>
+     <constant>EIO_DT_CMP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Spezieller Netzwerk-Knotentyp unter HP-UX.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-lnk">
+    <term>
+     <constant>EIO_DT_LNK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp für einen Link.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-sock">
+    <term>
+     <constant>EIO_DT_SOCK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp für einen Socket.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-door">
+    <term>
+     <constant>EIO_DT_DOOR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp für eine Solaris-Door.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-wht">
+    <term>
+     <constant>EIO_DT_WHT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Knotentyp.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-dt-max">
+    <term>
+     <constant>EIO_DT_MAX</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Höchster Wert eines Knotentyps.
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+<!--}}}-->
+
+  </variablelist>
+ </para>
+ <para>
+  Zugriffsmodi für den Parameter <parameter>flags</parameter> von
+  <function>eio_open</function>:
+  <variablelist>
+
+<!--{{{ EIO_O_*-->
+   <varlistentry xml:id="constant.eio-o-rdonly">
+    <term>
+     <constant>EIO_O_RDONLY</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-wronly">
+    <term>
+     <constant>EIO_O_WRONLY</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-rdwr">
+    <term>
+     <constant>EIO_O_RDWR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-nonblock">
+    <term>
+     <constant>EIO_O_NONBLOCK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-append">
+    <term>
+     <constant>EIO_O_APPEND</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-creat">
+    <term>
+     <constant>EIO_O_CREAT</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-trunc">
+    <term>
+     <constant>EIO_O_TRUNC</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-excl">
+    <term>
+     <constant>EIO_O_EXCL</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-o-fsync">
+    <term>
+     <constant>EIO_O_FSYNC</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+<!--}}}-->
+
+  </variablelist>
+ </para>
+ <para>
+  Flags für den Parameter <parameter>mode</parameter> von <function>eio_open</function>:
+  <variablelist>
+
+<!--{{{ EIO_S_I*-->
+   <varlistentry xml:id="constant.eio-s-irusr">
+    <term>
+     <constant>EIO_S_IRUSR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-iwusr">
+    <term>
+     <constant>EIO_S_IWUSR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ixusr">
+    <term>
+     <constant>EIO_S_IXUSR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-irgrp">
+    <term>
+     <constant>EIO_S_IRGRP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-iwgrp">
+    <term>
+     <constant>EIO_S_IWGRP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ixgrp">
+    <term>
+     <constant>EIO_S_IXGRP</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-iroth">
+    <term>
+     <constant>EIO_S_IROTH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-iwoth">
+    <term>
+     <constant>EIO_S_IWOTH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ixoth">
+    <term>
+     <constant>EIO_S_IXOTH</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ifreg">
+    <term>
+     <constant>EIO_S_IFREG</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ifchr">
+    <term>
+     <constant>EIO_S_IFCHR</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ifblk">
+    <term>
+     <constant>EIO_S_IFBLK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ififo">
+    <term>
+     <constant>EIO_S_IFIFO</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-s-ifsock">
+    <term>
+     <constant>EIO_S_IFSOCK</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+<!--}}}-->
+
+
+  </variablelist>
+ </para>
+ <para>
+  Flags für <function>eio_sync_file_range</function>:
+  <variablelist>
+
+<!--{{{ EIO_SYNC_FILE_*-->
+   <varlistentry xml:id="constant.eio-sync-file-range-wait-before">
+    <term>
+     <constant>EIO_SYNC_FILE_RANGE_WAIT_BEFORE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-sync-file-range-write">
+    <term>
+     <constant>EIO_SYNC_FILE_RANGE_WRITE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.eio-sync-file-range-wait-after">
+    <term>
+     <constant>EIO_SYNC_FILE_RANGE_WAIT_AFTER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+<!--}}}-->
+
+
+  </variablelist>
+ </para>
+ <para>
+  Flags für <function>eio_fallocate</function>:
+  <variablelist>
+
+   <varlistentry xml:id="constant.eio-falloc-fl-keep-size">
+    <term>
+     <constant>EIO_FALLOC_FL_KEEP_SIZE</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+
+  </variablelist>
+ </para>
+
+ <note xmlns="http://docbook.org/ns/docbook">
+  <simpara>
+   Die <emphasis>EIO_S_I*</emphasis>-Konstanten haben dieselbe Bedeutung wie ihre
+   POSIX-Gegenstücke <emphasis>S_I*</emphasis>.
+  </simpara>
+ </note>
+
+ <note xmlns="http://docbook.org/ns/docbook">
+  <simpara>
+   Die <emphasis>EIO_SYNC_FILE_*</emphasis>-Konstanten haben dieselbe Bedeutung wie ihre
+   Gegenstücke <emphasis>SYNC_FILE_**</emphasis>.
+  </simpara>
+ </note>
+
+ <note xmlns="http://docbook.org/ns/docbook">
+  <simpara>
+   Die <emphasis>EIO_O_*</emphasis>-Konstanten haben dieselbe Bedeutung wie ihre
+   POSIX-Gegenstücke <emphasis>O_*</emphasis>.
+  </simpara>
+ </note>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
New translation of `reference/eio/constants.xml`.

Closes #239.