### PR TITLE
[Sync EN] phar:setStub Change the parameter type to match stub

### DIFF
--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 4c394e560dac163a0be9098de27153a9f98ef490 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="phardata.setstub">
+ <refnamediv>
+  <refname>PharData::setStub</refname>
+  <refpurpose>Dummy-Funktion (Phar::setStub ist für PharData nicht gültig)</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PharData">
+   <modifier>public</modifier> <type>true</type><methodname>PharData::setStub</methodname>
+   <methodparam><type class="union"><type>resource</type><type>string</type></type><parameter>stub</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+
+
+  <para>
+   Nicht ausführbare tar/zip-Archive können keinen Stub haben, daher wirft diese
+   Methode einfach eine Ausnahme.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>stub</parameter></term>
+     <listitem>
+      <para>
+       Ein String oder ein offenes Stream-Handle, das als ausführbarer Stub für dieses
+       Phar-Archiv verwendet werden soll.  Dieser Parameter wird ignoriert.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>length</parameter></term>
+     <listitem>
+      <para>
+
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.true.always;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Wirft bei allen Methodenaufrufen eine <classname>PharException</classname>
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.84;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>Phar::setStub</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -17,7 +17,7 @@
 
   <para>
    Nicht ausführbare tar/zip-Archive können keinen Stub haben, daher wirft diese
-   Methode einfach eine Ausnahme.
+   Methode einfach eine Exception.
   </para>
  </refsect1>
 

--- a/reference/phar/PharData/setStub.xml
+++ b/reference/phar/PharData/setStub.xml
@@ -29,8 +29,8 @@
      <term><parameter>stub</parameter></term>
      <listitem>
       <para>
-       Ein String oder ein offenes Stream-Handle, das als ausführbarer Stub für dieses
-       Phar-Archiv verwendet werden soll.  Dieser Parameter wird ignoriert.
+       Eine Zeichenkette oder ein offenes Stream-Handle, das als ausführbarer Stub für
+       dieses Phar-Archiv verwendet werden soll. Dieser Parameter wird ignoriert.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
Übersetzt die neue Datei <methodname>PharData::setStub</methodname> ins Deutsche (zuvor nicht übersetzt) auf dem Stand des aktuellen EN-Texts.

Fixes #271