### PR TITLE
[Sync EN] Fix various class method signatures to match stub

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -874,6 +874,13 @@ Dateinamen gesucht.'>
  </entry>
 </row>'>
 
+<!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  Der Rückgabewert ist nun &true; vorher war es <type>bool</type>.
+ </entry>
+</row>'>
+
 <!ENTITY return.falseforfailure 'Bei einem Fehler wird &false; zurückgegeben.'>
 <!ENTITY return.falseforfailure.style.procedural '&style.procedural; Im Fehlerfall wird &false; zurückgegeben.'>
 

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -877,7 +877,7 @@ Dateinamen gesucht.'>
 <!ENTITY return.type.true.84 '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.4.0</entry>
  <entry>
-  Der Rückgabewert ist nun &true; vorher war es <type>bool</type>.
+  Der Rückgabewert ist nun &true;; vorher war es <type>bool</type>.
  </entry>
 </row>'>
 

--- a/reference/pdo/pdostatement/setfetchmode.xml
+++ b/reference/pdo/pdostatement/setfetchmode.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: b4756524479423ee3118adec1effa89171a9ffda Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 8a910daad2efdfd29acf6766be8bca7c32c3dd2a Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="pdostatement.setfetchmode" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -13,25 +12,25 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_COLUMN</initializer></methodparam>
    <methodparam><type>int</type><parameter>colno</parameter></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_CLASS</initializer></methodparam>
    <methodparam><type>string</type><parameter>class</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>null</type></type><parameter>constructorArgs</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
   <methodsynopsis role="PDOStatement">
-   <modifier>public</modifier> <type>bool</type><methodname>PDOStatement::setFetchMode</methodname>
+   <modifier>public</modifier> <type>true</type><methodname>PDOStatement::setFetchMode</methodname>
    <methodparam><type>int</type><parameter>mode</parameter><initializer>PDO::FETCH_INTO</initializer></methodparam>
    <methodparam><type>object</type><parameter>object</parameter></methodparam>
   </methodsynopsis>
@@ -89,9 +88,26 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
-   &return.success;
-  </para>
+  <simpara>
+   &return.true.always;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Synchronisierung der DE-Übersetzung mit dem EN-Commit 8a910daa: Rückgabetyp von `PDOStatement::setFetchMode` auf `true` aktualisiert, `return.success` durch `return.true.always` ersetzt und Changelog-Eintrag für 8.4.0 ergänzt.

Fixes #266