### PR TITLE
[Sync EN] Fix typos and spelling mistakes (#5582)

### DIFF
--- a/reference/event/eventbuffer/write.xml
+++ b/reference/event/eventbuffer/write.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision: $ -->
-<!-- EN-Revision: e41806c30bf6975e452c0d4ce35ab0984c2fa68c Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: cmb Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="eventbuffer.write" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -36,10 +36,10 @@
      <parameter>fd</parameter>
     </term>
     <listitem>
-     <para>
+     <simpara>
       Socket-Ressource, Stream oder numerischer Datei-Deskriptor normalerweise
       verbunden mit einem Socket.
-     </para>
+     </simpara>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/reference/gnupg/functions/gnupg-getengineinfo.xml
+++ b/reference/gnupg/functions/gnupg-getengineinfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: a148eb08b658eafa139f8996ad92d860e023da3f Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gnupg-getengineinfo">
  <refnamediv>

--- a/reference/mysql_xdevapi/mysql_xdevapi/columnresult/isnumbersigned.xml
+++ b/reference/mysql_xdevapi/mysql_xdevapi/columnresult/isnumbersigned.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: ee52285714f7f7371364a3e5233d2ca2da078706 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 
 <refentry xml:id="mysql-xdevapi-columnresult.isnumbersigned" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -30,10 +30,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Gibt &true; zurück, wenn der Typ der angegebenen Spalte vorzeichenbehaftet
    ist.
-  </para>
+  </simpara>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/strings/functions/utf8-decode.xml
+++ b/reference/strings/functions/utf8-decode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 9b1673cf114a1e10c4563ab9223cb56aed552b89 Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a223531900823441f82d178ca4e94c0444f24576 Reviewer: samesch -->
 <refentry xml:id="function.utf8-decode" xmlns="http://docbook.org/ns/docbook">
@@ -236,7 +236,7 @@ var_dump($iso8859_1_string);
      &example.outputs;
      <screen>
 <![CDATA[
-sring(1) "?"
+string(1) "?"
 ]]>
      </screen>
     </informalexample>

--- a/security/cgi-bin.xml
+++ b/security/cgi-bin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 <!-- splitted from ./index.xml, last change in rev 1.66 -->
-<!-- EN-Revision: 87d3bf2e9ea7da5abbeca3e60ea7cf7abfa6f7f3 Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: wiesemann Status: ready -->
   <chapter xml:id="security.cgi-bin" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>Installiert als CGI-Version</title>
 


### PR DESCRIPTION
Bringt die bestehenden doc-de Dateien auf den Stand der Nit-PR upstream (`php/doc-en#5582`, codespell/Tippfehler).

Da die englischen Tippfehler sprachspezifisch waren, vermittelten die deutschen Übersetzungen die korrigierte Bedeutung bereits. Die Änderungen bestehen daher überwiegend aus EN-Revision-Bumps, den entsprechenden `<para>` → `<simpara>`-Spiegelungen und der Korrektur eines Tippfehlers in einer `<screen>`-Ausgabe (`sring` → `string`). Die bestehenden `Maintainer:`-Einträge wurden beibehalten.

Adressiert teilweise #242: nur der Abschnitt „Zu aktualisierende DE-Dateien“. Der Abschnitt „Neue EN-Dateien (noch nicht übersetzt)“ bleibt für nachfolgende Übersetzungs-Arbeit offen.