### PR TITLE
[Sync EN] zookeeper/connect: Fix typo

### DIFF
--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -72,10 +72,10 @@
    Typen der Parameter falsch sind oder die Instanz nicht initialisiert werden konnte.
   </para>
   <caution>
-    <simpara>
-      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname>
-      und deren Ableitungen.
-    </simpara>
+   <simpara>
+    Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname>
+    und deren Ableitungen.
+   </simpara>
   </caution>
  </refsect1>
 

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -51,7 +51,7 @@
     <listitem>
      <para>
       Das Timeout für diese Sitzung, nur gültig, wenn die Verbindung aktuell besteht
-      (d. h. der letzte Watcher-Zustand ist ZOO_CONNECTED_STATE).
+      (&dh; der letzte Watcher-Zustand ist ZOO_CONNECTED_STATE).
      </para>
     </listitem>
    </varlistentry>

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 999d171f3e2972aa42c860916761d0bcb9ce6b70 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="zookeeper.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::connect</refname>
+  <refpurpose>Erzeugt ein Handle zur Kommunikation mit Zookeeper</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>Zookeeper::connect</methodname>
+   <methodparam><type>string</type><parameter>host</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>recv_timeout</parameter><initializer>10000</initializer></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Diese Methode erzeugt ein neues Handle und eine Zookeeper-Sitzung, die diesem
+   Handle entspricht. Der Sitzungsaufbau erfolgt asynchron, das heißt, eine Sitzung
+   sollte erst dann als aufgebaut betrachtet werden, wenn ein Ereignis mit dem Zustand
+   ZOO_CONNECTED_STATE empfangen wird.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <para>
+      Durch Kommas getrennte host:port-Paare, die jeweils einem zk-Server entsprechen,
+      z. B. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Die globale Watcher-Callback-Funktion. Wenn Benachrichtigungen ausgelöst werden,
+      wird diese Funktion aufgerufen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>recv_timeout</parameter></term>
+    <listitem>
+     <para>
+      Das Timeout für diese Sitzung, nur gültig, wenn die Verbindung aktuell besteht
+      (d. h. der letzte Watcher-Zustand ist ZOO_CONNECTED_STATE).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine Warnung aus, wenn die Anzahl oder die
+   Typen der Parameter falsch sind oder die Instanz nicht initialisiert werden konnte.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname>
+      und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -4,7 +4,7 @@
 <refentry xml:id="zookeeper.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>Zookeeper::connect</refname>
-  <refpurpose>Erzeugt ein Handle zur Kommunikation mit Zookeeper</refpurpose>
+  <refpurpose>Erzeugt ein Handle für die Kommunikation mit Zookeeper</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">

--- a/reference/zookeeper/zookeeper/connect.xml
+++ b/reference/zookeeper/zookeeper/connect.xml
@@ -32,8 +32,8 @@
     <term><parameter>host</parameter></term>
     <listitem>
      <para>
-      Durch Kommas getrennte host:port-Paare, die jeweils einem zk-Server entsprechen,
-      z. B. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+      Durch Kommas getrennte host:port-Paare, die jeweils einem ZK-Server entsprechen,
+      &zb; "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Übersetzt die neue Datei <methodname>Zookeeper::connect</methodname> ins Deutsche (zuvor nicht übersetzt) auf dem Stand des aktuellen EN-Texts.

Fixes #272