### PR TITLE
[Sync EN] Fix copy-pasted descriptions: eio, ev, event, fann (#5576)

### DIFF
--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -79,7 +79,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_chown</function> liefert bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+   <function>eio_chown</function> liefert bei Erfolg eine Anfrage-Ressource. &return.falseforfailure;
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -49,7 +49,7 @@
     <term><parameter>gid</parameter></term>
     <listitem>
      <simpara>
-     Gruppenkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+      Gruppenkennung. Wird ignoriert, wenn der Wert -1 beträgt.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -41,7 +41,7 @@
     <term><parameter>uid</parameter></term>
     <listitem>
      <simpara>
-     Benutzerkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+      Benutzerkennung. Wird ignoriert, wenn der Wert -1 beträgt.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -56,7 +56,7 @@
    <varlistentry>
     <term><parameter>pri</parameter></term>
     <listitem>
-    &eio.request.pri.values;
+     &eio.request.pri.values;
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-chown">
+ <refnamediv>
+  <refname>eio_chown</refname>
+  <refpurpose>Ändert den Datei- oder Verzeichnisbesitzer</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_chown</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>int</type><parameter>uid</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>gid</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+  <function>eio_chown</function> ändert den Besitzer einer Datei oder eines Verzeichnisses. Der
+  neue Besitzer wird durch <parameter>uid</parameter> und die Gruppe durch
+  <parameter>gid</parameter> angegeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+      Pfad zu einer Datei oder einem Verzeichnis.
+     </simpara>
+     &eio.warn.relpath;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>uid</parameter></term>
+    <listitem>
+     <simpara>
+     Benutzerkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>gid</parameter></term>
+    <listitem>
+     <simpara>
+     Gruppenkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pri</parameter></term>
+    <listitem>
+    &eio.request.pri.values;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     &eio.callback.proto;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_chown</function> liefert bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_chmod</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-chown.xml
+++ b/reference/eio/functions/eio-chown.xml
@@ -69,7 +69,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <simpara>
-     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+      Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -40,7 +40,7 @@
     <term><parameter>uid</parameter></term>
     <listitem>
      <simpara>
-     Benutzerkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+      Benutzerkennung. Wird ignoriert, wenn der Wert -1 beträgt.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fchown">
+ <refnamediv>
+  <refname>eio_fchown</refname>
+  <refpurpose>Ändert den Dateibesitzer</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_fchown</methodname>
+   <methodparam><type>mixed</type><parameter>fd</parameter></methodparam>
+   <methodparam><type>int</type><parameter>uid</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>gid</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>eio_fchown</function> ändert den Besitzer der durch den Dateideskriptor
+   <parameter>fd</parameter> angegebenen Datei.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fd</parameter></term>
+    <listitem>
+     <simpara>
+     Stream, Socket-Ressource oder numerischer Dateideskriptor.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>uid</parameter></term>
+    <listitem>
+     <simpara>
+     Benutzerkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>gid</parameter></term>
+    <listitem>
+     <simpara>
+     Gruppenkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pri</parameter></term>
+    <listitem>
+    &eio.request.pri.values;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     &eio.callback.proto;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_fchown</function> liefert bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_fchmod</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -32,7 +32,7 @@
     <term><parameter>fd</parameter></term>
     <listitem>
      <simpara>
-     Stream, Socket-Ressource oder numerischer Dateideskriptor.
+      Stream, Socket-Ressource oder numerischer Dateideskriptor.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -55,7 +55,7 @@
    <varlistentry>
     <term><parameter>pri</parameter></term>
     <listitem>
-    &eio.request.pri.values;
+     &eio.request.pri.values;
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -68,7 +68,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <simpara>
-     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+      Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fchown.xml
+++ b/reference/eio/functions/eio-fchown.xml
@@ -48,7 +48,7 @@
     <term><parameter>gid</parameter></term>
     <listitem>
      <simpara>
-     Gruppenkennung. Wird ignoriert, wenn der Wert -1 beträgt.
+      Gruppenkennung. Wird ignoriert, wenn der Wert -1 beträgt.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -30,7 +30,7 @@
     <term><parameter>fd</parameter></term>
     <listitem>
      <simpara>
-     Stream, Socket-Ressource oder numerischer Dateideskriptor.
+      Stream, Socket-Ressource oder numerischer Dateideskriptor.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -37,7 +37,7 @@
    <varlistentry>
     <term><parameter>pri</parameter></term>
     <listitem>
-    &eio.request.pri.values;
+     &eio.request.pri.values;
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -50,7 +50,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <simpara>
-     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+      Beliebige Variable, die an das <parameter>callback</parameter> übergeben wird.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -60,7 +60,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_fstat</function> liefert bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+   <function>eio_fstat</function> liefert bei Erfolg eine Anfrage-Ressource. &return.falseforfailure;
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -18,7 +18,7 @@
   </methodsynopsis>
   <simpara>
    <function>eio_fstat</function> liefert Informationen zum Dateistatus im
-   Argument <parameter>result</parameter> des <parameter>callback</parameter>.
+   Argument <parameter>result</parameter> des <parameter>callback</parameter>s.
   </simpara>
 
  </refsect1>

--- a/reference/eio/functions/eio-fstat.xml
+++ b/reference/eio/functions/eio-fstat.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fstat">
+ <refnamediv>
+  <refname>eio_fstat</refname>
+   <refpurpose>Liefert den Dateistatus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_fstat</methodname>
+   <methodparam><type>mixed</type><parameter>fd</parameter></methodparam>
+   <methodparam><type>int</type><parameter>pri</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>eio_fstat</function> liefert Informationen zum Dateistatus im
+   Argument <parameter>result</parameter> des <parameter>callback</parameter>.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fd</parameter></term>
+    <listitem>
+     <simpara>
+     Stream, Socket-Ressource oder numerischer Dateideskriptor.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pri</parameter></term>
+    <listitem>
+    &eio.request.pri.values;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     &eio.callback.proto;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_fstat</function> liefert bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>eio_fstat</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// Temporäre Datei erstellen
+$tmp_filename = dirname(__FILE__) ."/eio-file.tmp";
+touch($tmp_filename);
+
+/* Wird aufgerufen, wenn eio_fstat() fertig ist */
+function my_res_cb($data, $result) {
+ // Sollte ein Array mit Stat-Informationen ausgeben
+ var_dump($result);
+
+ if ($data['fd']) {
+  // Temporäre Datei schließen
+  eio_close($data['fd']);
+  eio_event_loop();
+ }
+ // Temporäre Datei löschen
+ @unlink($data['file']);
+}
+
+/* Wird aufgerufen, wenn eio_open() fertig ist */
+function my_open_cb($data, $result) {
+ // Daten für den Callback vorbereiten
+ $d = array(
+  'fd'  => $result,
+  'file'=> $data
+ );
+ // Stat-Informationen anfordern
+ eio_fstat($result, EIO_PRI_DEFAULT, "my_res_cb", $d);
+ // Anfrage(n) verarbeiten
+ eio_event_loop();
+}
+
+// Temporäre Datei öffnen
+eio_open($tmp_filename, EIO_O_RDONLY, NULL, EIO_PRI_DEFAULT,
+  "my_open_cb", $tmp_filename);
+eio_event_loop();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(12) {
+ ["st_dev"]=>
+  int(2050)
+  ["st_ino"]=>
+  int(2489159)
+  ["st_mode"]=>
+  int(33188)
+  ["st_nlink"]=>
+  int(1)
+  ["st_uid"]=>
+  int(1000)
+  ["st_gid"]=>
+  int(100)
+  ["st_rdev"]=>
+  int(0)
+  ["st_blksize"]=>
+  int(4096)
+  ["st_blocks"]=>
+  int(0)
+  ["st_atime"]=>
+  int(1318239506)
+  ["st_mtime"]=>
+  int(1318239506)
+  ["st_ctime"]=>
+  int(1318239506)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_lstat</function></member>
+   <member><function>eio_stat</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -27,7 +27,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   <function>eio_nready</function> liefert die Anzahl der noch nicht bearbeiteten Anfragen zurück.
+   <function>eio_nready</function> liefert die Anzahl der noch nicht bearbeiteten Anfragen.
   </simpara>
  </refsect1>
 

--- a/reference/eio/functions/eio-nready.xml
+++ b/reference/eio/functions/eio-nready.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-nready">
+ <refnamediv>
+  <refname>eio_nready</refname>
+  <refpurpose>Liefert die Anzahl der noch nicht bearbeiteten Anfragen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>eio_nready</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_nready</function> liefert die Anzahl der noch nicht bearbeiteten Anfragen zurück.
+  </simpara>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_nreqs</function></member>
+   <member><function>eio_nthreads</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-truncate">
+ <refnamediv>
+  <refname>eio_truncate</refname>
+  <refpurpose>Kürzt eine Datei</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_truncate</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>offset</parameter><initializer>0</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+  <function>eio_truncate</function> kürzt die durch <parameter>path</parameter> angegebene reguläre Datei auf
+  eine Größe von genau <parameter>length</parameter> Bytes.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <simpara>
+     Dateipfad.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+     Offset vom Dateianfang.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pri</parameter></term>
+    <listitem>
+    &eio.request.pri.values;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     &eio.callback.proto;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_truncate</function> liefert bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_ftruncate</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -59,7 +59,7 @@
     <term><parameter>data</parameter></term>
     <listitem>
      <simpara>
-     Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
+      Beliebige Variable, die an den <parameter>callback</parameter> übergeben wird.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -46,7 +46,7 @@
    <varlistentry>
     <term><parameter>pri</parameter></term>
     <listitem>
-    &eio.request.pri.values;
+     &eio.request.pri.values;
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -39,7 +39,7 @@
     <term><parameter>offset</parameter></term>
     <listitem>
      <simpara>
-     Offset vom Dateianfang.
+      Offset vom Dateianfang.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/eio/functions/eio-truncate.xml
+++ b/reference/eio/functions/eio-truncate.xml
@@ -31,7 +31,7 @@
     <term><parameter>path</parameter></term>
     <listitem>
      <simpara>
-     Dateipfad.
+      Dateipfad.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/ev/evchild/createstopped.xml
+++ b/reference/ev/evchild/createstopped.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evchild.createstopped">
+ <refnamediv>
+  <refname>EvChild::createStopped</refname>
+  <refpurpose>Erstellt eine Instanz eines gestoppten EvChild-Watchers</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>object</type>
+   <methodname>EvChild::createStopped</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>pid</parameter>
+   </methodparam>
+   <methodparam>
+    <type>bool</type>
+    <parameter>trace</parameter>
+   </methodparam>
+   <methodparam>
+    <type>callable</type>
+    <parameter>callback</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>mixed</type>
+    <parameter>data</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>int</type>
+    <parameter>priority</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Identisch zu
+   <methodname>EvChild::__construct</methodname>,
+   startet den Watcher jedoch nicht automatisch.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>pid</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Identisch zu
+      <methodname>EvChild::__construct</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>trace</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Identisch zu
+      <methodname>EvChild::__construct</methodname>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>callback</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Siehe
+      <link linkend="ev.watcher-callbacks">Watcher-Callbacks</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>data</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Benutzerdefinierte, mit dem Watcher verknüpfte Daten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>priority</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      <link linkend="ev.constants.watcher-pri">Watcher-Priorität</link>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara/>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EvChild::__construct</methodname>
+   </member>
+   <member>
+    <methodname>EvLoop::child</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/evsignal/construct.xml
+++ b/reference/ev/evsignal/construct.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.construct">
+ <refnamediv>
+  <refname>EvSignal::__construct</refname>
+  <refpurpose>Erstellt ein EvSignal-Watcher-Objekt</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier>
+   <methodname>EvSignal::__construct</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>signum</parameter>
+   </methodparam>
+   <methodparam>
+    <type>callable</type>
+    <parameter>callback</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>mixed</type>
+    <parameter>data</parameter>
+    <initializer>&null;</initializer>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>int</type>
+    <parameter>priority</parameter>
+    <initializer>0</initializer>
+   </methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Erstellt ein EvSignal-Watcher-Objekt und startet es automatisch. Für einen
+   gestoppten Signal-Watcher ist die Verwendung der Methode
+   <methodname>EvSignal::createStopped</methodname>
+   in Erwägung zu ziehen.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>signum</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Signalnummer. Siehe die von der Erweiterung
+      <emphasis>pcntl</emphasis>
+      exportierten Konstanten. Siehe auch die Manpage
+      <literal>signal(7)</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>callback</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Siehe
+      <link linkend="ev.watcher-callbacks">Watcher-Callbacks</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>data</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Benutzerdefinierte, mit dem Watcher verknüpfte Daten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>priority</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      <link linkend="ev.constants.watcher-pri">Watcher-Priorität</link>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+ <example>
+   <title>Behandlung des Signals SIGTERM</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$w = new EvSignal(SIGTERM, function ($watcher) {
+    echo "SIGTERM received\n";
+    $watcher->stop();
+});
+
+Ev::run();
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EvSignal::createStopped</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -11,7 +11,7 @@
    <para>
     Die Klasse
     <classname>Event</classname>
-    repräsentiert ein Event, das ausgelöst wird, wenn ein Dateideskriptor zum Lesen
+    repräsentiert ein Ereignis, das ausgelöst wird, wenn ein Dateideskriptor zum Lesen
     oder Schreiben bereit ist; wenn ein Dateideskriptor zum Lesen oder Schreiben
     bereit wird (nur flankengesteuerte E/A); wenn eine Zeitüberschreitung abläuft;
     wenn ein Signal auftritt; oder bei einem vom Benutzer ausgelösten Ereignis.

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -117,8 +117,8 @@
      </term>
      <listitem>
       <para>
-       Gibt an, ob das Event pending ist. Siehe
-       <link linkend="event.persistence">Über die Event-Persistenz</link>.
+       Gibt an, ob das Ereignis pending ist. Siehe
+       <link linkend="event.persistence">Über die Ereignis-Persistenz</link>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -135,8 +135,8 @@
      </term>
      <listitem>
       <para>
-       Gibt an, dass das Event flankengesteuert sein soll, sofern das zugrunde liegende
-       Event-Base-Backend flankengesteuerte Events unterstützt. Dies beeinflusst die
+       Gibt an, dass das Ereignis flankengesteuert sein soll, sofern das zugrunde liegende
+       Event-Base-Backend flankengesteuerte Ereignisse unterstützt. Dies beeinflusst die
        Semantik von
        <constant>Event::READ</constant>
        und

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -200,8 +200,8 @@
       <para>
        Das Flag
        <constant>Event::TIMEOUT</constant>
-       wird beim Erstellen eines Events ignoriert: entweder wird eine Zeitüberschreitung
-       gesetzt, wenn das Event
+       wird beim Erstellen eines Ereignisses ignoriert: entweder wird eine Zeitüberschreitung
+       gesetzt, wenn das Ereignis
        <emphasis>hinzugefügt</emphasis>
        wird, oder nicht. Es wird im Argument
        <literal>$what</literal>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<reference xml:id="class.event" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Die Klasse Event</title>
+ <titleabbrev>Event</titleabbrev>
+ <partintro>
+<!-- {{{ Event intro -->
+  <section xml:id="event.intro">
+   &reftitle.intro;
+   <para>
+    Die Klasse
+    <classname>Event</classname>
+    repräsentiert ein Event, das ausgelöst wird, wenn ein Dateideskriptor zum Lesen
+    oder Schreiben bereit ist; wenn ein Dateideskriptor zum Lesen oder Schreiben
+    bereit wird (nur flankengesteuerte E/A); wenn eine Zeitüberschreitung abläuft;
+    wenn ein Signal auftritt; oder bei einem benutzerausgelösten Event.
+   </para>
+   <para>
+    Jedes Event ist mit einer
+    <classname>EventBase</classname>
+    verknüpft.
+    Ein Event wird jedoch erst ausgelöst, wenn es
+    <emphasis>hinzugefügt</emphasis>
+    wurde (über
+    <methodname>Event::add</methodname>
+    ). Ein hinzugefügtes Event verbleibt im Zustand
+    <emphasis>pending</emphasis>,
+    bis das registrierte Event eintritt, wodurch es in den Zustand
+    <emphasis>active</emphasis>
+    wechselt. Um Events zu behandeln, kann ein Callback registriert werden, der aufgerufen wird,
+    wenn das Event aktiv wird. Wenn das Event als
+    <emphasis>persistent</emphasis>
+    konfiguriert ist, bleibt es pending. Ist es nicht persistent, ist es nicht mehr pending,
+    sobald sein Callback ausgeführt wurde.
+    Die Methode
+    <methodname>Event::del</methodname>
+    <emphasis>löscht</emphasis>
+    ein Event und versetzt es somit in den Zustand non-pending. Mittels der Methode
+    <methodname>Event::add</methodname>
+    kann es erneut hinzugefügt werden.
+   </para>
+  </section>
+<!-- }}} -->
+  <section xml:id="event.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>Event</classname>
+    </ooclass>
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>Event</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="event.constants.et">Event::ET</varname>
+     <initializer>32</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="event.constants.persist">Event::PERSIST</varname>
+     <initializer>16</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="event.constants.read">Event::READ</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="event.constants.write">Event::WRITE</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="event.constants.signal">Event::SIGNAL</varname>
+     <initializer>8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="event.constants.timeout">Event::TIMEOUT</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>bool</type>
+     <varname linkend="event.props.pending">pending</varname>
+    </fieldsynopsis>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.event')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+   </classsynopsis>
+<!-- }}} -->
+  </section>
+<!-- {{{ Event properties -->
+  <section xml:id="event.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="event.props.pending">
+     <term>
+      <varname>pending</varname>
+     </term>
+     <listitem>
+      <para>
+       Gibt an, ob das Event pending ist. Siehe
+       <link linkend="event.persistence">Über die Event-Persistenz</link>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+<!-- {{{ Event constants -->
+  <section xml:id="event.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="event.constants.et">
+     <term>
+      <constant>Event::ET</constant>
+     </term>
+     <listitem>
+      <para>
+       Gibt an, dass das Event flankengesteuert sein soll, sofern das zugrunde liegende
+       Event-Base-Backend flankengesteuerte Events unterstützt. Dies beeinflusst die
+       Semantik von
+       <constant>Event::READ</constant>
+       und
+       <constant>Event::WRITE</constant>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="event.constants.persist">
+     <term>
+      <constant>Event::PERSIST</constant>
+     </term>
+     <listitem>
+      <para>
+       Gibt an, dass das Event persistent ist. Siehe
+       <link linkend="event.persistence">Über die Event-Persistenz</link>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="event.constants.read">
+     <term>
+      <constant>Event::READ</constant>
+     </term>
+     <listitem>
+      <para>
+       Dieses Flag zeigt ein Event an, das aktiv wird, wenn der angegebene Dateideskriptor
+       (üblicherweise eine Stream-Ressource oder ein Socket) zum Lesen bereit ist.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="event.constants.write">
+     <term>
+      <constant>Event::WRITE</constant>
+     </term>
+     <listitem>
+      <simpara>
+       Dieses Flag zeigt ein Event an, das aktiv wird, wenn der angegebene Dateideskriptor
+       (üblicherweise eine Stream-Ressource oder ein Socket) zum Schreiben bereit ist.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="event.constants.signal">
+     <term>
+      <constant>Event::SIGNAL</constant>
+     </term>
+     <listitem>
+      <para>
+       Wird verwendet, um eine Signalerkennung zu implementieren. Siehe "Constructing signal events"
+       weiter unten.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="event.constants.timeout">
+     <term>
+      <constant>Event::TIMEOUT</constant>
+     </term>
+     <listitem>
+      <para>
+       Dieses Flag zeigt ein Event an, das aktiv wird, nachdem eine Zeitüberschreitung
+       abgelaufen ist.
+      </para>
+      <para>
+       Das Flag
+       <constant>Event::TIMEOUT</constant>
+       wird beim Erstellen eines Events ignoriert: entweder wird eine Zeitüberschreitung
+       gesetzt, wenn das Event
+       <emphasis>hinzugefügt</emphasis>
+       wird, oder nicht. Es wird im Argument
+       <literal>$what</literal>
+       der Callback-Funktion gesetzt, wenn eine Zeitüberschreitung aufgetreten ist.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+ </partintro>
+
+ &reference.event.entities.event;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -14,7 +14,7 @@
     repräsentiert ein Event, das ausgelöst wird, wenn ein Dateideskriptor zum Lesen
     oder Schreiben bereit ist; wenn ein Dateideskriptor zum Lesen oder Schreiben
     bereit wird (nur flankengesteuerte E/A); wenn eine Zeitüberschreitung abläuft;
-    wenn ein Signal auftritt; oder bei einem benutzerausgelösten Event.
+    wenn ein Signal auftritt; oder bei einem vom Benutzer ausgelösten Ereignis.
    </para>
    <para>
     Jedes Event ist mit einer

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -172,7 +172,7 @@
      </term>
      <listitem>
       <simpara>
-       Dieses Flag zeigt ein Event an, das aktiv wird, wenn der angegebene Dateideskriptor
+       Dieses Flag zeigt ein Ereignis an, das aktiv wird, wenn der angegebene Dateideskriptor
        (üblicherweise eine Stream-Ressource oder ein Socket) zum Schreiben bereit ist.
       </simpara>
      </listitem>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -24,19 +24,19 @@
     <emphasis>hinzugefügt</emphasis>
     wurde (über
     <methodname>Event::add</methodname>
-    ). Ein hinzugefügtes Event verbleibt im Zustand
+    ). Ein hinzugefügtes Ereignis verbleibt im Zustand
     <emphasis>pending</emphasis>,
-    bis das registrierte Event eintritt, wodurch es in den Zustand
+    bis das registrierte Ereignis eintritt, wodurch es in den Zustand
     <emphasis>active</emphasis>
-    wechselt. Um Events zu behandeln, kann ein Callback registriert werden, der aufgerufen wird,
-    wenn das Event aktiv wird. Wenn das Event als
+    wechselt. Um Ereignisse zu behandeln, kann ein Callback registriert werden, der aufgerufen wird,
+    wenn das Ereignis aktiv wird. Wenn das Ereignis als
     <emphasis>persistent</emphasis>
     konfiguriert ist, bleibt es pending. Ist es nicht persistent, ist es nicht mehr pending,
     sobald sein Callback ausgeführt wurde.
     Die Methode
     <methodname>Event::del</methodname>
     <emphasis>löscht</emphasis>
-    ein Event und versetzt es somit in den Zustand non-pending. Mittels der Methode
+    ein Ereignis und versetzt es somit in den Zustand non-pending. Mittels der Methode
     <methodname>Event::add</methodname>
     kann es erneut hinzugefügt werden.
    </para>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -194,7 +194,7 @@
      </term>
      <listitem>
       <para>
-       Dieses Flag zeigt ein Event an, das aktiv wird, nachdem eine Zeitüberschreitung
+       Dieses Flag zeigt ein Ereignis an, das aktiv wird, nachdem eine Zeitüberschreitung
        abgelaufen ist.
       </para>
       <para>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -151,7 +151,7 @@
      <listitem>
       <para>
        Gibt an, dass das Ereignis persistent ist. Siehe
-       <link linkend="event.persistence">Über die Event-Persistenz</link>.
+       <link linkend="event.persistence">Über die Ereignis-Persistenz</link>.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -17,7 +17,7 @@
     wenn ein Signal auftritt; oder bei einem vom Benutzer ausgelösten Ereignis.
    </para>
    <para>
-    Jedes Event ist mit einer
+    Jedes Ereignis ist mit einer
     <classname>EventBase</classname>
     verknüpft.
     Ein Ereignis wird jedoch erst ausgelöst, wenn es

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -150,7 +150,7 @@
      </term>
      <listitem>
       <para>
-       Gibt an, dass das Event persistent ist. Siehe
+       Gibt an, dass das Ereignis persistent ist. Siehe
        <link linkend="event.persistence">Über die Event-Persistenz</link>.
       </para>
      </listitem>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -20,7 +20,7 @@
     Jedes Event ist mit einer
     <classname>EventBase</classname>
     verknüpft.
-    Ein Event wird jedoch erst ausgelöst, wenn es
+    Ein Ereignis wird jedoch erst ausgelöst, wenn es
     <emphasis>hinzugefügt</emphasis>
     wurde (über
     <methodname>Event::add</methodname>

--- a/reference/event/event.xml
+++ b/reference/event/event.xml
@@ -161,7 +161,7 @@
      </term>
      <listitem>
       <para>
-       Dieses Flag zeigt ein Event an, das aktiv wird, wenn der angegebene Dateideskriptor
+       Dieses Flag zeigt ein Ereignis an, das aktiv wird, wenn der angegebene Dateideskriptor
        (üblicherweise eine Stream-Ressource oder ein Socket) zum Lesen bereit ist.
       </para>
      </listitem>

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -38,8 +38,7 @@
   &reftitle.returnvalues;
   <para>
    Liefert ein
-   <classname>EventBufferEvent</classname>-Objekt
-   zurück.
+   <classname>EventBufferEvent</classname>-Objekt.
   </para>
  </refsect1>
  <refsect1 role="seealso">

--- a/reference/event/eventhttprequest/getbufferevent.xml
+++ b/reference/event/eventhttprequest/getbufferevent.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventhttprequest.getbufferevent" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventHttpRequest::getBufferEvent</refname>
+  <refpurpose>Liefert ein EventBufferEvent-Objekt</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>EventBufferEvent</type>
+   <methodname>EventHttpRequest::getBufferEvent</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Liefert ein
+   <classname>EventBufferEvent</classname>-Objekt,
+   das das von der Verbindung verwendete Buffer-Event repräsentiert.
+  </para>
+  <warning>
+   <para>
+    Der Referenzzähler des zurückgegebenen Objekts wird um eins erhöht, um
+    interne Strukturen vor vorzeitiger Zerstörung zu schützen, wenn die Methode
+    aus einem Benutzer-Callback aufgerufen wird. Daher sollte das
+    <classname>EventBufferEvent</classname>-Objekt explizit mit der Methode
+    <methodname>EventBufferEvent::free</methodname> freigegeben werden.
+    Andernfalls kommt es zu einem Speicherleck.
+   </para>
+  </warning>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Liefert ein
+   <classname>EventBufferEvent</classname>-Objekt
+   zurück.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EventHttpRequest::getConnection</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fann/functions/fann-get-activation-function.xml
+++ b/reference/fann/functions/fann-get-activation-function.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.fann-get-activation-function" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fann_get_activation_function</refname>
+  <refpurpose>Liefert die Aktivierungsfunktion</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>fann_get_activation_function</methodname>
+   <methodparam><type>resource</type><parameter>ann</parameter></methodparam>
+   <methodparam><type>int</type><parameter>layer</parameter></methodparam>
+   <methodparam><type>int</type><parameter>neuron</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Liefert die Aktivierungsfunktion für das Neuron mit der Nummer <literal>neuron</literal> in der Schicht
+   mit der Nummer <literal>layer</literal>, wobei die Eingabeschicht als Schicht 0 gezählt wird.
+  </para>
+  <para>
+   Es ist nicht möglich, die Aktivierungsfunktionen der Neuronen in der Eingabeschicht abzufragen.
+  </para>
+  <para>
+   Der Rückgabewert ist eine der Konstanten der <link linkend="constants.fann-activation-funcs">Aktivierungsfunktionen</link>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ann</parameter></term>
+    <listitem>
+     &fann.ann.description;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>layer</parameter></term>
+    <listitem>
+     <para>
+      Nummer der Schicht.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>neuron</parameter></term>
+    <listitem>
+     <para>
+      Nummer des Neurons.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Eine Konstante der <link linkend="constants.fann-activation-funcs">Aktivierungsfunktionen</link> oder -1,
+   wenn das Neuron im neuronalen Netz nicht definiert ist, oder &false; im Fehlerfall.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fann_set_activation_function_layer</function></member>
+    <member><function>fann_set_activation_function_hidden</function></member>
+    <member><function>fann_set_activation_function_output</function></member>
+    <member><function>fann_set_activation_steepness</function></member>
+    <member><function>fann_set_activation_function</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fann/functions/fann-get-rprop-decrease-factor.xml
+++ b/reference/fann/functions/fann-get-rprop-decrease-factor.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 184764a63e01525315f54897f3bd38eaa1242b42 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.fann-get-rprop-decrease-factor" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fann_get_rprop_decrease_factor</refname>
+  <refpurpose>Liefert den während des RPROP-Trainings verwendeten Verminderungsfaktor</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>fann_get_rprop_decrease_factor</methodname>
+   <methodparam><type>resource</type><parameter>ann</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Der Verminderungsfaktor ist ein Wert kleiner als 1, der zur Verringerung der Schrittweite während des RPROP-Trainings verwendet wird.
+  </para>
+  <para>
+   Der Standardwert des Verminderungsfaktors ist 0.5.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ann</parameter></term>
+    <listitem>
+     &fann.ann.description;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Der Verminderungsfaktor oder &false; im Fehlerfall.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fann_set_rprop_decrease_factor</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/ÜBERSETZUNGEN.txt
+++ b/ÜBERSETZUNGEN.txt
@@ -73,6 +73,7 @@ Glossar - aus dem aktuellen Bestand abgeleitet:
   | callable                      | callable (unverändert)        |
   | callback function             | Callback-Funktion             |
   | closure                       | Closure (unverändert)         |
+  | event                         | Ereignis (Eigennamen bleiben) |
   | exception                     | Exception (unverändert)       |
   | exception thrown              | Exception ausgelöst           |
   | handle                        | Handle (unverändert)          |


### PR DESCRIPTION
New translations of 11 files covering eio, ev, event and fann extensions.

Part 2 of the upstream PR #5576 sync. Closes #240.