### PR TITLE
[Sync EN] image: Fix examples and description

### DIFF
--- a/reference/image/functions/imagedashedline.xml
+++ b/reference/image/functions/imagedashedline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagedashedline" xmlns="http://docbook.org/ns/docbook">
@@ -22,7 +22,7 @@
   <para>
    Diese Funktion ist veraltet. Stattdessen sollte eine Kombination von
    <function>imagesetstyle</function> und <function>imageline</function>
-   verwendet werden.
+   verwendet werden. 0,0 ist die obere linke Ecke des Bildes.
   </para>
  </refsect1>
 
@@ -35,7 +35,7 @@
      <term><parameter>x1</parameter></term>
      <listitem>
       <para>
-       x-Koordinate des oberen linken Punktes.
+       x-Koordinate des ersten Punktes.
       </para>
      </listitem>
     </varlistentry>
@@ -43,8 +43,7 @@
      <term><parameter>y1</parameter></term>
      <listitem>
       <para>
-       y-Koordinate des oberen linken Punktes. 0,0 ist die obere linke Ecke des
-       Bildes.
+       y-Koordinate des ersten Punktes.
       </para>
      </listitem>
     </varlistentry>
@@ -52,7 +51,7 @@
      <term><parameter>x2</parameter></term>
      <listitem>
       <para>
-       x-Koordinate des unteren rechten Punktes.
+       x-Koordinate des zweiten Punktes.
       </para>
      </listitem>
     </varlistentry>
@@ -60,7 +59,7 @@
      <term><parameter>y2</parameter></term>
      <listitem>
       <para>
-       y-Koordinate des unteren rechten Punktes.
+       y-Koordinate des zweiten Punktes.
       </para>
      </listitem>
     </varlistentry>

--- a/reference/image/functions/imagerectangle.xml
+++ b/reference/image/functions/imagerectangle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: fcd9214294f88b05862a538c6dd94c7872420139 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: d56953fc8d508615279a2220f21d7fb6c3298417 Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 593ea510e853ff034e03f78a4be0daa41661c9d4 Reviewer: samesch -->
 <refentry xml:id="function.imagerectangle" xmlns="http://docbook.org/ns/docbook">
@@ -21,7 +21,7 @@
   </methodsynopsis>
   <para>
    <function>imagerectangle</function> erzeugt ein Rechteck mit den angegebenen
-   Koordinaten.
+   Koordinaten. 0,0 ist die obere linke Ecke des Bildes.
   </para>
  </refsect1>
 
@@ -43,7 +43,6 @@
      <listitem>
       <para>
        Obere linke y-Koordinate.
-       0,0 ist die obere linke Ecke des Bildes.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Synchronisierung der DE-Übersetzung mit dem EN-Commit d56953fc: Parameterbeschreibungen von `imagedashedline` und `imagerectangle` angepasst. `imagesetbrush` und `imagesetthickness` sind noch nicht übersetzt und bleiben hier außen vor.

Fixes #267