### PR TITLE
[Sync EN] Cubrid: Fix the broken cubrid_prepare description

### DIFF
--- a/reference/cubrid/functions/cubrid-prepare.xml
+++ b/reference/cubrid/functions/cubrid-prepare.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 5acad2fc911ee95b2293ece98dfb45a64b91ae14 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-prepare">
+ <refnamediv>
+  <refname>cubrid_prepare</refname>
+  <refpurpose>Bereitet eine SQL-Anweisung zur Ausführung vor</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>cubrid_prepare</methodname>
+   <methodparam><type>resource</type><parameter>conn_identifier</parameter></methodparam>
+   <methodparam><type>string</type><parameter>prepare_stmt</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>option</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Die Funktion <function>cubrid_prepare</function> kompiliert eine SQL-Anweisung für eine
+   gegebene Verbindungskennung und gibt eine Kennung zurück, die die vorkompilierte Anweisung
+   repräsentiert.
+  </simpara>
+  <simpara>
+   Eine vorbereitete Anweisung kann mehrfach ausgeführt werden, was bei wiederholter Ausführung
+   oder bei der Verarbeitung großer Datenmengen effizient ist. Es kann nur eine einzelne Anweisung
+   verwendet werden, und ein Parameter kann mit einem Fragezeichen (<literal>?</literal>) an der
+   entsprechenden Stelle in der SQL-Anweisung markiert werden. Ein Parameter wird hinzugefügt,
+   wenn ein Wert in der <literal>VALUES</literal>-Klausel einer <literal>INSERT</literal>-Anweisung
+   oder in der <literal>WHERE</literal>-Klausel gebunden wird. Es ist zu beachten, dass ein Wert
+   nur mit der Funktion <function>cubrid_bind</function> an einen Parameter gebunden werden kann.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>conn_identifier</parameter></term>
+    <listitem><simpara>Verbindungskennung.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>prepare_stmt</parameter></term>
+    <listitem><simpara>Vorzubereitende Abfrage.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>option</parameter></term>
+    <listitem><simpara>OID-Rückgabeoption <constant>CUBRID_INCLUDE_OID</constant>.</simpara></listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Eine Anfragekennung bei Erfolg,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>cubrid_prepare</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$conn = cubrid_connect("localhost", 33000, "demodb");
+
+$sql = <<<EOD
+SELECT g.event_code, e.name
+FROM game g
+JOIN event e ON g.event_code=e.code
+WHERE host_year = ? AND event_code NOT IN (SELECT event_code FROM game WHERE host_year=?) GROUP BY event_code;
+EOD;
+
+$req = cubrid_prepare($conn, $sql);
+
+cubrid_bind($req, 1, 2004);
+cubrid_bind($req, 2, 2000);
+cubrid_execute($req);
+
+$row_num = cubrid_num_rows($req);
+printf("There are %d event that exits in 2004 olympic but not in 2000. For example:\n\n", $row_num);
+
+printf("%-15s %s\n", "Event_code", "Event_name");
+printf("----------------------------\n");
+
+$row = cubrid_fetch_assoc($req);
+printf("%-15d %s\n", $row["event_code"], $row["name"]);
+$row = cubrid_fetch_assoc($req);
+printf("%-15d %s\n", $row["event_code"], $row["name"]);
+
+cubrid_disconnect($conn);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+There are 27 event that exits in 2004 olympic but not in 2000. For example:
+
+Event_code      Event_name
+----------------------------
+20063           +91kg
+20070           64kg
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>cubrid_execute</function></member>
+   <member><function>cubrid_bind</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cubrid/functions/cubrid-prepare.xml
+++ b/reference/cubrid/functions/cubrid-prepare.xml
@@ -52,7 +52,7 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <simpara>
-   Eine Anfragekennung bei Erfolg,&return.falseforfailure;.
+   Eine Anfragekennung bei Erfolg. &return.falseforfailure;
   </simpara>
  </refsect1>
 


### PR DESCRIPTION
Übersetzt die neue Datei <function>cubrid_prepare</function> ins Deutsche (zuvor nicht übersetzt) auf dem Stand des aktuellen EN-Texts.

Fixes #278