### PR TITLE
[Sync EN] reflection: ReflectionFunction::__construct() example expects bool param

### DIFF
--- a/reference/reflection/reflectionfunction/construct.xml
+++ b/reference/reflection/reflectionfunction/construct.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 629dfc9ec496d66c49b626dfc72a4981e74d6250 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="reflectionfunction.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFunction::__construct</refname>
+  <refpurpose>Erzeugt ein ReflectionFunction-Objekt</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="ReflectionFunction">
+   <modifier>public</modifier> <methodname>ReflectionFunction::__construct</methodname>
+   <methodparam><type class="union"><type>Closure</type><type>string</type></type><parameter>function</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Erzeugt ein <classname>ReflectionFunction</classname>-Objekt.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>function</parameter></term>
+     <listitem>
+      <para>
+       Der Name der zu reflektierenden Funktion oder eine <link linkend="functions.anonymous">Closure</link>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Eine <classname>ReflectionException</classname>, wenn der Parameter
+   <parameter>function</parameter> keine gültige Funktion enthält.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>ReflectionFunction::__construct</methodname>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+/**
+ * Ein einfacher Zähler
+ *
+ * @return    int
+ */
+function counter1()
+{
+    static $c = 0;
+    return ++$c;
+}
+
+/**
+ * Ein weiterer einfacher Zähler
+ *
+ * @return    int
+ */
+$counter2 = function()
+{
+    static $d = 0;
+    return ++$d;
+
+};
+
+function dumpReflectionFunction($func)
+{
+    // Grundlegende Informationen ausgeben
+    printf(
+        "\n\n===> The %s function '%s'\n".
+        "     declared in %s\n".
+        "     lines %d to %d\n",
+        $func->isInternal() ? 'internal' : 'user-defined',
+        $func->getName(),
+        $func->getFileName(),
+        $func->getStartLine(),
+        $func->getEndline()
+    );
+
+    // Dokumentationskommentar ausgeben
+    printf("---> Documentation:\n %s\n", var_export($func->getDocComment(), true));
+
+    // Statische Variablen ausgeben, falls vorhanden
+    if ($statics = $func->getStaticVariables())
+    {
+        printf("---> Static variables: %s\n", var_export($statics, true));
+    }
+}
+
+// Eine Instanz der Klasse ReflectionFunction erzeugen
+dumpReflectionFunction(new ReflectionFunction('counter1'));
+dumpReflectionFunction(new ReflectionFunction($counter2));
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+===> The user-defined function 'counter1'
+     declared in Z:\reflectcounter.php
+     lines 7 to 11
+---> Documentation:
+ '/**
+ * Ein einfacher Zähler
+ *
+ * @return    int
+ */'
+---> Static variables: array (
+  'c' => 0,
+)
+
+
+===> The user-defined function '{closure}'
+     declared in Z:\reflectcounter.php
+     lines 18 to 23
+---> Documentation:
+ '/**
+ * Ein weiterer einfacher Zähler
+ *
+ * @return    int
+ */'
+---> Static variables: array (
+  'd' => 0,
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionMethod::__construct</methodname></member>
+    <member><link linkend="language.oop5.decon.constructor">Konstruktoren</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neue Datei <methodname>ReflectionFunction::__construct</methodname> ins Deutsche (zuvor nicht übersetzt) auf dem Stand des aktuellen EN-Texts.

Fixes #275