### PR TITLE
[Sync EN] Fix copy-pasted descriptions: apcu, cubrid, enchant, zmq (#5576)

### DIFF
--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -26,10 +26,9 @@
     <term><parameter>limited</parameter></term>
     <listitem>
      <simpara>
-      Wenn <parameter>limited</parameter> den Wert &true; hat, schließt der
-      Rückgabewert die einzelne Liste der Cache-Einträge aus. Dies ist
-      nützlich, wenn versucht wird, Aufrufe für die Erfassung von Statistiken
-      zu optimieren.
+      Wenn <parameter>limited</parameter> den Wert &true; hat, wird die Liste
+      der einzelnen Cache-Einträge aus dem Rückgabewert ausgeschlossen. Dies
+      ist nützlich, um Aufrufe zur Erfassung von Statistiken zu optimieren..
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -39,7 +39,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Array der zwischengespeicherten Daten (und Metadaten)&return.falseforfailure;
+   Array der zwischengespeicherten Daten (und Metadaten). &return.falseforfailure;
   </simpara>
   <note>
    <simpara>

--- a/reference/apcu/functions/apcu-cache-info.xml
+++ b/reference/apcu/functions/apcu-cache-info.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-cache-info">
+ <refnamediv>
+  <refname>apcu_cache_info</refname>
+  <refpurpose>
+   Ruft zwischengespeicherte Informationen aus dem Datenspeicher von APCu ab
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>apcu_cache_info</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>limited</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Ruft zwischengespeicherte Informationen und Metadaten aus dem Datenspeicher von APCu ab.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>limited</parameter></term>
+    <listitem>
+     <simpara>
+      Wenn <parameter>limited</parameter> den Wert &true; hat, schließt der
+      Rückgabewert die einzelne Liste der Cache-Einträge aus. Dies ist
+      nützlich, wenn versucht wird, Aufrufe für die Erfassung von Statistiken
+      zu optimieren.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Array der zwischengespeicherten Daten (und Metadaten)&return.falseforfailure;
+  </simpara>
+  <note>
+   <simpara>
+    <function>apcu_cache_info</function> löst eine Warnung aus, wenn die
+    APCu-Cache-Daten nicht abgerufen werden können. Dies tritt üblicherweise
+    auf, wenn APCu nicht aktiviert ist.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL apcu 3.0.11</entry>
+      <entry>
+       Der Parameter <parameter>limited</parameter> wurde eingeführt.
+      </entry>
+     </row>
+     <row>
+      <entry>PECL apcu 3.0.16</entry>
+      <entry>
+       Die Option "<literal>filehits</literal>" für den Parameter
+       <parameter>cache_type</parameter> wurde eingeführt.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ein Beispiel für <function>apcu_cache_info</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+print_r(apcu_cache_info());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [num_slots] => 2000
+    [ttl] => 0
+    [num_hits] => 9
+    [num_misses] => 3
+    [start_time] => 1123958803
+    [cache_list] => Array
+        (
+            [0] => Array
+                (
+                    [filename] => /path/to/apcu_test.php
+                    [device] => 29954
+                    [inode] => 1130511
+                    [type] => file
+                    [num_hits] => 1
+                    [mtime] => 1123960686
+                    [creation_time] => 1123960696
+                    [deletion_time] => 0
+                    [access_time] => 1123962864
+                    [ref_count] => 1
+                    [mem_size] => 677
+                )
+            [1] => Array (...iterates for each cached file)
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="apcu.configuration">APCu-Konfigurationsdirektiven</link></member>
+   <member><methodname>APCUIterator::getTotalSize</methodname></member>
+   <member><methodname>APCUIterator::getTotalHits</methodname></member>
+   <member><methodname>APCUIterator::getTotalCount</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/apcu/functions/apcu-key-info.xml
+++ b/reference/apcu/functions/apcu-key-info.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.apcu-key-info">
+ <refnamediv>
+  <refname>apcu_key_info</refname>
+  <refpurpose>
+   Liefert detaillierte Informationen über den Cache-Schlüssel
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>null</type></type><methodname>apcu_key_info</methodname>
+   <methodparam><type>string</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Liefert detaillierte Informationen über den Cache-Schlüssel
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <simpara>
+      Der Schlüssel, für den Informationen abgerufen werden sollen.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ein Array mit den detaillierten Informationen über den Cache-Schlüssel oder &null;, wenn der Schlüssel nicht existiert.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ein Beispiel für <function>apcu_key_info</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+apcu_add('a','b');
+var_dump(apcu_key_info('a'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(7) {
+  ["hits"]=>
+  int(0)
+  ["access_time"]=>
+  int(1606701783)
+  ["mtime"]=>
+  int(1606701783)
+  ["creation_time"]=>
+  int(1606701783)
+  ["deletion_time"]=>
+  int(0)
+  ["ttl"]=>
+  int(0)
+  ["refs"]=>
+  int(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>apcu_store</function></member>
+   <member><function>apcu_fetch</function></member>
+   <member><function>apcu_delete</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cubrid/functions/cubrid-lob2-import.xml
+++ b/reference/cubrid/functions/cubrid-lob2-import.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-lob2-import">
+ <refnamediv>
+  <refname>cubrid_lob2_import</refname>
+  <refpurpose>Importiert BLOB/CLOB-Daten aus einer Datei</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>cubrid_lob2_import</methodname>
+   <methodparam><type>resource</type><parameter>lob_identifier</parameter></methodparam>
+   <methodparam><type>string</type><parameter>file_name</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Die Funktion <function>cubrid_lob2_import</function> wird verwendet, um den
+   Inhalt von BLOB/CLOB-Daten aus einer Datei zu speichern. Um diese Funktion
+   zu verwenden, muss zuerst <function>cubrid_lob2_new</function> aufgerufen
+   oder ein LOB-Objekt aus der CUBRID-Datenbank geholt werden. Wenn die Datei
+   nicht existiert, schlägt die Operation fehl.
+   Diese Funktion beeinflusst die Cursor-Position des LOB-Objekts nicht.
+   Sie operiert auf dem gesamten LOB-Objekt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+ &reftitle.parameters;
+ <variablelist>
+  <varlistentry>
+   <term><parameter>lob_identifier</parameter></term>
+   <listitem>
+    <simpara>LOB-Identifikator als Ergebnis von <function>cubrid_lob2_new</function> oder aus dem Ergebnis-Set bezogen.</simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term><parameter>filename</parameter></term>
+   <listitem>
+    <simpara>Name der Datei, aus der BLOB/CLOB-Daten importiert werden sollen. Der Pfad der Datei wird ebenfalls unterstützt.</simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>cubrid_lob2_export</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$conn = cubrid_connect("localhost", 33000, "demodb", "dba", "");
+
+cubrid_execute($conn,"DROP TABLE if exists test_lob");
+cubrid_execute($conn,"CREATE TABLE test_lob (id INT, contents CLOB)");
+
+$req = cubrid_prepare($conn, "INSERT INTO test_lob VALUES (?, ?)");
+cubrid_bind($req, 1, 1);
+
+$lob = cubrid_lob2_new($conn, "clob");
+cubrid_lob2_import($lob, "doc_1.txt");
+cubrid_lob2_bind($req, 2, $lob, 'CLOB'); // oder cubrid_lob2_bind($req, 2, $lob);
+
+cubrid_execute($req);
+
+cubrid_lob2_close($lob);
+cubrid_disconnect($conn);
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+  <member><function>cubrid_lob2_new</function></member>
+  <member><function>cubrid_lob2_close</function></member>
+  <member><function>cubrid_lob2_export</function></member>
+  <member><function>cubrid_lob2_bind</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cubrid/functions/cubrid-pconnect.xml
+++ b/reference/cubrid/functions/cubrid-pconnect.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-pconnect">
+ <refnamediv>
+  <refname>cubrid_pconnect</refname>
+  <refpurpose>Öffnet eine dauerhafte Verbindung zu einem CUBRID-Server</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>cubrid_pconnect</methodname>
+   <methodparam><type>string</type><parameter>host</parameter></methodparam>
+   <methodparam><type>int</type><parameter>port</parameter></methodparam>
+   <methodparam><type>string</type><parameter>dbname</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>userid</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>passwd</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Stellt eine dauerhafte Verbindung zu einem CUBRID-Server her.
+  </simpara>
+  <simpara>
+   <function>cubrid_pconnect</function> verhält sich sehr ähnlich wie
+   <function>cubrid_connect</function>, mit zwei wesentlichen Unterschieden.
+  </simpara>
+  <simpara>
+   Erstens versucht die Funktion beim Verbinden zunächst, eine (dauerhafte)
+   Verbindung zu finden, die bereits mit demselben Host, Port, dbname und
+   userid geöffnet ist. Wird eine gefunden, wird stattdessen ein Identifikator
+   dafür zurückgegeben, anstatt eine neue Verbindung zu öffnen.
+  </simpara>
+  <simpara>
+   Zweitens wird die Verbindung zum SQL-Server nicht geschlossen, wenn die
+   Ausführung des Skripts endet. Stattdessen bleibt die Verbindung für die
+   spätere Verwendung offen (<function>cubrid_close</function> oder
+   <function>cubrid_disconnect</function> schließen keine Verbindungen, die
+   von <function>cubrid_pconnect</function> hergestellt wurden).
+  </simpara>
+  <simpara>
+   Diese Art von Verbindung wird deshalb als „dauerhaft“ (persistent) bezeichnet.
+  </simpara>
+ </refsect1>
+
+  <refsect1 role="parameters">
+ &reftitle.parameters;
+ <variablelist>
+  <varlistentry>
+   <term><parameter>host</parameter></term>
+   <listitem><simpara>Hostname oder IP-Adresse des CUBRID-CAS-Servers.</simpara></listitem>
+  </varlistentry>
+  <varlistentry>
+   <term><parameter>port</parameter></term>
+   <listitem><simpara>Portnummer des CUBRID-CAS-Servers (BROKER_PORT, konfiguriert in $CUBRID/conf/cubrid_broker.conf).</simpara></listitem>
+  </varlistentry>
+  <varlistentry>
+   <term><parameter>dbname</parameter></term>
+   <listitem><simpara>Name der Datenbank.</simpara></listitem>
+  </varlistentry>
+  <varlistentry>
+   <term><parameter>userid</parameter></term>
+   <listitem><simpara>Benutzername für die Datenbank.</simpara></listitem>
+  </varlistentry>
+  <varlistentry>
+   <term><parameter>passwd</parameter></term>
+   <listitem><simpara>Benutzerpasswort.</simpara></listitem>
+  </varlistentry>
+ </variablelist>
+ </refsect1>
+
+  <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+    Verbindungs-Identifikator im Erfolgsfall,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>cubrid_pconnect</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+printf("%-30s %s\n", "CUBRID PHP Version:", cubrid_version());
+
+printf("\n");
+
+$conn = cubrid_pconnect("localhost", 33000, "demodb", "dba");
+
+if (!$conn) {
+    die('Connect Error ('. cubrid_error_code() .')' . cubrid_error_msg());
+}
+
+$db_params = cubrid_get_db_parameter($conn);
+
+while (list($param_name, $param_value) = each($db_params)) {
+    printf("%-30s %s\n", $param_name, $param_value);
+}
+
+printf("\n");
+
+$server_info = cubrid_get_server_info($conn);
+$client_info = cubrid_get_client_info();
+
+printf("%-30s %s\n", "Server Info:", $server_info);
+printf("%-30s %s\n", "Client Info:", $client_info);
+
+printf("\n");
+
+$charset = cubrid_get_charset($conn);
+
+printf("%-30s %s\n", "CUBRID Charset:", $charset);
+
+cubrid_disconnect($conn);
+?>
+]]>
+   </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+CUBRID PHP Version:            9.1.0.0001
+
+PARAM_ISOLATION_LEVEL          3
+LOCK_TIMEOUT                   -1
+MAX_STRING_LENGTH              1073741823
+PARAM_AUTO_COMMIT              1
+
+Server Info:                   9.1.0.0212
+Client Info:                   9.1.0
+
+CUBRID Charset:                iso8859-1
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+   <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+  <member><function>cubrid_connect</function></member>
+  <member><function>cubrid_connect_with_url</function></member>
+  <member><function>cubrid_pconnect_with_url</function></member>
+  <member><function>cubrid_disconnect</function></member>
+  <member><function>cubrid_close</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cubrid/functions/cubrid-seq-insert.xml
+++ b/reference/cubrid/functions/cubrid-seq-insert.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-seq-insert">
+ <refnamediv>
+  <refname>cubrid_seq_insert</refname>
+  <refpurpose>Fügt ein Element in eine Spalte vom Typ Sequenz anhand der OID ein</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>cubrid_seq_insert</methodname>
+   <methodparam><type>resource</type><parameter>conn_identifier</parameter></methodparam>
+   <methodparam><type>string</type><parameter>oid</parameter></methodparam>
+   <methodparam><type>string</type><parameter>attr_name</parameter></methodparam>
+   <methodparam><type>int</type><parameter>index</parameter></methodparam>
+   <methodparam><type>string</type><parameter>seq_element</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Die Funktion <function>cubrid_seq_insert</function> wird verwendet, um an
+    einer gewünschten Position ein Element in ein Attribut vom Typ Sequenz
+    einzufügen.
+  </simpara>
+ </refsect1>
+
+<refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+ <term><parameter>conn_identifier</parameter></term>
+ <listitem><simpara>Verbindungs-Identifikator.</simpara></listitem>
+  </varlistentry>
+  <varlistentry>
+ <term><parameter>oid</parameter></term>
+ <listitem><simpara>OID der Instanz, mit der gearbeitet werden soll.</simpara></listitem>
+  </varlistentry>
+      <varlistentry>
+ <term><parameter>attr_name</parameter></term>
+ <listitem><simpara>Name des Attributs, in das eine Instanz eingefügt werden soll.</simpara></listitem>
+  </varlistentry>
+  <varlistentry>
+ <term><parameter>index</parameter></term>
+ <listitem><simpara>Position des Elements, an der das Element eingefügt werden soll (1-basiert).</simpara></listitem>
+  </varlistentry>
+ <varlistentry>
+ <term><parameter>seq_element</parameter></term>
+ <listitem><simpara>Inhalt des Elements, das eingefügt werden soll.</simpara></listitem>
+  </varlistentry>
+ </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>cubrid_seq_insert</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$conn = cubrid_connect("localhost", 33000, "demodb", "dba");
+
+@cubrid_execute($conn, "DROP TABLE foo");
+cubrid_execute($conn, "CREATE TABLE foo(a int AUTO_INCREMENT, b set(int), c sequence(int), d char(10))");
+cubrid_execute($conn, "INSERT INTO foo(a, b, c, d) VALUES(1, {1,2,3}, {11,22,33,333}, 'a')");
+
+$req = cubrid_execute($conn, "SELECT * FROM foo", CUBRID_INCLUDE_OID);
+
+cubrid_move_cursor($req, 1, CUBRID_CURSOR_FIRST);
+$oid = cubrid_current_oid($req);
+
+$attr = cubrid_col_get($conn, $oid, "c");
+var_dump($attr);
+
+cubrid_seq_insert($conn, $oid, "c", 5, "44");
+
+$attr = cubrid_col_get($conn, $oid, "c");
+var_dump($attr);
+
+cubrid_close_request($req);
+cubrid_disconnect($conn);
+?>
+]]>
+   </programlisting>
+&example.outputs;
+    <screen>
+<![CDATA[
+array(4) {
+  [0]=>
+  string(2) "11"
+  [1]=>
+  string(2) "22"
+  [2]=>
+  string(2) "33"
+  [3]=>
+  string(3) "333"
+}
+array(5) {
+  [0]=>
+  string(2) "11"
+  [1]=>
+  string(2) "22"
+  [2]=>
+  string(2) "33"
+  [3]=>
+  string(3) "333"
+  [4]=>
+  string(2) "44"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>cubrid_seq_drop</function></member>
+   <member><function>cubrid_seq_put</function></member>
+  </simplelist>
+  </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -24,7 +24,7 @@
     <term><parameter>word</parameter></term>
     <listitem>
      <simpara>
-      Wort, das für die Vorschläge verwendet werden soll.
+      Das Wort, das für die Vorschläge verwendet werden soll.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/enchant/functions/enchant-dict-suggest.xml
+++ b/reference/enchant/functions/enchant-dict-suggest.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-suggest">
+ <refnamediv>
+  <refname>enchant_dict_suggest</refname>
+  <refpurpose>Schlägt Schreibweisen für ein Wort vor</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>enchant_dict_suggest</methodname>
+   <methodparam><type>EnchantDictionary</type><parameter>dictionary</parameter></methodparam>
+   <methodparam><type>string</type><parameter>word</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &enchant.param.dictionary;
+   <varlistentry>
+    <term><parameter>word</parameter></term>
+    <listitem>
+     <simpara>
+      Wort, das für die Vorschläge verwendet werden soll.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt ein Array mit Vorschlägen zurück, wenn das Wort falsch geschrieben ist.
+  </simpara>
+ </refsect1>
+
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &enchant.changelog.dictionary-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ein Beispiel für <function>enchant_dict_suggest</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$tag = 'en_US';
+$r = enchant_broker_init();
+if (enchant_broker_dict_exists($r,$tag)) {
+    $d = enchant_broker_request_dict($r, $tag);
+
+    $wordcorrect = enchant_dict_check($d, "soong");
+    if (!$wordcorrect) {
+        $suggs = enchant_dict_suggest($d, "soong");
+        echo "Suggestions for 'soong':";
+        print_r($suggs);
+    }
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>enchant_dict_check</function></member>
+   <member><function>enchant_dict_quick_check</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -35,8 +35,8 @@
     <listitem>
      <simpara>
       Callback-Funktion, die aufgerufen wird, wenn der Timer auslöst.
-      Wird von dieser Funktion false oder ein Wert, der zu false ausgewertet
-      wird, zurückgegeben, so bewirkt dies, dass das Device anhält.
+      Gibt diese Funktion &false; oder einen Wert zurück, der zu &false; ausgewertet wird,
+      ausgewertet wird, wird das Device angehalten.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -47,7 +47,7 @@
       Wie oft der Timer-Callback aufgerufen wird, in Millisekunden. Der
       Timer-Callback wird periodisch aufgerufen.
       Der Timeout-Wert garantiert, dass zwischen den Aufrufen der
-      Callback-Funktion mindestens dieser Betrag an Millisekunden liegt.
+      Callback-Funktion mindestens dieser Zeitraum in Millisekunden vergeht.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -44,8 +44,8 @@
     <term><parameter>timeout</parameter></term>
     <listitem>
      <simpara>
-      Wie oft der Timer-Callback aufgerufen wird, in Millisekunden. Der
-      Timer-Callback wird periodisch aufgerufen.
+      Das Intervall, in dem der Timer-Callback aufgerufen wird,
+      in Millisekunden. Der Timer-Callback wird periodisch aufgerufen.
       Der Timeout-Wert garantiert, dass zwischen den Aufrufen der
       Callback-Funktion mindestens dieser Zeitraum in Millisekunden vergeht.
      </simpara>

--- a/reference/zmq/zmqdevice/settimercallback.xml
+++ b/reference/zmq/zmqdevice/settimercallback.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zmqdevice.settimercallback" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ZMQDevice::setTimerCallback</refname>
+  <refpurpose>Setzt die Timer-Callback-Funktion</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>ZMQDevice</type><methodname>ZMQDevice::setTimerCallback</methodname>
+   <methodparam><type>callable</type><parameter>cb_func</parameter></methodparam>
+   <methodparam><type>int</type><parameter>timeout</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>user_data</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Setzt die Timer-Callback-Funktion. Der Timer-Callback wird aufgerufen,
+   nachdem das Timeout abgelaufen ist. Der Unterschied zwischen Idle- und
+   Timer-Callbacks besteht darin, dass der Idle-Callback nur dann aufgerufen
+   wird, wenn das Device untätig ist.
+
+   Die Signatur der Callback-Funktion lautet callback (mixed $user_data).
+   Hinzugefügt in Version 1.1.0 der ZMQ-Erweiterung.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>cb_func</parameter></term>
+    <listitem>
+     <simpara>
+      Callback-Funktion, die aufgerufen wird, wenn der Timer auslöst.
+      Wird von dieser Funktion false oder ein Wert, der zu false ausgewertet
+      wird, zurückgegeben, so bewirkt dies, dass das Device anhält.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem>
+     <simpara>
+      Wie oft der Timer-Callback aufgerufen wird, in Millisekunden. Der
+      Timer-Callback wird periodisch aufgerufen.
+      Der Timeout-Wert garantiert, dass zwischen den Aufrufen der
+      Callback-Funktion mindestens dieser Betrag an Millisekunden liegt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user_data</parameter></term>
+    <listitem>
+     <para>
+      Zusätzliche Daten, die an die Callback-Funktion übergeben werden.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Im Erfolgsfall gibt diese Methode das aktuelle Objekt zurück.
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
New translations of 7 files covering apcu, cubrid, enchant and zmq extensions.

Part 1 of the upstream PR #5576 sync. Closes #240.