### PR TITLE
[Sync EN] zookeeper: German translation of new files

### DIFF
--- a/reference/zookeeper/zookeeper.xml
+++ b/reference/zookeeper/zookeeper.xml
@@ -1,0 +1,831 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.zookeeper"
+ role="class"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns="http://docbook.org/ns/docbook">
+ <title>Die Zookeeper-Klasse</title>
+ <titleabbrev>Zookeeper</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Zookeeper intro -->
+  <section xml:id="zookeeper.intro">
+   &reftitle.intro;
+   <para>
+    Stellt eine ZooKeeper-Sitzung dar.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="zookeeper.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>Zookeeper</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>Zookeeper</classname>
+     </ooclass>
+
+    </classsynopsisinfo>
+<!-- }}} -->
+
+<!-- {{{ Class methods -->
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeper')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])">
+     <xi:fallback />
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.zookeeper')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])">
+     <xi:fallback />
+    </xi:include>
+<!-- }}} -->
+
+<!-- {{{ Class constants -->
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.perm-read">PERM_READ</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.perm-write">PERM_WRITE</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.perm-create">PERM_CREATE</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.perm-delete">PERM_DELETE</varname>
+     <initializer>8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.perm-admin">PERM_ADMIN</varname>
+     <initializer>16</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.perm-all">PERM_ALL</varname>
+     <initializer>31</initializer>
+    </fieldsynopsis>
+
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.ephemeral">EPHEMERAL</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.sequence">SEQUENCE</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.log-level-error">LOG_LEVEL_ERROR</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.log-level-warn">LOG_LEVEL_WARN</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.log-level-info">LOG_LEVEL_INFO</varname>
+     <initializer>3</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.log-level-debug">LOG_LEVEL_DEBUG</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.expired-session-state">EXPIRED_SESSION_STATE</varname>
+     <initializer>-112</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.auth-failed-state">AUTH_FAILED_STATE</varname>
+     <initializer>-113</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.connecting-state">CONNECTING_STATE</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.associating-state">ASSOCIATING_STATE</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.connected-state">CONNECTED_STATE</varname>
+     <initializer>3</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.readonly-state">READONLY_STATE</varname>
+     <initializer>5</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.notconnected-state">NOTCONNECTED_STATE</varname>
+     <initializer>999</initializer>
+    </fieldsynopsis>
+
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.created-event">CREATED_EVENT</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.deleted-event">DELETED_EVENT</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.changed-event">CHANGED_EVENT</varname>
+     <initializer>3</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.child-event">CHILD_EVENT</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.session-event">SESSION_EVENT</varname>
+     <initializer>-1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.notwatching-event">NOTWATCHING_EVENT</varname>
+     <initializer>-2</initializer>
+    </fieldsynopsis>
+
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.systemerror">SYSTEMERROR</varname>
+     <initializer>-1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.runtimeinconsistency">RUNTIMEINCONSISTENCY</varname>
+     <initializer>-2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.datainconsistency">DATAINCONSISTENCY</varname>
+     <initializer>-3</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.connectionloss">CONNECTIONLOSS</varname>
+     <initializer>-4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.marshallingerror">MARSHALLINGERROR</varname>
+     <initializer>-5</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.unimplemented">UNIMPLEMENTED</varname>
+     <initializer>-6</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.operationtimeout">OPERATIONTIMEOUT</varname>
+     <initializer>-7</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.badarguments">BADARGUMENTS</varname>
+     <initializer>-8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.invalidstate">INVALIDSTATE</varname>
+     <initializer>-9</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.newconfignoquorum">NEWCONFIGNOQUORUM</varname>
+     <initializer>-13</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.reconfiginprogress">RECONFIGINPROGRESS</varname>
+     <initializer>-14</initializer>
+    </fieldsynopsis>
+
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.ok">OK</varname>
+     <initializer>0</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.apierror">APIERROR</varname>
+     <initializer>-100</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.nonode">NONODE</varname>
+     <initializer>-101</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.noauth">NOAUTH</varname>
+     <initializer>-102</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.badversion">BADVERSION</varname>
+     <initializer>-103</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.nochildrenforephemerals">NOCHILDRENFOREPHEMERALS</varname>
+     <initializer>-108</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.nodeexists">NODEEXISTS</varname>
+     <initializer>-110</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.notempty">NOTEMPTY</varname>
+     <initializer>-111</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.sessionexpired">SESSIONEXPIRED</varname>
+     <initializer>-112</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.invalidcallback">INVALIDCALLBACK</varname>
+     <initializer>-113</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.invalidacl">INVALIDACL</varname>
+     <initializer>-114</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.authfailed">AUTHFAILED</varname>
+     <initializer>-115</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.closing">CLOSING</varname>
+     <initializer>-116</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.nothing">NOTHING</varname>
+     <initializer>-117</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.sessionmoved">SESSIONMOVED</varname>
+     <initializer>-118</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.notreadonly">NOTREADONLY</varname>
+     <initializer>-119</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.ephemeralonlocalsession">EPHEMERALONLOCALSESSION</varname>
+     <initializer>-120</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.nowatcher">NOWATCHER</varname>
+     <initializer>-121</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="zookeeper.constants.reconfigdisabled">RECONFIGDISABLED</varname>
+     <initializer>-122</initializer>
+    </fieldsynopsis>
+<!-- }}} -->
+
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+<!-- {{{ Constants -->
+  <section xml:id="zookeeper.class.constants">
+   &reftitle.constants;
+
+<!-- {{{ Constants Permissions -->
+   <section xml:id="zookeeper.constants.perms">
+    <title><acronym>ZooKeeper</acronym>-Berechtigungen</title>
+    <variablelist>
+
+     <varlistentry xml:id="zookeeper.constants.perm-read">
+      <term><constant>Zookeeper::PERM_READ</constant></term>
+      <listitem>
+       <para>Kann den Wert von Knoten lesen und deren Kindknoten auflisten</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.perm-write">
+      <term><constant>Zookeeper::PERM_WRITE</constant></term>
+      <listitem>
+       <para>Kann den Wert von Knoten setzen</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.perm-create">
+      <term><constant>Zookeeper::PERM_CREATE</constant></term>
+      <listitem>
+       <para>Kann Kindknoten erstellen</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.perm-delete">
+      <term><constant>Zookeeper::PERM_DELETE</constant></term>
+      <listitem>
+       <para>Kann Kindknoten löschen</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.perm-admin">
+      <term><constant>Zookeeper::PERM_ADMIN</constant></term>
+      <listitem>
+       <para>Kann set_acl() ausführen</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.perm-all">
+      <term><constant>Zookeeper::PERM_ALL</constant></term>
+      <listitem>
+       <para>Alle der oben genannten Flags mit ODER verknüpft</para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+<!-- {{{ Constants Create Flags -->
+   <section xml:id="zookeeper.constants.create-flags">
+    <title><acronym>ZooKeeper</acronym>-Erstellungs-Flags</title>
+    <variablelist>
+
+     <varlistentry xml:id="zookeeper.constants.ephemeral">
+      <term><constant>Zookeeper::EPHEMERAL</constant></term>
+      <listitem>
+       <para>Ist das Flag Zookeeper::EPHEMERAL gesetzt, wird der Knoten automatisch entfernt, sobald die Client-Sitzung beendet wird.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.sequence">
+      <term><constant>Zookeeper::SEQUENCE</constant></term>
+      <listitem>
+       <para>Ist das Flag Zookeeper::SEQUENCE gesetzt, wird dem Pfadnamen eine eindeutige, monoton steigende Sequenznummer angehängt. Die Sequenznummer hat stets eine feste Länge von 10 Stellen und wird mit Nullen aufgefüllt.</para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+<!-- {{{ Constants Log Levels -->
+   <section xml:id="zookeeper.constants.log-levels">
+    <title><acronym>ZooKeeper</acronym>-Protokollierungsstufen</title>
+    <variablelist>
+
+     <varlistentry xml:id="zookeeper.constants.log-level-error">
+      <term><constant>Zookeeper::LOG_LEVEL_ERROR</constant></term>
+      <listitem>
+       <simpara>Gibt nur Fehlermeldungen aus</simpara>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.log-level-warn">
+      <term><constant>Zookeeper::LOG_LEVEL_WARN</constant></term>
+      <listitem>
+       <para>Gibt Fehler/Warnungen aus</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.log-level-info">
+      <term><constant>Zookeeper::LOG_LEVEL_INFO</constant></term>
+      <listitem>
+       <para>Gibt neben Fehlern/Warnungen auch Meldungen über wichtige Aktionen aus</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.log-level-debug">
+      <term><constant>Zookeeper::LOG_LEVEL_DEBUG</constant></term>
+      <listitem>
+       <para>Gibt alles aus</para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+<!-- {{{ Constants States -->
+   <section xml:id="zookeeper.constants.states">
+    <title><acronym>ZooKeeper</acronym>-Zustände</title>
+    <variablelist>
+
+     <varlistentry xml:id="zookeeper.constants.expired-session-state">
+      <term><constant>Zookeeper::EXPIRED_SESSION_STATE</constant></term>
+      <listitem>
+       <para>Verbunden, aber die Sitzung ist abgelaufen</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.auth-failed-state">
+      <term><constant>Zookeeper::AUTH_FAILED_STATE</constant></term>
+      <listitem>
+       <para>Verbunden, aber die Authentifizierung ist fehlgeschlagen</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.connecting-state">
+      <term><constant>Zookeeper::CONNECTING_STATE</constant></term>
+      <listitem>
+       <para>Verbindungsaufbau läuft</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.associating-state">
+      <term><constant>Zookeeper::ASSOCIATING_STATE</constant></term>
+      <listitem>
+       <para>Zuordnung läuft</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.connected-state">
+      <term><constant>Zookeeper::CONNECTED_STATE</constant></term>
+      <listitem>
+       <para>Verbunden</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.readonly-state">
+      <term><constant>Zookeeper::READONLY_STATE</constant></term>
+      <listitem>
+       <para>TODO: Helfen Sie uns, diese Erweiterung zu verbessern.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.notconnected-state">
+      <term><constant>Zookeeper::NOTCONNECTED_STATE</constant></term>
+      <listitem>
+       <para>Verbindung fehlgeschlagen</para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+<!-- {{{ Constants Watch Types -->
+   <section xml:id="zookeeper.constants.watch-types">
+    <title><acronym>ZooKeeper</acronym>-Watch-Typen</title>
+    <variablelist>
+
+     <varlistentry xml:id="zookeeper.constants.created-event">
+      <term><constant>Zookeeper::CREATED_EVENT</constant></term>
+      <listitem>
+       <para>Ein Knoten wurde erstellt</para>
+       <para>Dies wird nur durch Watches auf nicht existierende Knoten ausgelöst. Diese Watches werden mit Zookeeper::exists gesetzt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.deleted-event">
+      <term><constant>Zookeeper::DELETED_EVENT</constant></term>
+      <listitem>
+       <para>Ein Knoten wurde gelöscht</para>
+       <para>Dies wird nur durch Watches auf Knoten ausgelöst. Diese Watches werden mit Zookeeper::exists und Zookeeper::get gesetzt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.changed-event">
+      <term><constant>Zookeeper::CHANGED_EVENT</constant></term>
+      <listitem>
+       <para>Ein Knoten wurde geändert</para>
+       <para>Dies wird nur durch Watches auf Knoten ausgelöst. Diese Watches werden mit Zookeeper::exists und Zookeeper::get gesetzt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.child-event">
+      <term><constant>Zookeeper::CHILD_EVENT</constant></term>
+      <listitem>
+       <simpara>In der Liste der Kindknoten ist eine Änderung aufgetreten</simpara>
+       <para>Dies wird nur durch Watches auf die Kindknotenliste eines Knotens ausgelöst. Diese Watches werden mit Zookeeper::getChildren gesetzt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.session-event">
+      <term><constant>Zookeeper::SESSION_EVENT</constant></term>
+      <listitem>
+       <para>Eine Sitzung wurde verloren</para>
+       <para>Dies wird ausgelöst, wenn ein Client den Kontakt zu einem Server verliert oder die Verbindung wiederherstellt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.notwatching-event">
+      <term><constant>Zookeeper::NOTWATCHING_EVENT</constant></term>
+      <listitem>
+       <para>Ein Watch wurde entfernt</para>
+       <para>Dies wird ausgelöst, wenn der Server aus irgendeinem Grund, vermutlich einer Ressourcenbeschränkung, einen Knoten nicht länger für einen Client überwacht.</para>
+      </listitem>
+     </varlistentry>
+
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+<!-- {{{ Constants System and Server-side Errors -->
+   <section xml:id="zookeeper.constants.system-n-server-side-errors">
+    <title><acronym>ZooKeeper</acronym>-System- und serverseitige Fehler</title>
+    <variablelist>
+     <varlistentry xml:id="zookeeper.constants.systemerror">
+      <term><constant>Zookeeper::SYSTEMERROR</constant></term>
+      <listitem>
+       <para>Dieser wird vom Server niemals geworfen; er sollte nur dazu verwendet werden, einen Bereich anzugeben. Konkret sind Fehlercodes, die größer als dieser Wert, aber kleiner als Zookeeper::APIERROR sind, Systemfehler.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.runtimeinconsistency">
+      <term><constant>Zookeeper::RUNTIMEINCONSISTENCY</constant></term>
+      <listitem>
+       <para>Eine Laufzeitinkonsistenz wurde festgestellt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.datainconsistency">
+      <term><constant>Zookeeper::DATAINCONSISTENCY</constant></term>
+      <listitem>
+       <para>Eine Dateninkonsistenz wurde festgestellt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.connectionloss">
+      <term><constant>Zookeeper::CONNECTIONLOSS</constant></term>
+      <listitem>
+       <para>Die Verbindung zum Server wurde verloren.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.marshallingerror">
+      <term><constant>Zookeeper::MARSHALLINGERROR</constant></term>
+      <listitem>
+       <para>Fehler beim Marshalling oder Unmarshalling von Daten.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.unimplemented">
+      <term><constant>Zookeeper::UNIMPLEMENTED</constant></term>
+      <listitem>
+       <para>Die Operation ist nicht implementiert.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.operationtimeout">
+      <term><constant>Zookeeper::OPERATIONTIMEOUT</constant></term>
+      <listitem>
+       <para>Zeitüberschreitung bei der Operation.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.badarguments">
+      <term><constant>Zookeeper::BADARGUMENTS</constant></term>
+      <listitem>
+       <para>Ungültige Argumente.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.invalidstate">
+      <term><constant>Zookeeper::INVALIDSTATE</constant></term>
+      <listitem>
+       <para>Ungültiger zhandle-Zustand.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.newconfignoquorum">
+      <term><constant>Zookeeper::NEWCONFIGNOQUORUM</constant></term>
+      <listitem>
+       <para>Kein Quorum der neuen Konfiguration ist verbunden und auf dem aktuellen Stand mit dem Leader der zuletzt bestätigten Konfiguration: Versuchen Sie die Rekonfiguration, nachdem neue Server verbunden und synchronisiert sind.</para>
+       <para>Verfügbar ab ZooKeeper 3.5.0</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.reconfiginprogress">
+      <term><constant>Zookeeper::RECONFIGINPROGRESS</constant></term>
+      <listitem>
+       <para>Eine Rekonfiguration wurde angefordert, während eine andere Rekonfiguration gerade in Bearbeitung ist. Dies wird derzeit nicht unterstützt. Bitte erneut versuchen.</para>
+       <para>Verfügbar ab ZooKeeper 3.5.0</para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+<!-- {{{ Constants API Errors -->
+   <section xml:id="zookeeper.constants.api-errors">
+    <title><acronym>ZooKeeper</acronym>-API-Fehler</title>
+    <variablelist>
+     <varlistentry xml:id="zookeeper.constants.ok">
+      <term><constant>Zookeeper::OK</constant></term>
+      <listitem>
+       <para>Alles ist in Ordnung.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.apierror">
+      <term><constant>Zookeeper::APIERROR</constant></term>
+      <listitem>
+       <para>Dieser wird vom Server niemals geworfen; er sollte nur dazu verwendet werden, einen Bereich anzugeben. Konkret sind Fehlercodes, die größer als dieser Wert sind, API-Fehler (während Werte kleiner als dieser einen Zookeeper::SYSTEMERROR anzeigen).</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.nonode">
+      <term><constant>Zookeeper::NONODE</constant></term>
+      <listitem>
+       <para>Der Knoten existiert nicht.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.noauth">
+      <term><constant>Zookeeper::NOAUTH</constant></term>
+      <listitem>
+       <para>Nicht authentifiziert.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.badversion">
+      <term><constant>Zookeeper::BADVERSION</constant></term>
+      <listitem>
+       <para>Versionskonflikt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.nochildrenforephemerals">
+      <term><constant>Zookeeper::NOCHILDRENFOREPHEMERALS</constant></term>
+      <listitem>
+       <para>Ephemere Knoten dürfen keine Kindknoten haben.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.nodeexists">
+      <term><constant>Zookeeper::NODEEXISTS</constant></term>
+      <listitem>
+       <para>Der Knoten existiert bereits.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.notempty">
+      <term><constant>Zookeeper::NOTEMPTY</constant></term>
+      <listitem>
+       <para>Der Knoten hat Kindknoten.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.sessionexpired">
+      <term><constant>Zookeeper::SESSIONEXPIRED</constant></term>
+      <listitem>
+       <para>Die Sitzung wurde vom Server für abgelaufen erklärt.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.invalidcallback">
+      <term><constant>Zookeeper::INVALIDCALLBACK</constant></term>
+      <listitem>
+       <para>Ungültiger Callback angegeben.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.invalidacl">
+      <term><constant>Zookeeper::INVALIDACL</constant></term>
+      <listitem>
+       <para>Ungültige ACL angegeben.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.authfailed">
+      <term><constant>Zookeeper::AUTHFAILED</constant></term>
+      <listitem>
+       <para>Die Client-Authentifizierung ist fehlgeschlagen.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.closing">
+      <term><constant>Zookeeper::CLOSING</constant></term>
+      <listitem>
+       <para>ZooKeeper wird geschlossen.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.nothing">
+      <term><constant>Zookeeper::NOTHING</constant></term>
+      <listitem>
+       <para>(kein Fehler) Keine Serverantworten zu verarbeiten.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.sessionmoved">
+      <term><constant>Zookeeper::SESSIONMOVED</constant></term>
+      <listitem>
+       <para>Die Sitzung wurde auf einen anderen Server verschoben, daher wird die Operation ignoriert.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.notreadonly">
+      <term><constant>Zookeeper::NOTREADONLY</constant></term>
+      <listitem>
+       <para>Eine zustandsändernde Anfrage wurde an einen schreibgeschützten Server übergeben.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.ephemeralonlocalsession">
+      <term><constant>Zookeeper::EPHEMERALONLOCALSESSION</constant></term>
+      <listitem>
+       <para>Versuch, einen ephemeren Knoten in einer lokalen Sitzung zu erstellen.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.nowatcher">
+      <term><constant>Zookeeper::NOWATCHER</constant></term>
+      <listitem>
+       <para>Der Watcher konnte nicht gefunden werden.</para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="zookeeper.constants.reconfigdisabled">
+      <term><constant>Zookeeper::RECONFIGDISABLED</constant></term>
+      <listitem>
+       <para>Versuche, eine Rekonfigurationsoperation durchzuführen, während die Rekonfigurationsfunktion deaktiviert ist.</para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </section>
+<!-- }}} -->
+
+  </section>
+
+<!-- }}} -->
+
+ </partintro>
+
+ &reference.zookeeper.entities.zookeeper;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/addauth.xml
+++ b/reference/zookeeper/zookeeper/addauth.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.addauth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::addAuth</refname>
+  <refpurpose>Anwendungsanmeldedaten angeben</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::addAuth</methodname>
+   <methodparam><type>string</type><parameter>scheme</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cert</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>completion_cb</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Die Anwendung ruft diese Funktion auf, um ihre Anmeldedaten zum Zweck der Authentifizierung anzugeben. Der Server verwendet den durch den Parameter scheme angegebenen Sicherheitsanbieter, um die Client-Verbindung zu authentifizieren. Falls die Authentifizierungsanfrage fehlgeschlagen ist:
+    - wird die Serververbindung getrennt.
+    - wird der Watcher mit dem Wert ZOO_AUTH_FAILED_STATE als state-Parameter aufgerufen.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>scheme</parameter></term>
+    <listitem>
+     <para>
+      Die Kennung des Authentifizierungsschemas. Nativ unterstützt: "digest", passwortbasierte Authentifizierung
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cert</parameter></term>
+    <listitem>
+     <para>
+      Anwendungsanmeldedaten. Der tatsächliche Wert hängt vom Schema ab.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>completion_cb</parameter></term>
+    <listitem>
+     <para>
+      Die aufzurufende Routine, sobald die Anfrage abgeschlossen ist. Einer der folgenden Ergebniscodes kann an den Abschluss-Callback übergeben werden:
+      - ZOK Operation erfolgreich abgeschlossen
+      - ZAUTHFAILED Authentifizierung fehlgeschlagen
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder die Operation fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.addauth.example.basic">
+   <title><methodname>Zookeeper::addAuth</methodname>-Beispiel</title>
+   <para>
+     Authentifizierung hinzufügen, bevor der Wert eines Knotens abgefragt wird.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$value = 'nodevalue';
+$zookeeper->set($path, $value);
+
+$zookeeper->addAuth('digest', 'user0:passwd0');
+$r = $zookeeper->get($path);
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+nodevalue
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::setAcl</methodname></member>
+   <member><methodname>Zookeeper::getAcl</methodname></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper-Zustände</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/close.xml
+++ b/reference/zookeeper/zookeeper/close.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.close" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::close</refname>
+  <refpurpose>Das Zookeeper-Handle schließen und alle Ressourcen freigeben</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>Zookeeper::close</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Diese Methode wirft <classname>ZookeeperException</classname> und deren Ableitungen, wenn eine nicht initialisierte Instanz geschlossen wird.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/construct.xml
+++ b/reference/zookeeper/zookeeper/construct.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::__construct</refname>
+  <refpurpose>Ein Handle für die Kommunikation mit Zookeeper erstellen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="oop">
+   <modifier>public</modifier>
+   <methodname>Zookeeper::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>host</parameter><initializer>''</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>recv_timeout</parameter><initializer>10000</initializer></methodparam>
+  </constructorsynopsis>
+  <para>
+   Diese Methode erstellt ein neues Handle und eine Zookeeper-Sitzung, die diesem Handle entspricht. Der Sitzungsaufbau erfolgt asynchron, das heißt, die Sitzung sollte erst dann als aufgebaut betrachtet werden, wenn (und sofern) ein Ereignis mit dem Zustand ZOO_CONNECTED_STATE empfangen wird.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>host</parameter></term>
+    <listitem>
+     <para>
+      kommagetrennte host:port-Paare, von denen jedes einem zk-Server entspricht, z. B. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002"
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      die globale Watcher-Callback-Funktion. Wenn Benachrichtigungen ausgelöst werden, wird diese Funktion aufgerufen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>recv_timeout</parameter></term>
+    <listitem>
+     <para>
+      die Zeitüberschreitung für diese Sitzung, nur gültig, wenn die Verbindung aktuell verbunden ist (d. h. der letzte Watcher-Zustand ist ZOO_CONNECTED_STATE).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder die Instanz nicht initialisiert werden konnte.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/create.xml
+++ b/reference/zookeeper/zookeeper/create.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.create" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::create</refname>
+  <refpurpose>Einen Knoten synchron erstellen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>string</type><methodname>Zookeeper::create</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
+   <methodparam><type>array</type><parameter>acls</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Diese Methode erstellt einen Knoten in ZooKeeper. Ein Knoten kann nur erstellt werden, wenn er nicht bereits existiert. Die Erstellungs-Flags beeinflussen die Erstellung von Knoten. Ist das Flag ZOO_EPHEMERAL gesetzt, wird der Knoten automatisch entfernt, sobald die Client-Sitzung beendet wird. Ist das Flag ZOO_SEQUENCE gesetzt, wird dem Pfadnamen eine eindeutige, monoton steigende Sequenznummer angehängt.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      Die im Knoten zu speichernden Daten.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>acls</parameter></term>
+    <listitem>
+     <para>
+      Die anfängliche ACL des Knotens. Die ACL darf nicht null oder leer sein.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+     <para>
+      dieser Parameter kann für eine normale Erstellung auf 0 gesetzt werden oder eine ODER-Verknüpfung der Erstellungs-Flags sein
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg den Pfad des neuen Knotens zurück (dieser kann sich aufgrund des Flags ZOO_SEQUENCE vom angegebenen Pfad unterscheiden) und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Erstellen des Knotens fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.create.example.basic">
+   <title><methodname>Zookeeper::create</methodname>-Beispiel</title>
+   <para>
+     Einen neuen Knoten erstellen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$aclArray = array(
+  array(
+    'perms'  => Zookeeper::PERM_ALL,
+    'scheme' => 'world',
+    'id'     => 'anyone',
+  )
+);
+$path = '/path/to/newnode';
+$realPath = $zookeeper->create($path, null, $aclArray);
+if ($realPath)
+  echo $realPath;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+/path/to/newnode
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::delete</methodname></member>
+   <member><methodname>Zookeeper::getChildren</methodname></member>
+   <member><link linkend="zookeeper.constants.perms">ZooKeeper-Berechtigungen</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/delete.xml
+++ b/reference/zookeeper/zookeeper/delete.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::delete</refname>
+  <refpurpose>Einen Knoten in Zookeeper synchron löschen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::delete</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Die erwartete Version des Knotens. Die Funktion schlägt fehl, wenn die tatsächliche Version des Knotens nicht mit der erwarteten Version übereinstimmt. Wird -1 verwendet, findet keine Versionsprüfung statt.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Löschen des Knotens fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.delete.example.basic">
+   <title><methodname>Zookeeper::delete</methodname>-Beispiel</title>
+   <para>
+     Einen vorhandenen Knoten löschen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$r = $zookeeper->delete($path);
+if ($r)
+  echo 'SUCCESS';
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+SUCCESS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::getChildren</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/exists.xml
+++ b/reference/zookeeper/zookeeper/exists.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.exists" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::exists</refname>
+  <refpurpose>Prüft synchron, ob ein Knoten in Zookeeper existiert</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>array</type><methodname>Zookeeper::exists</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      ist dieser Wert ungleich null, wird auf dem Server ein Watch gesetzt, um den Client zu benachrichtigen, wenn sich der Knoten ändert. Der Watch wird auch dann gesetzt, wenn der Knoten nicht existiert
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt den stat-Wert für den Pfad zurück, falls der angegebene Knoten existiert, andernfalls false.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder die Prüfung auf die Existenz eines Knotens fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.exists.example.basic">
+   <title><methodname>Zookeeper::exists</methodname>-Beispiel</title>
+   <para>
+     Die Existenz eines Knotens prüfen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$r = $zookeeper->exists($path);
+if ($r)
+  echo 'EXISTS';
+else
+  echo 'N/A or ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+EXISTS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::get</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/get.xml
+++ b/reference/zookeeper/zookeeper/get.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::get</refname>
+  <refpurpose>Ruft die einem Knoten zugeordneten Daten synchron ab</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>string</type><methodname>Zookeeper::get</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>max_size</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert ungleich null, wird auf dem Server ein Watch gesetzt, um den Client zu benachrichtigen, wenn sich der Knoten ändert.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert nicht NULL, enthält er bei der Rückkehr den stat-Wert für den Pfad.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>max_size</parameter></term>
+    <listitem>
+     <para>
+      Maximale Größe der Daten. Wird 0 verwendet, gibt diese Methode die gesamten Daten zurück.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die Daten zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Abrufen des Werts aus dem Knoten fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.get.example.basic">
+   <title><methodname>Zookeeper::get</methodname>-Beispiel</title>
+   <para>
+     Wert aus einem Knoten abrufen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$value = 'nodevalue';
+$zookeeper->set($path, $value);
+
+$r = $zookeeper->get($path);
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+nodevalue
+]]>
+   </screen>
+  </example>
+
+  <example xml:id="zookeeper.get.example.stat">
+   <title><methodname>Zookeeper::get</methodname>-stat-Beispiel</title>
+   <para>
+     Stat-Informationen eines Knotens abrufen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$stat = [];
+$zookeeper->get($path, null, $stat);
+var_dump($stat);
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(11) {
+  ["czxid"]=>
+  float(0)
+  ["mzxid"]=>
+  float(0)
+  ["ctime"]=>
+  float(0)
+  ["mtime"]=>
+  float(0)
+  ["version"]=>
+  int(0)
+  ["cversion"]=>
+  int(-2)
+  ["aversion"]=>
+  int(0)
+  ["ephemeralOwner"]=>
+  float(0)
+  ["dataLength"]=>
+  int(0)
+  ["numChildren"]=>
+  int(2)
+  ["pzxid"]=>
+  float(0)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::set</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getacl.xml
+++ b/reference/zookeeper/zookeeper/getacl.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.getacl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getAcl</refname>
+  <refpurpose>Ruft die einem Knoten zugeordnete ACL synchron ab</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>array</type><methodname>Zookeeper::getAcl</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg ein ACL-Array zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Abrufen der ACL eines Knotens fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.getacl.example.basic">
+   <title><methodname>Zookeeper::getAcl</methodname>-Beispiel</title>
+   <para>
+     Die ACL eines Knotens abrufen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$aclArray = array(
+  array(
+    'perms'  => Zookeeper::PERM_ALL,
+    'scheme' => 'world',
+    'id'     => 'anyone',
+  )
+);
+$path = '/path/to/newnode';
+$zookeeper->setAcl($path, $aclArray);
+
+$r = $zookeeper->getAcl($path);
+if ($r)
+  var_dump($r);
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  array(3) {
+    ["perms"]=>
+    int(31)
+    ["scheme"]=>
+    string(5) "world"
+    ["id"]=>
+    string(6) "anyone"
+  }
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::setAcl</methodname></member>
+   <member><link linkend="zookeeper.constants.perms">ZooKeeper-Berechtigungen</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getchildren.xml
+++ b/reference/zookeeper/zookeeper/getchildren.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.getchildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getChildren</refname>
+  <refpurpose>Listet die Kindknoten eines Knotens synchron auf</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>array</type><methodname>Zookeeper::getChildren</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert ungleich null, wird auf dem Server ein Watch gesetzt, um den Client zu benachrichtigen, wenn sich der Knoten ändert.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg ein Array mit den Pfaden der Kindknoten zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Auflisten der Kindknoten eines Knotens fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.getchildren.example.basic">
+   <title><methodname>Zookeeper::getChildren</methodname>-Beispiel</title>
+   <para>
+     Listet die Kindknoten eines Knotens auf.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/zookeeper';
+$r = $zookeeper->getchildren($path);
+
+if ($r) {
+    var_dump($r);
+} else {
+    echo 'ERR';
+}
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  string(6) "config"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::delete</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getclientid.xml
+++ b/reference/zookeeper/zookeeper/getclientid.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.getclientid" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getClientId</refname>
+  <refpurpose>Gibt die Sitzungs-ID des Clients zurück, nur gültig, wenn die Verbindung aktuell verbunden ist (d. h. der letzte Watcher-Zustand ist ZOO_CONNECTED_STATE)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>int</type><methodname>Zookeeper::getClientId</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die Sitzungs-ID des Clients zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Sitzungs-ID des Clients nicht ermittelt werden konnte.
+  </para>
+  <caution>
+    <para>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </para>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><methodname>Zookeeper::getState</methodname></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper-Zustände</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getrecvtimeout.xml
+++ b/reference/zookeeper/zookeeper/getrecvtimeout.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.getrecvtimeout" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getRecvTimeout</refname>
+  <refpurpose>Gibt die Zeitüberschreitung für diese Sitzung zurück, nur gültig, wenn die Verbindung aktuell verbunden ist (d. h. der letzte Watcher-Zustand ist ZOO_CONNECTED_STATE). Dieser Wert kann sich nach einer erneuten Serververbindung ändern</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>int</type><methodname>Zookeeper::getRecvTimeout</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die Zeitüberschreitung für diese Sitzung zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Operation fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/getstate.xml
+++ b/reference/zookeeper/zookeeper/getstate.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.getstate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::getState</refname>
+  <refpurpose>Ruft den Zustand der Zookeeper-Verbindung ab</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>int</type><methodname>Zookeeper::getState</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg den Zustand der Zookeeper-Verbindung zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn das Abrufen des Zustands der Zookeeper-Verbindung fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><methodname>Zookeeper::getClientId</methodname></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper-Zustände</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/isrecoverable.xml
+++ b/reference/zookeeper/zookeeper/isrecoverable.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.isrecoverable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::isRecoverable</refname>
+  <refpurpose>Prüft, ob der aktuelle Zustand der Zookeeper-Verbindung wiederhergestellt werden kann</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::isRecoverable</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Die Anwendung muss das Handle schließen und versuchen, die Verbindung wiederherzustellen.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg true/false zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Operation fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><methodname>Zookeeper::getClientId</methodname></member>
+   <member><link linkend="zookeeper.constants.states">ZooKeeper-Zustände</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/set.xml
+++ b/reference/zookeeper/zookeeper/set.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::set</refname>
+  <refpurpose>Setzt die einem Knoten zugeordneten Daten</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::set</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      Die im Knoten zu speichernden Daten.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Die erwartete Version des Knotens. Die Funktion schlägt fehl, wenn die tatsächliche Version des Knotens nicht mit der erwarteten Version übereinstimmt. Wird -1 verwendet, findet keine Versionsprüfung statt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert nicht NULL, enthält er bei der Rückkehr den stat-Wert für den Pfad.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Speichern des Werts im Knoten fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.set.example.basic">
+   <title><methodname>Zookeeper::set</methodname>-Beispiel</title>
+   <para>
+     Wert in einem Knoten speichern.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$path = '/path/to/node';
+$value = 'nodevalue';
+$r = $zookeeper->set($path, $value);
+if ($r)
+  echo 'SUCCESS';
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+SUCCESS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::get</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setacl.xml
+++ b/reference/zookeeper/zookeeper/setacl.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.setacl" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setAcl</refname>
+  <refpurpose>Setzt die einem Knoten zugeordnete ACL synchron</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::setAcl</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>int</type><parameter>version</parameter></methodparam>
+   <methodparam><type>array</type><parameter>acl</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+      Der Name des Knotens. Wird als Dateiname ausgedrückt, wobei Schrägstriche die Vorfahren des Knotens trennen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Die erwartete Version des Pfads.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>acl</parameter></term>
+    <listitem>
+     <para>
+      Die für den Pfad zu setzende ACL.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Setzen der ACL für einen Knoten fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.setacl.example.basic">
+   <title><methodname>Zookeeper::setAcl</methodname>-Beispiel</title>
+   <para>
+     ACL für einen Knoten setzen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zookeeper = new Zookeeper('localhost:2181');
+$aclArray = array(
+  array(
+    'perms'  => Zookeeper::PERM_ALL,
+    'scheme' => 'world',
+    'id'     => 'anyone',
+  )
+);
+$path = '/path/to/newnode';
+$zookeeper->setAcl($path, $aclArray);
+
+$r = $zookeeper->getAcl($path);
+if ($r)
+  var_dump($r);
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  [0]=>
+  array(3) {
+    ["perms"]=>
+    int(31)
+    ["scheme"]=>
+    string(5) "world"
+    ["id"]=>
+    string(6) "anyone"
+  }
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::create</methodname></member>
+   <member><methodname>Zookeeper::getAcl</methodname></member>
+   <member><link linkend="zookeeper.constants.perms">ZooKeeper-Berechtigungen</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setdebuglevel.xml
+++ b/reference/zookeeper/zookeeper/setdebuglevel.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.setdebuglevel" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setDebugLevel</refname>
+  <refpurpose>Setzt die Debugging-Stufe für die Bibliothek</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type><methodname>Zookeeper::setDebugLevel</methodname>
+   <methodparam><type>int</type><parameter>logLevel</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>logLevel</parameter></term>
+    <listitem>
+     <para>
+      ZooKeeper-Protokollierungsstufen-Konstanten.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Setzen der Debugging-Stufe fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeper.setdebuglevel.example.basic">
+   <title><methodname>Zookeeper::setDebugLevel</methodname>-Beispiel</title>
+   <para>
+     Debugging-Stufe setzen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$r = Zookeeper::setDebugLevel(Zookeeper::LOG_LEVEL_WARN);
+if ($r)
+  echo 'SUCCESS';
+else
+  echo 'ERR';
+?>
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+SUCCESS
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><link linkend="zookeeper.constants.log-levels">ZooKeeper-Protokollierungsstufen</link></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
+++ b/reference/zookeeper/zookeeper/setdeterministicconnorder.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.setdeterministicconnorder" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setDeterministicConnOrder</refname>
+  <refpurpose>Aktiviert/deaktiviert die Zufallsanordnung der Quorum-Endpunkte</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>bool</type><methodname>Zookeeper::setDeterministicConnOrder</methodname>
+   <methodparam><type>bool</type><parameter>yesOrNo</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Wird ein true-Wert übergeben, verbindet sich der Client mit den Quorum-Peers in der Reihenfolge, die im Aufruf von zookeeper_init() angegeben ist. Ein false-Wert veranlasst zookeeper_init(), die Peer-Endpunkte zu permutieren, was für eine gleichmäßigere Verteilung der Client-Verbindungen auf die Quorum-Peers sorgt.
+   Der ZooKeeper-C-Client verwendet standardmäßig false.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>yesOrNo</parameter></term>
+    <listitem>
+     <para>
+      Deaktiviert/aktiviert die Zufallsanordnung der Quorum-Endpunkte.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder die Operation fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::__construct</methodname></member>
+   <member><methodname>Zookeeper::connect</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setlogstream.xml
+++ b/reference/zookeeper/zookeeper/setlogstream.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.setlogstream" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setLogStream</refname>
+  <refpurpose>Setzt den Stream, der von der Bibliothek für die Protokollierung verwendet wird</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::setLogStream</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Die Zookeeper-Bibliothek verwendet stderr als ihren Standard-Protokoll-Stream. Die Anwendung muss sicherstellen, dass der Stream beschreibbar ist. Wird NULL übergeben, wird der Stream auf seinen Standardwert (stderr) zurückgesetzt.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stream</parameter></term>
+    <listitem>
+     <para>
+      Der Stream, der von der Bibliothek für die Protokollierung verwendet werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder die Operation fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::setDebugLevel</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeper/setwatcher.xml
+++ b/reference/zookeeper/zookeeper/setwatcher.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeper.setwatcher" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Zookeeper::setWatcher</refname>
+  <refpurpose>Setzt eine Watcher-Funktion</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>bool</type><methodname>Zookeeper::setWatcher</methodname>
+   <methodparam><type>callable</type><parameter>watcher_cb</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Auf dem Server wird ein Watch gesetzt, um den Client zu benachrichtigen, wenn sich der Knoten ändert.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Diese Methode löst einen PHP-Fehler bzw. eine PHP-Warnung aus, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Setzen des Watchers fehlschlägt.
+  </para>
+  <caution>
+    <simpara>
+      Seit Version 0.3.0 wirft diese Methode <classname>ZookeeperException</classname> und deren Ableitungen.
+    </simpara>
+  </caution>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Zookeeper::exists</methodname></member>
+   <member><methodname>Zookeeper::get</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeperconfig/add.xml
+++ b/reference/zookeeper/zookeeperconfig/add.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeperconfig.add" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ZookeeperConfig::add</refname>
+  <refpurpose>Fügt dem Ensemble Server hinzu</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>ZookeeperConfig::add</methodname>
+   <methodparam><type>string</type><parameter>members</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>members</parameter></term>
+    <listitem>
+     <para>
+      Kommagetrennte Liste der dem Ensemble hinzuzufügenden Server. Jeder Eintrag enthält eine Konfigurationszeile für einen hinzuzufügenden Server (wie sie in einer
+ Konfigurationsdatei erscheinen würde), nur für Mehrheits-Quoren.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Die erwartete Version des Knotens. Die Funktion schlägt fehl, wenn die tatsächliche Version des Knotens nicht mit der erwarteten Version übereinstimmt. Wird -1 verwendet, findet keine Versionsprüfung statt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert nicht NULL, enthält er bei der Rückkehr den stat-Wert für den Pfad.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Diese Methode wirft <classname>ZookeeperException</classname> und deren Ableitungen, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Speichern des Werts im Knoten fehlschlägt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeperconfig.add.example.basic">
+   <title><methodname>ZookeeperConfig::add</methodname>-Beispiel</title>
+   <para>
+     Mitglieder hinzufügen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Zookeeper();
+$client->connect('localhost:2181');
+$client->addAuth('digest', 'timandes:timandes');
+$zkConfig = $client->getConfig();
+$zkConfig->set("server.1=localhost:2888:3888:participant;0.0.0.0:2181");
+$zkConfig->add("server.2=localhost:2889:3889:participant;0.0.0.0:2182");
+$r = $zkConfig->get();
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+server.1=localhost:2888:3888:participant;0.0.0.0:2181
+server.2=localhost:2889:3889:participant;0.0.0.0:2182
+version=0xca01e881a2
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ZookeeperConfig::get</methodname></member>
+   <member><methodname>ZookeeperConfig::set</methodname></member>
+   <member><methodname>ZookeeperConfig::remove</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeperconfig/get.xml
+++ b/reference/zookeeper/zookeeperconfig/get.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeperconfig.get" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ZookeeperConfig::get</refname>
+  <refpurpose>Ruft synchron die zuletzt bestätigte Konfiguration des ZooKeeper-Clusters ab, so wie sie dem Server bekannt ist, mit dem der Client verbunden ist</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>string</type><methodname>ZookeeperConfig::get</methodname>
+   <methodparam choice="opt"><type>callable</type><parameter>watcher_cb</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>watcher_cb</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert ungleich null, wird auf dem Server ein Watch gesetzt, um den Client zu benachrichtigen, wenn sich der Knoten ändert.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert nicht NULL, enthält er bei der Rückkehr den stat-Wert für den Pfad.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg die Konfigurationszeichenkette zurück und false bei einem Fehler.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Diese Methode wirft <classname>ZookeeperException</classname> und deren Ableitungen, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Abrufen der Konfiguration fehlschlägt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeperconfig.get.example.basic">
+   <title><methodname>ZookeeperConfig::get</methodname>-Beispiel</title>
+   <para>
+     Konfiguration abrufen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$zk = new Zookeeper();
+$zk->connect('localhost:2181');
+$zk->addAuth('digest', 'timandes:timandes');
+$zkConfig = $zk->getConfig();
+$r = $zkConfig->get();
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+server.1=localhost:2888:3888:participant;0.0.0.0:2181
+version=0xca01e881a2
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ZookeeperConfig::set</methodname></member>
+   <member><methodname>ZookeeperConfig::add</methodname></member>
+   <member><methodname>ZookeeperConfig::remove</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeperconfig/remove.xml
+++ b/reference/zookeeper/zookeeperconfig/remove.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeperconfig.remove" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ZookeeperConfig::remove</refname>
+  <refpurpose>Entfernt Server aus dem Ensemble</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>ZookeeperConfig::remove</methodname>
+   <methodparam><type>string</type><parameter>id_list</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>id_list</parameter></term>
+    <listitem>
+     <para>
+      Kommagetrennte Liste der aus dem Ensemble zu entfernenden Server-IDs. Jeder Eintrag enthält die ID eines zu entfernenden Servers, nur für Mehrheits-Quoren.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Die erwartete Version des Knotens. Die Funktion schlägt fehl, wenn die tatsächliche Version des Knotens nicht mit der erwarteten Version übereinstimmt. Wird -1 verwendet, findet keine Versionsprüfung statt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert nicht NULL, enthält er bei der Rückkehr den stat-Wert für den Pfad.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Diese Methode wirft <classname>ZookeeperException</classname> und deren Ableitungen, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Speichern des Werts im Knoten fehlschlägt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeperconfig.remove.example.basic">
+   <title><methodname>ZookeeperConfig::remove</methodname>-Beispiel</title>
+   <para>
+     Mitglieder entfernen.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Zookeeper();
+$client->connect('localhost:2181');
+$client->addAuth('digest', 'timandes:timandes');
+$zkConfig = $client->getConfig();
+$zkConfig->set("server.1=localhost:2888:3888:participant;0.0.0.0:2181,server.2=localhost:2889:3889:participant;0.0.0.0:2182");
+$zkConfig->remove("2");
+echo $zkConfig->get();
+if ($r)
+  echo $r;
+else
+  echo 'ERR';
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+server.1=localhost:2888:3888:participant;0.0.0.0:2181
+version=0xca01e881a2
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ZookeeperConfig::get</methodname></member>
+   <member><methodname>ZookeeperConfig::add</methodname></member>
+   <member><methodname>ZookeeperConfig::set</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/zookeeper/zookeeperconfig/set.xml
+++ b/reference/zookeeper/zookeeperconfig/set.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="zookeeperconfig.set" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ZookeeperConfig::set</refname>
+  <refpurpose>Ändert die Ensemble-Mitgliedschaft des ZK-Clusters und die Rollen der Ensemble-Peers</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="oop">
+   <modifier>public</modifier>
+   <type>void</type><methodname>ZookeeperConfig::set</methodname>
+   <methodparam><type>string</type><parameter>members</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>version</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">stat</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>members</parameter></term>
+    <listitem>
+     <para>
+      Kommagetrennte Liste der neuen Mitgliedschaft (z. B. der Inhalt einer Mitgliedschafts-Konfigurationsdatei): nur zur Verwendung bei einer nicht inkrementellen Rekonfiguration.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>version</parameter></term>
+    <listitem>
+     <para>
+      Die erwartete Version des Knotens. Die Funktion schlägt fehl, wenn die tatsächliche Version des Knotens nicht mit der erwarteten Version übereinstimmt. Wird -1 verwendet, findet keine Versionsprüfung statt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>stat</parameter></term>
+    <listitem>
+     <para>
+      Ist dieser Wert nicht NULL, enthält er bei der Rückkehr den stat-Wert für den Pfad.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Diese Methode wirft <classname>ZookeeperException</classname> und deren Ableitungen, wenn die Anzahl oder die Typen der Parameter falsch sind oder das Speichern des Werts im Knoten fehlschlägt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="zookeeperconfig.set.example.basic">
+   <title><methodname>ZookeeperConfig::set</methodname>-Beispiel</title>
+   <para>
+     Rekonfiguration.
+   </para>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$client = new Zookeeper();
+$client->connect('localhost:2181');
+$client->addAuth('digest', 'timandes:timandes');
+$zkConfig = $client->getConfig();
+$zkConfig->set("server.1=localhost:2888:3888:participant;0.0.0.0:2181");
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ZookeeperConfig::get</methodname></member>
+   <member><methodname>ZookeeperConfig::add</methodname></member>
+   <member><methodname>ZookeeperConfig::remove</methodname></member>
+   <member><classname>ZookeeperException</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `zookeeper` ins Deutsche, auf dem Stand des aktuellen EN-Texts (24 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").