### PR TITLE
[Sync EN] ds: German translation of new files

### DIFF
--- a/reference/ds/ds.hashable.xml
+++ b/reference/ds/ds.hashable.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.ds-hashable" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Das Hashable-Interface</title>
+ <titleabbrev>Ds\Hashable</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Ds\Hashable intro -->
+  <section xml:id="ds-hashable.intro">
+   &reftitle.intro;
+   <simpara>
+        Hashable ist ein Interface, das es ermöglicht, Objekte als Schlüssel zu
+        verwenden. Es ist eine Alternative zu <function>spl_object_hash</function>,
+        die den Hash eines Objekts anhand seines Handles bestimmt:
+        das bedeutet, dass zwei Objekte, die durch eine implizite Definition als
+        gleich gelten, nicht als gleich behandelt würden, da sie nicht dieselbe
+        Instanz sind.
+   </simpara>
+   <para>
+        <function>hash</function> wird verwendet, um einen skalaren Wert
+        zurückzugeben, der als Hash-Wert des Objekts dient und bestimmt, an welche
+        Stelle es in der Hash-Tabelle gelangt. Dieser Wert muss zwar nicht eindeutig
+        sein, doch Objekte, die gleich sind, müssen denselben Hash-Wert haben.
+    </para>
+    <para>
+        <function>equals</function> wird verwendet, um zu bestimmen, ob zwei Objekte
+        gleich sind. Es ist garantiert, dass das zu vergleichende Objekt eine Instanz
+        derselben Klasse wie das Subjekt ist.
+    </para>
+
+  </section>
+<!-- }}} -->
+
+  <section xml:id="ds-hashable.synopsis">
+   &reftitle.interfacesynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="interface">
+    <oointerface><interfacename>Ds\Hashable</interfacename></oointerface>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ds-hashable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.ds.ds.entities.hashable;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/deque/allocate.xml
+++ b/reference/ds/ds/deque/allocate.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-deque.allocate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Deque::allocate</refname>
+  <refpurpose>Reserviert ausreichend Speicher für eine benötigte Kapazität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\Deque::allocate</methodname>
+   <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Stellt sicher, dass ausreichend Speicher für eine benötigte Kapazität reserviert
+    ist. Dadurch entfällt die Notwendigkeit, den internen Puffer neu zu allozieren,
+    wenn Werte hinzugefügt werden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>capacity</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Werte, für die Kapazität reserviert werden soll.
+     </para>
+     <note>
+        <para>
+            Die Kapazität bleibt unverändert, wenn dieser Wert kleiner oder gleich der
+            aktuellen Kapazität ist.
+        </para>
+    </note>
+    <note>
+        <para>
+            Die Kapazität wird immer auf die nächste Zweierpotenz aufgerundet.
+        </para>
+     </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Deque::allocate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$deque = new \Ds\Deque();
+var_dump($deque->capacity());
+
+$deque->allocate(100);
+var_dump($deque->capacity());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(8)
+int(128)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/deque/contains.xml
+++ b/reference/ds/ds/deque/contains.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-deque.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Deque::contains</refname>
+  <refpurpose>Bestimmt, ob der Deque die angegebenen Werte enthält</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Ds\Deque::contains</methodname>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Bestimmt, ob der Deque alle Werte enthält.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>values</parameter></term>
+    <listitem>
+     <para>
+        Die zu prüfenden Werte.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &false;, wenn einer der angegebenen <parameter>values</parameter> nicht im Deque
+    enthalten ist, andernfalls &true;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Deque::contains</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$deque = new \Ds\Deque(['a', 'b', 'c', 1, 2, 3]);
+
+var_dump($deque->contains('a'));                // true
+var_dump($deque->contains('a', 'b'));           // true
+var_dump($deque->contains('c', 'd'));           // false
+
+var_dump($deque->contains(...['c', 'b', 'a'])); // true
+
+// Immer strikt
+var_dump($deque->contains(1));                  // true
+var_dump($deque->contains('1'));                // false
+
+var_dump($deque->contains(...[]));                 // true
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/deque/rotate.xml
+++ b/reference/ds/ds/deque/rotate.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-deque.rotate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Deque::rotate</refname>
+  <refpurpose>Rotiert den Deque um eine angegebene Anzahl von Rotationen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\Deque::rotate</methodname>
+   <methodparam><type>int</type><parameter>rotations</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Rotiert den Deque um eine angegebene Anzahl von Rotationen, was dem sukzessiven
+    Aufruf von <code>$deque-&gt;push($deque-&gt;shift())</code> entspricht, wenn die Anzahl
+    der Rotationen positiv ist, oder <code>$deque-&gt;unshift($deque-&gt;pop())</code>, wenn
+    sie negativ ist.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>rotations</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Male, die der Deque rotiert werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;. Der Deque der aktuellen Instanz wird rotiert.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Deque::rotate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$deque = new \Ds\Deque(["a", "b", "c", "d"]);
+
+$deque->rotate(1);  // "a" wird per shift entfernt, dann per push hinzugefügt.
+print_r($deque);
+
+$deque->rotate(2);  // "b" und "c" werden per shift entfernt, dann per push hinzugefügt.
+print_r($deque);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+(
+    [0] => b
+    [1] => c
+    [2] => d
+    [3] => a
+)
+Ds\Deque Object
+(
+    [0] => d
+    [1] => a
+    [2] => b
+    [3] => c
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/map/haskey.xml
+++ b/reference/ds/ds/map/haskey.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-map.haskey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Map::hasKey</refname>
+  <refpurpose>Bestimmt, ob die Map einen angegebenen Schlüssel enthält</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Ds\Map::hasKey</methodname>
+   <methodparam><type>mixed</type><parameter>key</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Bestimmt, ob die Map einen angegebenen Schlüssel enthält.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>key</parameter></term>
+    <listitem>
+     <para>
+        Der zu suchende Schlüssel.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+    Gibt &true; zurück, wenn der Schlüssel gefunden werden konnte, andernfalls &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Map::hasKey</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$map = new \Ds\Map(["a" => 1, "b" => 2, "c" => 3]);
+
+var_dump($map->hasKey("a")); // true
+var_dump($map->hasKey("e")); // false
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/map/hasvalue.xml
+++ b/reference/ds/ds/map/hasvalue.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-map.hasvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Map::hasValue</refname>
+  <refpurpose>Bestimmt, ob die Map einen angegebenen Wert enthält</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Ds\Map::hasValue</methodname>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Bestimmt, ob die Map einen angegebenen Wert enthält.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+        Der zu suchende Wert.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+    Gibt &true; zurück, wenn der Wert gefunden werden konnte, andernfalls &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Map::hasValue</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$map = new \Ds\Map(["a" => 1, "b" => 2, "c" => 3]);
+
+var_dump($map->hasValue(1)); // true
+var_dump($map->hasValue(4)); // false
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/map/toarray.xml
+++ b/reference/ds/ds/map/toarray.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-map.toarray" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Map::toArray</refname>
+  <refpurpose>
+    Konvertiert die Map in ein &array;
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>array</type><methodname>Ds\Map::toArray</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+    Konvertiert die Map in ein &array;.
+  </para>
+  <caution>
+        <simpara>
+            Maps mit nicht-skalaren Schlüsseln können nicht in ein &array; konvertiert
+            werden.
+        </simpara>
+    </caution>
+    <caution>
+        <para>
+            Ein &array; behandelt alle numerischen Schlüssel als Ganzzahlen,
+            z. B. werden <code>"1"</code> und <code>1</code> als Schlüssel in der Map
+            nur dazu führen, dass <code>1</code> im Array enthalten ist.
+        </para>
+    </caution>
+  <note>
+    <para>
+        Die Umwandlung in ein &array; wird noch nicht unterstützt.
+    </para>
+  </note>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    Ein &array;, das alle Werte in derselben Reihenfolge wie die Map enthält.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Map::toArray</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$map = new \Ds\Map([
+    "a" => 1,
+    "b" => 2,
+    "c" => 3,
+]);
+
+var_dump($map->toArray());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+array(3) {
+  ["a"]=>
+  int(1)
+  ["b"]=>
+  int(2)
+  ["c"]=>
+  int(3)
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/priorityqueue/allocate.xml
+++ b/reference/ds/ds/priorityqueue/allocate.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-priorityqueue.allocate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\PriorityQueue::allocate</refname>
+  <refpurpose>Reserviert ausreichend Speicher für eine benötigte Kapazität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\PriorityQueue::allocate</methodname>
+   <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Stellt sicher, dass ausreichend Speicher für eine benötigte Kapazität reserviert
+    ist. Dadurch entfällt die Notwendigkeit, den internen Puffer neu zu allozieren,
+    wenn Werte hinzugefügt werden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>capacity</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Werte, für die Kapazität reserviert werden soll.
+     </para>
+     <note>
+        <para>
+            Die Kapazität bleibt unverändert, wenn dieser Wert kleiner oder gleich der
+            aktuellen Kapazität ist.
+        </para>
+    </note>
+    <note>
+        <para>
+            Die Kapazität wird immer auf die nächste Zweierpotenz aufgerundet.
+        </para>
+     </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\PriorityQueue::allocate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$queue = new \Ds\PriorityQueue();
+var_dump($queue->capacity());
+
+$queue->allocate(100);
+var_dump($queue->capacity());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(8)
+int(128)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/queue/allocate.xml
+++ b/reference/ds/ds/queue/allocate.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-queue.allocate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Queue::allocate</refname>
+  <refpurpose>Reserviert ausreichend Speicher für eine benötigte Kapazität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\Queue::allocate</methodname>
+   <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Stellt sicher, dass ausreichend Speicher für eine benötigte Kapazität reserviert
+    ist. Dadurch entfällt die Notwendigkeit, den internen Puffer neu zu allozieren,
+    wenn Werte hinzugefügt werden.
+  </simpara>
+  <note>
+    <para>
+        Die Kapazität wird immer auf die nächste Zweierpotenz aufgerundet.
+    </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>capacity</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Werte, für die Kapazität reserviert werden soll.
+     </para>
+     <note>
+        <para>
+            Die Kapazität bleibt unverändert, wenn dieser Wert kleiner oder gleich der
+            aktuellen Kapazität ist.
+        </para>
+    </note>
+    <note>
+        <para>
+            Die Kapazität wird immer auf die nächste Zweierpotenz aufgerundet.
+        </para>
+     </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Queue::allocate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$queue = new \Ds\Queue();
+var_dump($queue->capacity());
+
+$queue->allocate(100);
+var_dump($queue->capacity());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(8)
+int(128)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/sequence/allocate.xml
+++ b/reference/ds/ds/sequence/allocate.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-sequence.allocate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Sequence::allocate</refname>
+  <refpurpose>Reserviert ausreichend Speicher für eine benötigte Kapazität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Ds\Sequence::allocate</methodname>
+   <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Stellt sicher, dass ausreichend Speicher für eine benötigte Kapazität reserviert
+    ist. Dadurch entfällt die Notwendigkeit, den internen Puffer neu zu allozieren,
+    wenn Werte hinzugefügt werden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>capacity</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Werte, für die Kapazität reserviert werden soll.
+     </para>
+     <note>
+        <para>
+            Die Kapazität bleibt unverändert, wenn dieser Wert kleiner oder gleich der
+            aktuellen Kapazität ist.
+        </para>
+    </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Sequence::allocate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$sequence = new \Ds\Vector();
+var_dump($sequence->capacity());
+
+$vector->allocate(100);
+var_dump($sequence->capacity());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(10)
+int(100)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/sequence/contains.xml
+++ b/reference/ds/ds/sequence/contains.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-sequence.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Sequence::contains</refname>
+  <refpurpose>Bestimmt, ob die Sequenz die angegebenen Werte enthält</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>bool</type><methodname>Ds\Sequence::contains</methodname>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Bestimmt, ob die Sequenz alle Werte enthält.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>values</parameter></term>
+    <listitem>
+     <para>
+        Die zu prüfenden Werte.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &false;, wenn einer der angegebenen <parameter>values</parameter> nicht in der
+    Sequenz enthalten ist, andernfalls &true;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Sequence::contains</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$sequence = new \Ds\Vector(['a', 'b', 'c', 1, 2, 3]);
+
+var_dump($sequence->contains('a'));                // true
+var_dump($sequence->contains('a', 'b'));           // true
+var_dump($sequence->contains('c', 'd'));           // false
+
+var_dump($sequence->contains(...['c', 'b', 'a'])); // true
+
+// Immer strikt
+var_dump($sequence->contains(1));                  // true
+var_dump($sequence->contains('1'));                // false
+
+var_dump($sequence->contains(...[]));               // true
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/sequence/rotate.xml
+++ b/reference/ds/ds/sequence/rotate.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-sequence.rotate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Sequence::rotate</refname>
+  <refpurpose>Rotiert die Sequenz um eine angegebene Anzahl von Rotationen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type>void</type><methodname>Ds\Sequence::rotate</methodname>
+   <methodparam><type>int</type><parameter>rotations</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Rotiert die Sequenz um eine angegebene Anzahl von Rotationen, was dem sukzessiven
+    Aufruf von <code>$sequence-&gt;push($sequence-&gt;shift())</code> entspricht, wenn die
+    Anzahl der Rotationen positiv ist, oder <code>$sequence-&gt;unshift($sequence-&gt;pop())</code>,
+    wenn sie negativ ist.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>rotations</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Male, die die Sequenz rotiert werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;. Die Sequenz der aktuellen Instanz wird rotiert.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Sequence::rotate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$sequence = new \Ds\Vector(["a", "b", "c", "d"]);
+
+$sequence->rotate(1);  // "a" wird per shift entfernt, dann per push hinzugefügt.
+print_r($sequence);
+
+$sequence->rotate(2);  // "b" und "c" werden per shift entfernt, dann per push hinzugefügt.
+print_r($sequence);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+(
+    [0] => b
+    [1] => c
+    [2] => d
+    [3] => a
+)
+Ds\Vector Object
+(
+    [0] => d
+    [1] => a
+    [2] => b
+    [3] => c
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/stack/allocate.xml
+++ b/reference/ds/ds/stack/allocate.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-stack.allocate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Stack::allocate</refname>
+  <refpurpose>Reserviert ausreichend Speicher für eine benötigte Kapazität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\Stack::allocate</methodname>
+   <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Stellt sicher, dass ausreichend Speicher für eine benötigte Kapazität reserviert
+    ist. Dadurch entfällt die Notwendigkeit, den internen Puffer neu zu allozieren,
+    wenn Werte hinzugefügt werden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>capacity</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Werte, für die Kapazität reserviert werden soll.
+     </para>
+     <note>
+        <para>
+            Die Kapazität bleibt unverändert, wenn dieser Wert kleiner oder gleich der
+            aktuellen Kapazität ist.
+        </para>
+    </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;
+  </para>
+ </refsect1>
+<!--
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Stack::allocate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$stack = new \Ds\Stack();
+var_dump($stack->capacity());
+
+$stack->allocate(100);
+var_dump($stack->capacity());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(10)
+int(100)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+ -->
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/vector/allocate.xml
+++ b/reference/ds/ds/vector/allocate.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-vector.allocate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Vector::allocate</refname>
+  <refpurpose>Reserviert ausreichend Speicher für eine benötigte Kapazität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\Vector::allocate</methodname>
+   <methodparam><type>int</type><parameter>capacity</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Stellt sicher, dass ausreichend Speicher für eine benötigte Kapazität reserviert
+    ist. Dadurch entfällt die Notwendigkeit, den internen Puffer neu zu allozieren,
+    wenn Werte hinzugefügt werden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>capacity</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Werte, für die Kapazität reserviert werden soll.
+     </para>
+     <note>
+        <para>
+            Die Kapazität bleibt unverändert, wenn dieser Wert kleiner oder gleich der
+            aktuellen Kapazität ist.
+        </para>
+    </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Vector::allocate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$vector = new \Ds\Vector();
+var_dump($vector->capacity());
+
+$vector->allocate(100);
+var_dump($vector->capacity());
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+int(10)
+int(100)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/vector/contains.xml
+++ b/reference/ds/ds/vector/contains.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-vector.contains" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Vector::contains</refname>
+  <refpurpose>Bestimmt, ob der Vector die angegebenen Werte enthält</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Ds\Vector::contains</methodname>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Bestimmt, ob der Vector alle Werte enthält.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>values</parameter></term>
+    <listitem>
+     <para>
+        Die zu prüfenden Werte.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &false;, wenn einer der angegebenen <parameter>values</parameter> nicht im Vector
+    enthalten ist, andernfalls &true;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Vector::contains</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$vector = new \Ds\Vector(['a', 'b', 'c', 1, 2, 3]);
+
+var_dump($vector->contains('a'));                // true
+var_dump($vector->contains('a', 'b'));           // true
+var_dump($vector->contains('c', 'd'));           // false
+
+var_dump($vector->contains(...['c', 'b', 'a'])); // true
+
+// Immer strikt
+var_dump($vector->contains(1));                  // true
+var_dump($vector->contains('1'));                // false
+
+var_dump($vector->contains(...[]));                // true
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ds/ds/vector/rotate.xml
+++ b/reference/ds/ds/vector/rotate.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ds-vector.rotate" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Ds\Vector::rotate</refname>
+  <refpurpose>Rotiert den Vector um eine angegebene Anzahl von Rotationen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Ds\Vector::rotate</methodname>
+   <methodparam><type>int</type><parameter>rotations</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Rotiert den Vector um eine angegebene Anzahl von Rotationen, was dem sukzessiven
+    Aufruf von <code>$vector-&gt;push($vector-&gt;shift())</code> entspricht, wenn die Anzahl
+    der Rotationen positiv ist, oder <code>$vector-&gt;unshift($vector-&gt;pop())</code>, wenn
+    sie negativ ist.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>rotations</parameter></term>
+    <listitem>
+     <para>
+        Die Anzahl der Male, die der Vector rotiert werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    &return.void;. Der Vector der aktuellen Instanz wird rotiert.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>Ds\Vector::rotate</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$vector = new \Ds\Vector(["a", "b", "c", "d"]);
+
+$vector->rotate(1);  // "a" wird per shift entfernt, dann per push hinzugefügt.
+print_r($vector);
+
+$vector->rotate(2);  // "b" und "c" werden per shift entfernt, dann per push hinzugefügt.
+print_r($vector);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+(
+    [0] => b
+    [1] => c
+    [2] => d
+    [3] => a
+)
+Ds\Vector Object
+(
+    [0] => d
+    [1] => a
+    [2] => b
+    [3] => c
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `ds` ins Deutsche, auf dem Stand des aktuellen EN-Texts (16 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").