### PR TITLE
[Sync EN] migration74: Tippfehler im Codebeispiel korrigieren

### DIFF
--- a/appendices/migration74/new-features.xml
+++ b/appendices/migration74/new-features.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e150cc645a17588282e5e6b5e43e600a2f345549 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 8e2cfbdce0cd028a6521c6e073f148e0f7efac7c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 
 <sect1 xml:id="migration74.new-features" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -96,8 +96,8 @@ class A
 class B extends A
 {
     // Fatal error: Could not check compatibility between B::method():C and
-    // A::method(): A, because class С is not available
-    public function method(): С {}
+    // A::method(): A, because class C is not available
+    public function method(): C {}
 }
 
 class C extends B {}


### PR DESCRIPTION
Korrigiert das kyrillische С zu lateinischem C im Codebeispiel (sonst nicht lauffähig), passend zur Upstream-Korrektur. Nur diese DE-Datei existiert bereits, die übrigen Dateien der Sync-Issue sind noch nicht übersetzt.

Fixes #270
