### PR TITLE
[Sync EN] enumerations: Amend the CS of the code examples

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 4c158f4a34c8f869a43f9f0bd5a4897fb35cec89 Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Aufzählungen (Enum)</title>
@@ -44,6 +44,7 @@
    <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -68,6 +69,7 @@ enum Suit
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -119,6 +121,7 @@ pick_a_card('Spades');
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -173,6 +176,7 @@ if ($a !== 'Spades') {
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -219,6 +223,7 @@ print Suit::Spades->name;
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -270,6 +275,7 @@ enum Suit: string
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -294,6 +300,7 @@ print Suit::Clubs->value;
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -351,6 +358,7 @@ $ref = &$suit->value;
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -400,6 +408,7 @@ print $suit->value . "\n";
    <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -415,7 +424,7 @@ enum Suit implements Colorful
     // Erfüllt die Schnittstellenvereinbarung
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -455,6 +464,7 @@ print Suit::Diamonds->shape(); // gibt "Rectangle" aus
   <programlisting role="php" annotations="non-interactive">
    <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -470,7 +480,7 @@ enum Suit: string implements Colorful
     // Erfüllt die Schnittstellenvereinbarung
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -506,6 +516,7 @@ enum Suit: string implements Colorful
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -522,7 +533,7 @@ final class Suit implements UnitEnum, Colorful
 
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -562,6 +573,7 @@ final class Suit implements UnitEnum, Colorful
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -570,7 +582,7 @@ enum Size
 
     public static function fromLength(int $cm): self
     {
-        return match(true) {
+        return match (true) {
             $cm < 50 => self::Small,
             $cm < 100 => self::Medium,
             default => self::Large,
@@ -608,6 +620,7 @@ var_dump(Size::fromLength(50));
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Size
 {
     case Small;
@@ -638,6 +651,7 @@ var_dump(Size::Huge);
    <programlisting role="php">
 <![CDATA[
 <?php
+
 interface Colorful
 {
     public function color(): string;
@@ -645,7 +659,8 @@ interface Colorful
 
 trait Rectangle
 {
-    public function shape(): string {
+    public function shape(): string
+    {
         return "Rectangle";
     }
 }
@@ -661,7 +676,7 @@ enum Suit implements Colorful
 
     public function color(): string
     {
-        return match($this) {
+        return match ($this) {
             Suit::Hearts, Suit::Diamonds => 'Red',
             Suit::Clubs, Suit::Spades => 'Black',
         };
@@ -701,6 +716,7 @@ var_dump($suit->shape());
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 // Dies ist eine völlig zulässige Definition einer Enum.
 enum Direction implements ArrayAccess
 {
@@ -807,6 +823,7 @@ $foo = new Foo();
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 $clovers = new Suit();
 // Error: Cannot instantiate enum Suit
 
@@ -832,6 +849,7 @@ $horseshoes = (new ReflectionClass(Suit::class))->newInstanceWithoutConstructor(
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit
 {
     case Hearts;
@@ -876,6 +894,7 @@ var_dump(SuitBacked::cases());
    <programlisting role="php">
 <![CDATA[
 <?php
+
 enum Suit: string
 {
     case Hearts = 'H';
@@ -915,11 +934,14 @@ print serialize(Suit::Hearts);
    <programlisting role="php">
 <![CDATA[
 <?php
-enum Foo {
+
+enum Foo
+{
     case Bar;
 }
 
-enum Baz: int {
+enum Baz: int
+{
     case Beep = 5;
 }
 
@@ -952,12 +974,14 @@ Baz Enum:int {
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 class A {}
 class B extends A {}
 
 function foo(A $a) {}
 
-function bar(B $b) {
+function bar(B $b)
+{
     foo($b);
 }
 ]]>
@@ -976,7 +1000,9 @@ function bar(B $b) {
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
-enum ErrorCode {
+
+enum ErrorCode
+{
     case SOMETHING_BROKE;
 }
 
@@ -1003,13 +1029,16 @@ function quux(ErrorCode $errorCode)
   <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 // Ein gedankliches Code-Experiment, bei dem Enums nicht final sind.
 // Es ist zu beachten, dass dies in PHP nicht funktioniert.
-enum MoreErrorCode extends ErrorCode {
+enum MoreErrorCode extends ErrorCode
+{
     case PEBKAC;
 }
 
-function fot(MoreErrorCode $errorCode) {
+function fot(MoreErrorCode $errorCode)
+{
     quux($errorCode);
 }
 
@@ -1043,6 +1072,7 @@ fot(MoreErrorCode::PEBKAC);
     <programlisting role="php" annotations="non-interactive">
 <![CDATA[
 <?php
+
 enum SortOrder
 {
     case Asc;
@@ -1074,6 +1104,7 @@ function query($fields, $filter, SortOrder $order = SortOrder::Asc)
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -1083,7 +1114,7 @@ enum UserStatus: string
 
     public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::Pending => 'Pending',
             self::Active => 'Active',
             self::Suspended => 'Suspended',
@@ -1118,6 +1149,7 @@ var_dump($status->label());
     <programlisting role="php">
 <![CDATA[
 <?php
+
 enum UserStatus: string
 {
     case Pending = 'P';
@@ -1127,7 +1159,7 @@ enum UserStatus: string
 
     public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::Pending => 'Pending',
             self::Active => 'Active',
             self::Suspended => 'Suspended',


### PR DESCRIPTION
Synchronisiert den Codestil der Beispiele mit der EN-Änderung: Leerzeile nach `<?php`, Leerzeichen in `match (` und öffnende geschweifte Klammer in eigener Zeile.

Fixes #276