### PR TITLE
[Sync EN] event: German translation of new files

### DIFF
--- a/reference/event/event/getsupportedmethods.xml
+++ b/reference/event/event/getsupportedmethods.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="event.getsupportedmethods" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Event::getSupportedMethods</refname>
+  <refpurpose>Gibt ein Array mit den Namen der in dieser Version von Libevent unterstützten Methoden zurück</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>array</type>
+   <methodname>Event::getSupportedMethods</methodname>
+   <void />
+  </methodsynopsis>
+  <simpara>
+   Gibt ein Array mit den Namen der in dieser Version von Libevent
+   unterstützten Methoden (Backends) zurück.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt ein Array zurück.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <classname>EventConfig</classname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventbuffer/pullup.xml
+++ b/reference/event/eventbuffer/pullup.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventbuffer.pullup" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventBuffer::pullup</refname>
+  <refpurpose>Linearisiert Daten innerhalb des Puffers
+  und gibt deren Inhalt als Zeichenkette zurück</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>string</type>
+   <methodname>EventBuffer::pullup</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>size</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <para>
+   "Linearisiert" die ersten
+   <parameter>size</parameter>
+   Bytes des Puffers, indem sie bei Bedarf kopiert oder verschoben werden, um
+   sicherzustellen, dass sie alle zusammenhängend sind und denselben
+   Speicherblock belegen. Ist size negativ, linearisiert die Funktion den
+   gesamten Puffer.
+  </para>
+  <warning>
+   <para>
+    Der Aufruf von
+    <methodname>EventBuffer::pullup</methodname>
+    mit einer großen size kann recht langsam sein, da unter Umständen der
+    gesamte Inhalt des Puffers kopiert werden muss.
+   </para>
+  </warning>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>size</parameter>
+    </term>
+    <listitem>
+     <para>
+      Die Anzahl der Bytes, die innerhalb des Puffers zusammenhängend sein
+      müssen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Ist
+   <parameter>size</parameter>
+   größer als die Anzahl der Bytes im Puffer, gibt die Funktion
+   &null; zurück. Andernfalls gibt
+   <methodname>EventBuffer::pullup</methodname>
+   eine Zeichenkette zurück.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EventBuffer::copyout</methodname>
+   </member>
+   <member>
+    <methodname>EventBuffer::drain</methodname>
+   </member>
+   <member>
+    <methodname>EventBuffer::read</methodname>
+   </member>
+   <member>
+    <methodname>EventBuffer::readLine</methodname>
+   </member>
+   <member>
+    <methodname>EventBuffer::appendFrom</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventbufferevent/sslerror.xml
+++ b/reference/event/eventbufferevent/sslerror.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventbufferevent.sslerror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventBufferEvent::sslError</refname>
+  <refpurpose>Gibt den zuletzt gemeldeten OpenSSL-Fehler des Buffer-Events zurück</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>string</type>
+   <methodname>EventBufferEvent::sslError</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Gibt den zuletzt gemeldeten OpenSSL-Fehler des Buffer-Events zurück.
+  </para>
+  <note>
+   <para>
+    Diese Funktion ist nur verfügbar, wenn
+    <literal>Event</literal>
+    mit OpenSSL-Unterstützung kompiliert wurde.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt die für das Buffer-Event gemeldete OpenSSL-Fehlerzeichenkette zurück
+   oder &false;, wenn kein weiterer Fehler zurückzugeben ist.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>
+    <function>EventBufferEvent::sslError</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+// Dieser Callback wird aufgerufen, wenn am Event-Listener ein Ereignis auftritt,
+// z. B. wenn die Verbindung geschlossen wird oder ein Fehler aufgetreten ist
+function ssl_event_cb($bev, $events, $ctx) {
+    if ($events & EventBufferEvent::ERROR) {
+        // Fehler vom SSL-Fehlerstack abrufen
+        while ($err = $bev->sslError()) {
+            fprintf(STDERR, "Bufferevent error %s.\n", $err);
+        }
+    }
+
+    if ($events & (EventBufferEvent::EOF | EventBufferEvent::ERROR)) {
+        $bev->free();
+    }
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EventBufferEvent::sslRenegotiate</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventconfig/setflags.xml
+++ b/reference/event/eventconfig/setflags.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventconfig.setflags" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventConfig::setFlags</refname>
+  <refpurpose>Setzt ein oder mehrere Flags, die festlegen, wie die spätere EventBase initialisiert wird</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>bool</type>
+   <methodname>EventConfig::setFlags</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>flags</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <para>
+   Setzt ein oder mehrere Flags, um festzulegen, welche Teile
+   der späteren EventBase initialisiert werden und wie sie arbeiten.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>flags</parameter>
+    </term>
+    <listitem>
+     <para>
+      Eine der <literal>EventBase::LOOP_*</literal>-Konstanten.
+      Siehe <link linkend="eventbase.constants">EventBase-Konstanten</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+<refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EventBase::getFeatures</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventdnsbase.xml
+++ b/reference/event/eventdnsbase.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<reference xml:id="class.eventdnsbase" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Die Klasse EventDnsBase</title>
+ <titleabbrev>EventDnsBase</titleabbrev>
+ <partintro>
+<!-- {{{ EventDnsBase intro -->
+  <section xml:id="eventdnsbase.intro">
+   &reftitle.intro;
+   <simpara>
+    Repräsentiert die DNS-Basisstruktur von Libevent. Wird verwendet, um DNS
+    asynchron aufzulösen, Konfigurationsdateien wie resolv.conf zu parsen usw.
+   </simpara>
+  </section>
+<!-- }}} -->
+  <section xml:id="eventdnsbase.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass>
+     <classname>EventDnsBase</classname>
+    </ooclass>
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <modifier>final</modifier>
+      <classname>EventDnsBase</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.option-search">EventDnsBase::OPTION_SEARCH</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.option-nameservers">EventDnsBase::OPTION_NAMESERVERS</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.option-misc">EventDnsBase::OPTION_MISC</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.option-hostsfile">EventDnsBase::OPTION_HOSTSFILE</varname>
+     <initializer>8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.options-all">EventDnsBase::OPTIONS_ALL</varname>
+     <initializer>15</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.disable-when-inactive">EventDnsBase::DISABLE_WHEN_INACTIVE</varname>
+     <initializer>32768</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.initialize-nameservers">EventDnsBase::INITIALIZE_NAMESERVERS</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="eventdnsbase.constants.nameservers-no-default">EventDnsBase::NAMESERVERS_NO_DEFAULT</varname>
+     <initializer>65536</initializer>
+    </fieldsynopsis>
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.eventdnsbase')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[1])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.eventdnsbase')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+   </classsynopsis>
+<!-- }}} -->
+  </section>
+<!-- {{{ EventDnsBase constants -->
+  <section xml:id="eventdnsbase.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="eventdnsbase.constants.option-search">
+     <term>
+      <constant>EventDnsBase::OPTION_SEARCH</constant>
+     </term>
+     <listitem>
+      <para>
+       Veranlasst das Lesen der Felder domain und search aus der Datei
+       <literal>resolv.conf</literal>
+       sowie der Option
+       <literal>ndots</literal>,
+       um anhand dieser zu entscheiden, in welchen Domains (falls überhaupt)
+       nach nicht vollständig qualifizierten Hostnamen gesucht werden soll.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.option-nameservers">
+     <term>
+      <constant>EventDnsBase::OPTION_NAMESERVERS</constant>
+     </term>
+     <listitem>
+      <para>
+       Veranlasst das Ermitteln der Nameserver aus der Datei
+       <literal>resolv.conf</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.option-misc">
+     <term>
+      <constant>EventDnsBase::OPTION_MISC</constant>
+     </term>
+     <listitem>
+      <para></para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.option-hostsfile">
+     <term>
+      <constant>EventDnsBase::OPTION_HOSTSFILE</constant>
+     </term>
+     <listitem>
+      <para>
+       Veranlasst das Lesen einer Liste von Hosts aus
+       <literal>/etc/hosts</literal>
+       als Teil des Ladens der Datei
+       <literal>resolv.conf</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.options-all">
+     <term>
+      <constant>EventDnsBase::OPTIONS_ALL</constant>
+     </term>
+     <listitem>
+      <para>
+       Veranlasst, so viel wie möglich aus der Datei
+       <literal>resolv.conf</literal>
+       zu ermitteln.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.disable-when-inactive">
+     <term>
+      <constant>EventDnsBase::DISABLE_WHEN_INACTIVE</constant>
+     </term>
+     <listitem>
+      <para>
+       Verhindert nicht, dass die Event-Schleife von libevent beendet wird, wenn keine aktiven DNS-Anfragen vorliegen.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.initialize-nameservers">
+     <term>
+      <constant>EventDnsBase::INITIALIZE_NAMESERVERS</constant>
+     </term>
+     <listitem>
+      <para>
+       Verarbeitet die <literal>resolv.conf</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="eventdnsbase.constants.nameservers-no-default">
+     <term>
+      <constant>EventDnsBase::NAMESERVERS_NO_DEFAULT</constant>
+     </term>
+     <listitem>
+      <para>
+       Fügt keinen Standard-Nameserver hinzu, wenn in der <literal>resolv.conf</literal> keine Nameserver vorhanden sind.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+ </partintro>
+
+ &reference.event.entities.eventdnsbase;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventhttp/setallowedmethods.xml
+++ b/reference/event/eventhttp/setallowedmethods.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventhttp.setallowedmethods" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventHttp::setAllowedMethods</refname>
+  <refpurpose>Legt fest, welche HTTP-Methoden in von diesem Server akzeptierten und an Benutzer-Callbacks übergebenen Anfragen unterstützt werden</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>void</type>
+   <methodname>EventHttp::setAllowedMethods</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>methods</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Legt fest, welche HTTP-Methoden in den von diesem Server akzeptierten und
+   an Benutzer-Callbacks übergebenen Anfragen unterstützt werden
+  </simpara>
+  <para>
+   Werden sie nicht unterstützt, erzeugen sie eine
+   <literal>"405 Method not
+  allowed"</literal>-Antwort.
+  </para>
+  <para>
+   Standardmäßig umfasst dies die folgenden Methoden:
+   <literal>GET</literal>,
+   <literal>POST</literal>,
+   <literal>HEAD</literal>,
+   <literal>PUT</literal>,
+   <literal>DELETE</literal>.
+   Siehe die
+   <literal>EventHttpRequest::CMD_*</literal>-Konstanten.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>methods</parameter>
+    </term>
+    <listitem>
+     <para>
+      Eine Bitmaske von
+      <link
+     linkend="eventhttprequest.constants">
+       <literal>EventHttpRequest::CMD_*</literal>-Konstanten</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventhttprequest/findheader.xml
+++ b/reference/event/eventhttprequest/findheader.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventhttprequest.findheader" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventHttpRequest::findHeader</refname>
+  <refpurpose>Findet den zu einem Header gehörenden Wert</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>void</type>
+   <methodname>EventHttpRequest::findHeader</methodname>
+   <methodparam>
+    <type>string</type>
+    <parameter>key</parameter>
+   </methodparam>
+   <methodparam>
+    <type>string</type>
+    <parameter>type</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Findet den zu einem Header gehörenden Wert.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>key</parameter>
+    </term>
+    <listitem>
+     <para>
+      Der Name des Headers.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>type</parameter>
+    </term>
+    <listitem>
+     <para>
+      Eine der
+      <link linkend="eventhttprequest.constants">
+       <literal>EventHttpRequest::*_HEADER</literal>-Konstanten</link>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &null; zurück, wenn der Header nicht gefunden wurde.
+  </para>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EventHttpRequest::addHeader</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/eventhttprequest/senderror.xml
+++ b/reference/event/eventhttprequest/senderror.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="eventhttprequest.senderror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>EventHttpRequest::sendError</refname>
+  <refpurpose>Sendet eine HTML-Fehlermeldung an den Client</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier>
+   <type>void</type>
+   <methodname>EventHttpRequest::sendError</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>error</parameter>
+   </methodparam>
+   <methodparam
+   choice="opt">
+    <type>string</type>
+    <parameter>reason</parameter>
+    <initializer>&null;</initializer>
+   </methodparam>
+  </methodsynopsis>
+  <para>
+   Sendet eine HTML-Fehlermeldung an den Client.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>error</parameter>
+    </term>
+    <listitem>
+     <para>
+      Der HTTP-Fehlercode.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>reason</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Eine kurze Erläuterung des Fehlers. Bei &null; wird die
+      Standardbedeutung des Fehlercodes verwendet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>
+    <function>EventHttpRequest::sendError</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function _http_400($req) {
+    $req->sendError(400);
+}
+
+$base = new EventBase();
+$http = new EventHttp($base);
+
+$http->setCallback("/err400", "_http_400");
+
+$http->bind("0.0.0.0", 8010);
+$base->loop();
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EventHttpRequest::sendReply</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/event/examples.xml
+++ b/reference/event/examples.xml
@@ -1,0 +1,1318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<chapter xml:id="event.examples" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.examples;
+ <example>
+  <title>Einfacher HTTP-Client</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+// Lese-Callback
+function readcb($bev, $base) {
+    //$input = $bev->input; //$bev->getInput();
+
+    //$pos = $input->search("TTP");
+    $pos = $bev->input->search("TTP");
+
+    while (($n = $bev->input->remove($buf, 1024)) > 0) {
+        echo $buf;
+    }
+}
+
+// Event-Callback
+function eventcb($bev, $events, $base) {
+    if ($events & EventBufferEvent::CONNECTED) {
+        echo "Connected.\n";
+    } elseif ($events & (EventBufferEvent::ERROR | EventBufferEvent::EOF)) {
+        if ($events & EventBufferEvent::ERROR) {
+            echo "DNS error: ", $bev->getDnsErrorString(), PHP_EOL;
+        }
+
+        echo "Closing\n";
+        $base->exit();
+        exit("Done\n");
+    }
+}
+
+if ($argc != 3) {
+    echo <<<EOS
+Trivial HTTP 0.x client
+Syntax: php {$argv[0]} [hostname] [resource]
+Example: php {$argv[0]} www.google.com /
+
+EOS;
+    exit();
+}
+
+$base = new EventBase();
+
+$dns_base = new EventDnsBase($base, TRUE); // Wir verwenden asynchrone DNS-Auflösung
+if (!$dns_base) {
+    exit("Failed to init DNS Base\n");
+}
+
+$bev = new EventBufferEvent($base, /* internen Socket verwenden */ NULL,
+    EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS,
+    "readcb", /* writecb */ NULL, "eventcb"
+);
+if (!$bev) {
+    exit("Failed creating bufferevent socket\n");
+}
+
+//$bev->setCallbacks("readcb", /* writecb */ NULL, "eventcb", $base);
+$bev->enable(Event::READ | Event::WRITE);
+
+$output = $bev->output; //$bev->getOutput();
+if (!$output->add(
+    "GET {$argv[2]} HTTP/1.0\r\n".
+    "Host: {$argv[1]}\r\n".
+    "Connection: Close\r\n\r\n"
+)) {
+    exit("Failed adding request to output buffer\n");
+}
+
+if (!$bev->connectHost($dns_base, $argv[1], 80, EventUtil::AF_UNSPEC)) {
+    exit("Can't connect to host {$argv[1]}\n");
+}
+
+$base->dispatch();
+?>
+]]>
+  </programlisting>
+  &example.outputs.similar;
+  <screen>
+<![CDATA[
+Connected.
+HTTP/1.1 301 Moved Permanently
+Date: Fri, 01 Mar 2013 18:47:48 GMT
+Location: http://www.google.co.uk/
+Content-Type: text/html; charset=UTF-8
+Cache-Control: public, max-age=2592000
+Server: gws
+Content-Length: 221
+X-XSS-Protection: 1; mode=block
+X-Frame-Options: SAMEORIGIN
+Age: 133438
+Expires: Sat, 30 Mar 2013 05:39:28 GMT
+Connection: close
+
+<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
+<TITLE>301 Moved</TITLE></HEAD><BODY>
+<H1>301 Moved</H1>
+The document has moved
+<A HREF="http://www.google.co.uk/">here</A>.
+</BODY></HTML>
+Closing
+Done
+]]>
+  </screen>
+ </example>
+ <example>
+  <title>HTTP-Client mit asynchronem DNS-Resolver</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * 1. Verbindung zu 127.0.0.1 auf Port 80
+ * mittels EventBufferEvent::connect() herstellen.
+ *
+ * 2. /index.cphp über HTTP/1.0
+ * unter Verwendung des Ausgabepuffers anfordern.
+ *
+ * 3. Die Antwort asynchron lesen und auf stdout ausgeben.
+ */
+
+// Lese-Callback
+function readcb($bev, $base) {
+    $input = $bev->getInput();
+
+    while (($n = $input->remove($buf, 1024)) > 0) {
+        echo $buf;
+    }
+}
+
+// Event-Callback
+function eventcb($bev, $events, $base) {
+    if ($events & EventBufferEvent::CONNECTED) {
+        echo "Connected.\n";
+    } elseif ($events & (EventBufferEvent::ERROR | EventBufferEvent::EOF)) {
+        if ($events & EventBufferEvent::ERROR) {
+            echo "DNS error: ", $bev->getDnsErrorString(), PHP_EOL;
+        }
+
+        echo "Closing\n";
+        $base->exit();
+        exit("Done\n");
+    }
+}
+
+$base = new EventBase();
+
+echo "step 1\n";
+$bev = new EventBufferEvent($base, /* internen Socket verwenden */ NULL,
+    EventBufferEvent::OPT_CLOSE_ON_FREE | EventBufferEvent::OPT_DEFER_CALLBACKS);
+if (!$bev) {
+    exit("Failed creating bufferevent socket\n");
+}
+
+echo "step 2\n";
+$bev->setCallbacks("readcb", /* writecb */ NULL, "eventcb", $base);
+$bev->enable(Event::READ | Event::WRITE);
+
+echo "step 3\n";
+// Anfrage senden
+$output = $bev->getOutput();
+if (!$output->add(
+    "GET /index.cphp HTTP/1.0\r\n".
+    "Connection: Close\r\n\r\n"
+)) {
+    exit("Failed adding request to output buffer\n");
+}
+
+/* Synchron mit dem Host verbinden.
+Wir kennen die IP und müssen kein DNS auflösen. */
+if (!$bev->connect("127.0.0.1:80")) {
+    exit("Can't connect to host\n");
+}
+
+// Ausstehende Events abarbeiten
+$base->dispatch();
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>Echo-Server</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Einfacher Echo-Server, der auf dem Verbindungs-Listener von libevent basiert.
+ *
+ * Verwendung:
+ * 1) In einem Terminalfenster ausführen:
+ *
+ * $ php listener.php 9881
+ *
+ * 2) In einem anderen Terminalfenster eine Verbindung öffnen, z. B.:
+ *
+ * $ nc 127.0.0.1 9881
+ *
+ * 3) Mit dem Tippen beginnen. Der Server sollte die Eingabe wiederholen.
+ */
+
+class MyListenerConnection {
+    private $bev, $base;
+
+    public function __destruct() {
+        $this->bev->free();
+    }
+
+    public function __construct($base, $fd) {
+        $this->base = $base;
+
+        $this->bev = new EventBufferEvent($base, $fd, EventBufferEvent::OPT_CLOSE_ON_FREE);
+
+        $this->bev->setCallbacks(array($this, "echoReadCallback"), NULL,
+            array($this, "echoEventCallback"), NULL);
+
+        if (!$this->bev->enable(Event::READ)) {
+            echo "Failed to enable READ\n";
+            return;
+        }
+    }
+
+    public function echoReadCallback($bev, $ctx) {
+        // Alle Daten vom Eingabepuffer in den Ausgabepuffer kopieren
+
+        // Variante #1
+        $bev->output->addBuffer($bev->input);
+
+        /* Variante #2 */
+        /*
+        $input    = $bev->getInput();
+        $output = $bev->getOutput();
+        $output->addBuffer($input);
+        */
+    }
+
+    public function echoEventCallback($bev, $events, $ctx) {
+        if ($events & EventBufferEvent::ERROR) {
+            echo "Error from bufferevent\n";
+        }
+
+        if ($events & (EventBufferEvent::EOF | EventBufferEvent::ERROR)) {
+            //$bev->free();
+            $this->__destruct();
+        }
+    }
+}
+
+class MyListener {
+    public $base,
+        $listener,
+        $socket;
+    private $conn = array();
+
+    public function __destruct() {
+        foreach ($this->conn as &$c) $c = NULL;
+    }
+
+    public function __construct($port) {
+        $this->base = new EventBase();
+        if (!$this->base) {
+            echo "Couldn't open event base";
+            exit(1);
+        }
+
+        // Variante #1
+        /*
+        $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if (!socket_bind($this->socket, '0.0.0.0', $port)) {
+            echo "Unable to bind socket\n";
+            exit(1);
+        }
+        $this->listener = new EventListener($this->base,
+            array($this, "acceptConnCallback"), $this->base,
+            EventListener::OPT_CLOSE_ON_FREE | EventListener::OPT_REUSEABLE,
+            -1, $this->socket);
+         */
+
+        // Variante #2
+         $this->listener = new EventListener($this->base,
+             array($this, "acceptConnCallback"), $this->base,
+             EventListener::OPT_CLOSE_ON_FREE | EventListener::OPT_REUSEABLE, -1,
+             "0.0.0.0:$port");
+
+        if (!$this->listener) {
+            echo "Couldn't create listener";
+            exit(1);
+        }
+
+        $this->listener->setErrorCallback(array($this, "accept_error_cb"));
+    }
+
+    public function dispatch() {
+        $this->base->dispatch();
+    }
+
+    // Dieser Callback wird aufgerufen, wenn auf $bev Daten zum Lesen vorliegen
+    public function acceptConnCallback($listener, $fd, $address, $ctx) {
+        // Wir haben eine neue Verbindung! Ein Bufferevent dafür einrichten. */
+        $base = $this->base;
+        $this->conn[] = new MyListenerConnection($base, $fd);
+    }
+
+    public function accept_error_cb($listener, $ctx) {
+        $base = $this->base;
+
+        fprintf(STDERR, "Got an error %d (%s) on the listener. "
+            ."Shutting down.\n",
+            EventUtil::getLastSocketErrno(),
+            EventUtil::getLastSocketError());
+
+        $base->exit(NULL);
+    }
+}
+
+$port = 9808;
+
+if ($argc > 1) {
+    $port = (int) $argv[1];
+}
+if ($port <= 0 || $port > 65535) {
+    exit("Invalid port");
+}
+
+$l = new MyListener($port);
+$l->dispatch();
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>SSL-Echo-Server</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * SSL-Echo-Server
+ *
+ * Zum Testen:
+ * 1) Ausführen:
+ * $ php examples/ssl-echo-server/server.php 9998
+ *
+ * 2) in einem anderen Terminalfenster ausführen:
+ * $ socat - SSL:127.0.0.1:9998,verify=1,cafile=examples/ssl-echo-server/cert.pem
+ */
+
+class MySslEchoServer {
+    public $port,
+        $base,
+        $bev,
+        $listener,
+        $ctx;
+
+    function __construct ($port, $host = "127.0.0.1") {
+        $this->port = $port;
+        $this->ctx = $this->init_ssl();
+        if (!$this->ctx) {
+            exit("Failed creating SSL context\n");
+        }
+
+        $this->base = new EventBase();
+        if (!$this->base) {
+            exit("Couldn't open event base\n");
+        }
+
+        $this->listener = new EventListener($this->base,
+            array($this, "ssl_accept_cb"), $this->ctx,
+            EventListener::OPT_CLOSE_ON_FREE | EventListener::OPT_REUSEABLE,
+            -1, "$host:$port");
+        if (!$this->listener) {
+            exit("Couldn't create listener\n");
+        }
+
+        $this->listener->setErrorCallback(array($this, "accept_error_cb"));
+    }
+    function dispatch() {
+        $this->base->dispatch();
+    }
+
+    // Dieser Callback wird aufgerufen, wenn auf $bev Daten zum Lesen vorliegen.
+    function ssl_read_cb($bev, $ctx) {
+        $in = $bev->input; //$bev->getInput();
+
+        printf("Received %zu bytes\n", $in->length);
+        printf("----- data ----\n");
+        printf("%ld:\t%s\n", (int) $in->length, $in->pullup(-1));
+
+        $bev->writeBuffer($in);
+    }
+
+    // Dieser Callback wird aufgerufen, wenn am Event-Listener ein Ereignis auftritt,
+    // z. B. wenn die Verbindung geschlossen wird oder ein Fehler aufgetreten ist
+    function ssl_event_cb($bev, $events, $ctx) {
+        if ($events & EventBufferEvent::ERROR) {
+            // Fehler vom SSL-Fehlerstack abrufen
+            while ($err = $bev->sslError()) {
+                fprintf(STDERR, "Bufferevent error %s.\n", $err);
+            }
+        }
+
+        if ($events & (EventBufferEvent::EOF | EventBufferEvent::ERROR)) {
+            $bev->free();
+        }
+    }
+
+    // Dieser Callback wird aufgerufen, wenn ein Client eine neue Verbindung annimmt
+    function ssl_accept_cb($listener, $fd, $address, $ctx) {
+        // Wir haben eine neue Verbindung! Ein Bufferevent dafür einrichten.
+        $this->bev = EventBufferEvent::sslSocket($this->base, $fd, $this->ctx,
+            EventBufferEvent::SSL_ACCEPTING, EventBufferEvent::OPT_CLOSE_ON_FREE);
+
+        if (!$this->bev) {
+            echo "Failed creating ssl buffer\n";
+            $this->base->exit(NULL);
+            exit(1);
+        }
+
+        $this->bev->enable(Event::READ);
+        $this->bev->setCallbacks(array($this, "ssl_read_cb"), NULL,
+            array($this, "ssl_event_cb"), NULL);
+    }
+
+    // Dieser Callback wird aufgerufen, wenn das Einrichten einer neuen Verbindung für einen Client fehlgeschlagen ist
+    function accept_error_cb($listener, $ctx) {
+        fprintf(STDERR, "Got an error %d (%s) on the listener. "
+            ."Shutting down.\n",
+            EventUtil::getLastSocketErrno(),
+            EventUtil::getLastSocketError());
+
+        $this->base->exit(NULL);
+    }
+
+    // SSL-Strukturen initialisieren, einen EventSslContext erzeugen
+    // Optional selbstsignierte Zertifikate erzeugen
+    function init_ssl() {
+        // Wir *müssen* Entropie haben. Andernfalls macht Kryptografie keinen Sinn.
+        if (!EventUtil::sslRandPoll()) {
+            exit("EventUtil::sslRandPoll failed\n");
+        }
+
+        $local_cert = __DIR__."/cert.pem";
+        $local_pk   = __DIR__."/privkey.pem";
+
+        if (!file_exists($local_cert) || !file_exists($local_pk)) {
+            echo "Couldn't read $local_cert or $local_pk file.  To generate a key\n",
+                "and self-signed certificate, run:\n",
+                "  openssl genrsa -out $local_pk 2048\n",
+                "  openssl req -new -key $local_pk -out cert.req\n",
+                "  openssl x509 -req -days 365 -in cert.req -signkey $local_pk -out $local_cert\n";
+
+            return FALSE;
+        }
+
+        $ctx = new EventSslContext(EventSslContext::SSLv3_SERVER_METHOD, array (
+             EventSslContext::OPT_LOCAL_CERT  => $local_cert,
+             EventSslContext::OPT_LOCAL_PK    => $local_pk,
+             //EventSslContext::OPT_PASSPHRASE  => "echo server",
+             EventSslContext::OPT_VERIFY_PEER => true,
+             EventSslContext::OPT_ALLOW_SELF_SIGNED => false,
+        ));
+
+        return $ctx;
+    }
+}
+
+// Überschreiben des Ports erlauben
+$port = 9999;
+if ($argc > 1) {
+    $port = (int) $argv[1];
+}
+if ($port <= 0 || $port > 65535) {
+    exit("Invalid port\n");
+}
+
+
+$l = new MySslEchoServer($port);
+$l->dispatch();
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>Signal-Handler</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+In einem Terminalfenster starten:
+
+$ php examples/signal.php
+
+In einem anderen Terminalfenster die PID ermitteln und SIGTERM senden, z. B.:
+
+$ ps aux | grep examp
+ruslan    3976  0.2  0.0 139896 11256 pts/1    S+   10:25   0:00 php examples/signal.php
+ruslan    3978  0.0  0.0   9572   864 pts/2    S+   10:26   0:00 grep --color=auto examp
+$ kill -TERM 3976
+
+Im ersten Terminalfenster sollte Folgendes erscheinen:
+
+Caught signal 15
+*/
+class MyEventSignal {
+    private $base;
+
+    function __construct($base) {
+        $this->base = $base;
+    }
+
+    function eventSighandler($no, $c) {
+        echo "Caught signal $no\n";
+        event_base_loopexit($c->base);
+    }
+}
+
+$base = event_base_new();
+$c    = new MyEventSignal($base);
+$no   = SIGTERM;
+$ev   = evsignal_new($base, $no, array($c,'eventSighandler'), $c);
+
+evsignal_add($ev);
+
+event_base_loop($base);
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>Die Schleife von libevent verwenden, um Anfragen der Erweiterung „eio“ zu verarbeiten</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+// Callback für eio_nop()
+function my_nop_cb($d, $r) {
+    echo "step 6\n";
+}
+
+$dir = "/tmp/abc-eio-temp";
+if (file_exists($dir)) {
+    rmdir($dir);
+}
+
+echo "step 1\n";
+
+$base = new EventBase();
+
+echo "step 2\n";
+
+eio_init();
+
+eio_mkdir($dir, 0750, EIO_PRI_DEFAULT, "my_nop_cb");
+
+$event = new Event($base, eio_get_event_stream(),
+    Event::READ | Event::PERSIST, function ($fd, $events, $base) {
+    echo "step 5\n";
+
+    while (eio_nreqs()) {
+        eio_poll();
+    }
+
+    $base->stop();
+}, $base);
+
+echo "step 3\n";
+
+$event->add();
+
+echo "step 4\n";
+
+$base->dispatch();
+
+echo "Done\n";
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>Verschiedenes</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/* {{{ Konfiguration & unterstützte Funktionen */
+echo "Supported methods:\n";
+foreach (Event::getSupportedMethods() as $m) {
+    echo $m, PHP_EOL;
+}
+
+// Die Methode "select" vermeiden
+$cfg = new EventConfig();
+if ($cfg->avoidMethod("select")) {
+    echo "'select' method avoided\n";
+}
+
+// Mit der Konfiguration verknüpfte event_base erzeugen
+$base = new EventBase($cfg);
+echo "Event method used: ", $base->getMethod(), PHP_EOL;
+
+echo "Features:\n";
+$features = $base->getFeatures();
+($features & EventConfig::FEATURE_ET) and print "ET - edge-triggered IO\n";
+($features & EventConfig::FEATURE_O1) and print "O1 - O(1) operation for adding/deleting events\n";
+($features & EventConfig::FEATURE_FDS) and print "FDS - arbitrary file descriptor types, and not just sockets\n";
+
+// Das Feature FDS erfordern
+if ($cfg->requireFeatures(EventConfig::FEATURE_FDS)) {
+    echo "FDS feature is now required\n";
+
+    $base = new EventBase($cfg);
+    ($base->getFeatures() & EventConfig::FEATURE_FDS)
+        and print "FDS - arbitrary file descriptor types, and not just sockets\n";
+}
+/* }}} */
+
+/* {{{ Base */
+$base = new EventBase();
+$event = new Event($base, STDIN, Event::READ | Event::PERSIST, function ($fd, $events, $arg) {
+    static $max_iterations = 0;
+
+    if (++$max_iterations >= 5) {
+        /* nach 5 Iterationen mit einem Timeout von 2,33 Sekunden beenden */
+        echo "Stopping...\n";
+        $arg[0]->exit(2.33);
+    }
+
+    echo fgets($fd);
+}, array (&$base));
+
+$event->add();
+$base->loop();
+/* Base }}} */
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>Einfacher HTTP-Server</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Einfacher HTTP-Server.
+ *
+ * Zum Testen:
+ * 1) Auf einem Port der Wahl ausführen, z. B.:
+ * $ php examples/http.php 8010
+ * 2) In einem anderen Terminal eine Verbindung zu einer Adresse auf diesem Port
+ * herstellen und eine GET- oder POST-Anfrage senden (andere sind hier abgeschaltet), z. B.:
+ * $ nc -t 127.0.0.1 8010
+ * POST /about HTTP/1.0
+ * Content-Type: text/plain
+ * Content-Length: 4
+ * Connection: close
+ * (Enter drücken)
+ *
+ * Es gibt aus
+ * a=12
+ * HTTP/1.0 200 OK
+ * Content-Type: text/html; charset=ISO-8859-1
+ * Connection: close
+ *
+ * $ nc -t 127.0.0.1 8010
+ * GET /dump HTTP/1.0
+ * Content-Type: text/plain
+ * Content-Encoding: UTF-8
+ * Connection: close
+ * (Enter drücken)
+ *
+ * Es gibt aus:
+ * HTTP/1.0 200 OK
+ * Content-Type: text/html; charset=ISO-8859-1
+ * Connection: close
+ * (Enter drücken)
+ *
+ * $ nc -t 127.0.0.1 8010
+ * GET /unknown HTTP/1.0
+ * Connection: close
+ *
+ * Es gibt aus:
+ * HTTP/1.0 200 OK
+ * Content-Type: text/html; charset=ISO-8859-1
+ * Connection: close
+ *
+ * 3) Beobachten, was der Server im vorherigen Terminalfenster ausgibt.
+ */
+
+function _http_dump($req, $data) {
+    static $counter      = 0;
+    static $max_requests = 2;
+
+    if (++$counter >= $max_requests)  {
+        echo "Counter reached max requests $max_requests. Exiting\n";
+        exit();
+    }
+
+    echo __METHOD__, " called\n";
+    echo "request:"; var_dump($req);
+    echo "data:"; var_dump($data);
+
+    echo "\n===== DUMP =====\n";
+    echo "Command:", $req->getCommand(), PHP_EOL;
+    echo "URI:", $req->getUri(), PHP_EOL;
+    echo "Input headers:"; var_dump($req->getInputHeaders());
+    echo "Output headers:"; var_dump($req->getOutputHeaders());
+
+    echo "\n >> Sending reply ...";
+    $req->sendReply(200, "OK");
+    echo "OK\n";
+
+    echo "\n >> Reading input buffer ...\n";
+    $buf = $req->getInputBuffer();
+    while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
+        echo $s, PHP_EOL;
+    }
+    echo "No more data in the buffer\n";
+}
+
+function _http_about($req) {
+    echo __METHOD__, PHP_EOL;
+    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "\n >> Sending reply ...";
+    $req->sendReply(200, "OK");
+    echo "OK\n";
+}
+
+function _http_default($req, $data) {
+    echo __METHOD__, PHP_EOL;
+    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "\n >> Sending reply ...";
+    $req->sendReply(200, "OK");
+    echo "OK\n";
+}
+
+$port = 8010;
+if ($argc > 1) {
+    $port = (int) $argv[1];
+}
+if ($port <= 0 || $port > 65535) {
+    exit("Invalid port");
+}
+
+$base = new EventBase();
+$http = new EventHttp($base);
+$http->setAllowedMethods(EventHttpRequest::CMD_GET | EventHttpRequest::CMD_POST);
+
+$http->setCallback("/dump", "_http_dump", array(4, 8));
+$http->setCallback("/about", "_http_about");
+$http->setDefaultCallback("_http_default", "custom data value");
+
+$http->bind("0.0.0.0", 8010);
+$base->loop();
+?>
+]]>
+  </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+a=12
+HTTP/1.0 200 OK
+Content-Type: text/html; charset=ISO-8859-1
+Connection: close
+
+HTTP/1.0 200 OK
+Content-Type: text/html; charset=ISO-8859-1
+Connection: close
+(press Enter)
+
+HTTP/1.0 200 OK
+Content-Type: text/html; charset=ISO-8859-1
+Connection: close
+]]>
+  </screen>
+ </example>
+ <example>
+  <title>Einfacher HTTPS-Server</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Einfacher HTTPS-Server.
+ *
+ * 1) Den Server starten: `php examples/https.php 9999`
+ * 2) Ihn testen: `php examples/ssl-connection.php 9999`
+ */
+
+function _http_dump($req, $data) {
+    static $counter      = 0;
+    static $max_requests = 200;
+
+    if (++$counter >= $max_requests)  {
+        echo "Counter reached max requests $max_requests. Exiting\n";
+        exit();
+    }
+
+    echo __METHOD__, " called\n";
+    echo "request:"; var_dump($req);
+    echo "data:"; var_dump($data);
+
+    echo "\n===== DUMP =====\n";
+    echo "Command:", $req->getCommand(), PHP_EOL;
+    echo "URI:", $req->getUri(), PHP_EOL;
+    echo "Input headers:"; var_dump($req->getInputHeaders());
+    echo "Output headers:"; var_dump($req->getOutputHeaders());
+
+    echo "\n >> Sending reply ...";
+    $req->sendReply(200, "OK");
+    echo "OK\n";
+
+    $buf = $req->getInputBuffer();
+    echo "\n >> Reading input buffer (", $buf->length, ") ...\n";
+    while ($s = $buf->read(1024)) {
+        echo $s;
+    }
+    echo "\nNo more data in the buffer\n";
+}
+
+function _http_about($req) {
+    echo __METHOD__, PHP_EOL;
+    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "\n >> Sending reply ...";
+    $req->sendReply(200, "OK");
+    echo "OK\n";
+}
+
+function _http_default($req, $data) {
+    echo __METHOD__, PHP_EOL;
+    echo "URI: ", $req->getUri(), PHP_EOL;
+    echo "\n >> Sending reply ...";
+    $req->sendReply(200, "OK");
+    echo "OK\n";
+}
+
+function _http_400($req) {
+    $req->sendError(400);
+}
+
+function _init_ssl() {
+    $local_cert = __DIR__."/ssl-echo-server/cert.pem";
+    $local_pk   = __DIR__."/ssl-echo-server/privkey.pem";
+
+    $ctx = new EventSslContext(EventSslContext::SSLv3_SERVER_METHOD, array (
+        EventSslContext::OPT_LOCAL_CERT  => $local_cert,
+        EventSslContext::OPT_LOCAL_PK    => $local_pk,
+        //EventSslContext::OPT_PASSPHRASE  => "test",
+        EventSslContext::OPT_ALLOW_SELF_SIGNED => true,
+    ));
+
+    return $ctx;
+}
+
+$port = 9999;
+if ($argc > 1) {
+    $port = (int) $argv[1];
+}
+if ($port <= 0 || $port > 65535) {
+    exit("Invalid port");
+}
+$ip = '0.0.0.0';
+
+$base = new EventBase();
+$ctx  = _init_ssl();
+$http = new EventHttp($base, $ctx);
+$http->setAllowedMethods(EventHttpRequest::CMD_GET | EventHttpRequest::CMD_POST);
+
+$http->setCallback("/dump", "_http_dump", array(4, 8));
+$http->setCallback("/about", "_http_about");
+$http->setCallback("/err400", "_http_400");
+$http->setDefaultCallback("_http_default", "custom data value");
+
+$http->bind($ip, $port);
+$base->dispatch();
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>OpenSSL-Verbindung</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Beispiel für einen OpenSSL-Client.
+ *
+ * Verwendung:
+ * 1) Einen Server starten, z. B.:
+ * $ php examples/https.php 9999
+ *
+ * 2) Den Client in einem anderen Terminal starten:
+ * $ php examples/ssl-connection.php 9999
+ */
+
+function _request_handler($req, $base) {
+    echo __FUNCTION__, PHP_EOL;
+
+    if (is_null($req)) {
+        echo "Timed out\n";
+    } else {
+        $response_code = $req->getResponseCode();
+
+        if ($response_code == 0) {
+            echo "Connection refused\n";
+        } elseif ($response_code != 200) {
+            echo "Unexpected response: $response_code\n";
+        } else {
+            echo "Success: $response_code\n";
+            $buf = $req->getInputBuffer();
+            echo "Body:\n";
+            while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
+                echo $s, PHP_EOL;
+            }
+        }
+    }
+
+    $base->exit(NULL);
+}
+
+function _init_ssl() {
+    $ctx = new EventSslContext(EventSslContext::SSLv3_CLIENT_METHOD, array ());
+
+    return $ctx;
+}
+
+
+// Überschreiben des Ports erlauben
+$port = 9999;
+if ($argc > 1) {
+    $port = (int) $argv[1];
+}
+if ($port <= 0 || $port > 65535) {
+    exit("Invalid port\n");
+}
+$host = '127.0.0.1';
+
+$ctx = _init_ssl();
+if (!$ctx) {
+    trigger_error("Failed creating SSL context", E_USER_ERROR);
+}
+
+$base = new EventBase();
+if (!$base) {
+    trigger_error("Failed to initialize event base", E_USER_ERROR);
+}
+
+$conn = new EventHttpConnection($base, NULL, $host, $port, $ctx);
+$conn->setTimeout(50);
+
+$req = new EventHttpRequest("_request_handler", $base);
+$req->addHeader("Host", $host, EventHttpRequest::OUTPUT_HEADER);
+$buf = $req->getOutputBuffer();
+$buf->add("<html>HTML TEST</html>");
+//$req->addHeader("Content-Length", $buf->length, EventHttpRequest::OUTPUT_HEADER);
+//$req->addHeader("Connection", "close", EventHttpRequest::OUTPUT_HEADER);
+$conn->makeRequest($req, EventHttpRequest::CMD_POST, "/dump");
+
+$base->dispatch();
+echo "END\n";
+?>
+]]>
+  </programlisting>
+ </example>
+ <example>
+  <title>
+   <function>EventHttpConnection::makeRequest</function>-Beispiel</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+function _request_handler($req, $base) {
+    echo __FUNCTION__, PHP_EOL;
+
+    if (is_null($req)) {
+        echo "Timed out\n";
+    } else {
+        $response_code = $req->getResponseCode();
+
+        if ($response_code == 0) {
+            echo "Connection refused\n";
+        } elseif ($response_code != 200) {
+            echo "Unexpected response: $response_code\n";
+        } else {
+            echo "Success: $response_code\n";
+            $buf = $req->getInputBuffer();
+            echo "Body:\n";
+            while ($s = $buf->readLine(EventBuffer::EOL_ANY)) {
+                echo $s, PHP_EOL;
+            }
+        }
+    }
+
+    $base->exit(NULL);
+}
+
+$address = "127.0.0.1";
+$port = 80;
+
+$base = new EventBase();
+$conn = new EventHttpConnection($base, NULL, $address, $port);
+$conn->setTimeout(5);
+$req = new EventHttpRequest("_request_handler", $base);
+
+$req->addHeader("Host", $address, EventHttpRequest::OUTPUT_HEADER);
+$req->addHeader("Content-Length", "0", EventHttpRequest::OUTPUT_HEADER);
+$conn->makeRequest($req, EventHttpRequest::CMD_GET, "/index.cphp");
+
+$base->loop();
+?>
+]]>
+  </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+_request_handler
+Success: 200
+Body:
+PHP, date:
+2013-03-13T20:27:52+05:00
+]]>
+  </screen>
+ </example>
+ <example>
+  <title>
+   Verbindungs-Listener auf Basis eines UNIX-Domain-Sockets</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+/*
+ * Einfacher Echo-Server, der auf dem Verbindungs-Listener von libevent basiert.
+ *
+ * Verwendung:
+ * 1) In einem Terminalfenster ausführen:
+ *
+ * $ php unix-domain-listener.php [Pfad-zum-Socket]
+ *
+ * 2) In einem anderen Terminalfenster eine Verbindung
+ * zum Socket öffnen, z. B.:
+ *
+ * $ socat - GOPEN:/tmp/1.sock
+ *
+ * 3) Mit dem Tippen beginnen. Der Server sollte die Eingabe wiederholen.
+ */
+
+class MyListenerConnection {
+    private $bev, $base;
+
+    public function __destruct() {
+        if ($this->bev) {
+            $this->bev->free();
+        }
+    }
+
+    public function __construct($base, $fd) {
+        $this->base = $base;
+
+        $this->bev = new EventBufferEvent($base, $fd, EventBufferEvent::OPT_CLOSE_ON_FREE);
+
+        $this->bev->setCallbacks(array($this, "echoReadCallback"), NULL,
+            array($this, "echoEventCallback"), NULL);
+
+        if (!$this->bev->enable(Event::READ)) {
+            echo "Failed to enable READ\n";
+            return;
+        }
+    }
+
+    public function echoReadCallback($bev, $ctx) {
+        // Alle Daten vom Eingabepuffer in den Ausgabepuffer kopieren
+        $bev->output->addBuffer($bev->input);
+    }
+
+    public function echoEventCallback($bev, $events, $ctx) {
+        if ($events & EventBufferEvent::ERROR) {
+            echo "Error from bufferevent\n";
+        }
+
+        if ($events & (EventBufferEvent::EOF | EventBufferEvent::ERROR)) {
+            $bev->free();
+            $bev = NULL;
+        }
+    }
+}
+
+class MyListener {
+    public $base,
+        $listener,
+        $socket;
+    private $conn = array();
+
+    public function __destruct() {
+        foreach ($this->conn as &$c) $c = NULL;
+    }
+
+    public function __construct($sock_path) {
+        $this->base = new EventBase();
+        if (!$this->base) {
+            echo "Couldn't open event base";
+            exit(1);
+        }
+
+        if (file_exists($sock_path)) {
+            unlink($sock_path);
+        }
+
+         $this->listener = new EventListener($this->base,
+             array($this, "acceptConnCallback"), $this->base,
+             EventListener::OPT_CLOSE_ON_FREE | EventListener::OPT_REUSEABLE, -1,
+             "unix:$sock_path");
+
+        if (!$this->listener) {
+            trigger_error("Couldn't create listener", E_USER_ERROR);
+        }
+
+        $this->listener->setErrorCallback(array($this, "accept_error_cb"));
+    }
+
+    public function dispatch() {
+        $this->base->dispatch();
+    }
+
+    // Dieser Callback wird aufgerufen, wenn auf $bev Daten zum Lesen vorliegen
+    public function acceptConnCallback($listener, $fd, $address, $ctx) {
+        // Wir haben eine neue Verbindung! Ein Bufferevent dafür einrichten. */
+        $base = $this->base;
+        $this->conn[] = new MyListenerConnection($base, $fd);
+    }
+
+    public function accept_error_cb($listener, $ctx) {
+        $base = $this->base;
+
+        fprintf(STDERR, "Got an error %d (%s) on the listener. "
+            ."Shutting down.\n",
+            EventUtil::getLastSocketErrno(),
+            EventUtil::getLastSocketError());
+
+        $base->exit(NULL);
+    }
+}
+
+if ($argc <= 1) {
+    exit("Socket path is not provided\n");
+}
+$sock_path = $argv[1];
+
+$l = new MyListener($sock_path);
+$l->dispatch();
+?>
+]]>
+  </programlisting>
+ </example>
+ <example xml:id="event.example.smtp">
+  <title>Einfacher SMTP-Server</title>
+  <programlisting role="php">
+<![CDATA[
+<?php
+ /*
+ * Author: Andrew Rose <hello at andrewrose dot co dot uk>
+ *
+ * Verwendung:
+ * 1) Die Dateien cert.pem (Zertifikat) und privkey.pem (privater Schlüssel) vorbereiten.
+ * 2) Das Server-Skript starten
+ * 3) Eine TLS-Verbindung öffnen, z. B.:
+ *      $ openssl s_client -connect localhost:25 -starttls smtp -crlf
+ * 4) Die in der Methode `cmd` weiter unten aufgeführten Befehle testen.
+ */
+
+class Handler {
+    public $domainName = FALSE;
+    public $connections = [];
+    public $buffers = [];
+    public $maxRead = 256000;
+
+    public function __construct() {
+        $this->ctx = new EventSslContext(EventSslContext::SSLv3_SERVER_METHOD, [
+            EventSslContext::OPT_LOCAL_CERT  => 'cert.pem',
+            EventSslContext::OPT_LOCAL_PK    => 'privkey.pem',
+            //EventSslContext::OPT_PASSPHRASE  => '',
+            EventSslContext::OPT_VERIFY_PEER => false, // mit einem echten Zertifikat auf true ändern
+            EventSslContext::OPT_ALLOW_SELF_SIGNED => true // mit einem echten Zertifikat auf false ändern
+        ]);
+
+        $this->base = new EventBase();
+        if (!$this->base) {
+            exit("Couldn't open event base\n");
+        }
+
+        if (!$this->listener = new EventListener($this->base,
+            [$this, 'ev_accept'],
+            $this->ctx,
+            EventListener::OPT_CLOSE_ON_FREE | EventListener::OPT_REUSEABLE,
+            -1,
+            '0.0.0.0:25'))
+        {
+            exit("Couldn't create listener\n");
+        }
+
+        $this->listener->setErrorCallback([$this, 'ev_error']);
+        $this->base->dispatch();
+    }
+
+    public function ev_accept($listener, $fd, $address, $ctx) {
+        static $id = 0;
+        $id += 1;
+
+        $this->connections[$id]['clientData'] = '';
+        $this->connections[$id]['cnx'] = new EventBufferEvent($this->base, $fd,
+            EventBufferEvent::OPT_CLOSE_ON_FREE);
+
+        if (!$this->connections[$id]['cnx']) {
+            echo "Failed creating buffer\n";
+            $this->base->exit(NULL);
+            exit(1);
+        }
+
+        $this->connections[$id]['cnx']->setCallbacks([$this, "ev_read"], NULL,
+            [$this, 'ev_error'], $id);
+        $this->connections[$id]['cnx']->enable(Event::READ | Event::WRITE);
+
+        $this->ev_write($id, '220 '.$this->domainName." wazzzap?\r\n");
+    }
+
+    function ev_error($listener, $ctx) {
+        $errno = EventUtil::getLastSocketErrno();
+
+        fprintf(STDERR, "Got an error %d (%s) on the listener. Shutting down.\n",
+            $errno, EventUtil::getLastSocketError());
+
+        if ($errno != 0) {
+            $this->base->exit(NULL);
+            exit();
+        }
+    }
+
+    public function ev_close($id) {
+        $this->connections[$id]['cnx']->disable(Event::READ | Event::WRITE);
+        unset($this->connections[$id]);
+    }
+
+    protected function ev_write($id, $string) {
+        echo 'S('.$id.'): '.$string;
+        $this->connections[$id]['cnx']->write($string);
+    }
+
+    public function ev_read($buffer, $id) {
+        while($buffer->input->length > 0) {
+            $this->connections[$id]['clientData'] .= $buffer->input->read($this->maxRead);
+            $clientDataLen = strlen($this->connections[$id]['clientData']);
+
+            if($this->connections[$id]['clientData'][$clientDataLen-1] == "\n"
+                && $this->connections[$id]['clientData'][$clientDataLen-2] == "\r")
+            {
+                // das abschließende \r\n entfernen
+                $line = substr($this->connections[$id]['clientData'], 0,
+                    strlen($this->connections[$id]['clientData']) - 2);
+
+                $this->connections[$id]['clientData'] = '';
+                $this->cmd($buffer, $id, $line);
+            }
+        }
+    }
+
+    protected function cmd($buffer, $id, $line) {
+        switch ($line) {
+            case strncmp('EHLO ', $line, 4):
+                $this->ev_write($id, "250-STARTTLS\r\n");
+                $this->ev_write($id, "250 OK ehlo\r\n");
+                break;
+
+            case strncmp('HELO ', $line, 4):
+                $this->ev_write($id, "250-STARTTLS\r\n");
+                $this->ev_write($id, "250 OK helo\r\n");
+                break;
+
+            case strncmp('QUIT', $line, 3):
+                $this->ev_write($id, "250 OK quit\r\n");
+                $this->ev_close($id);
+                break;
+
+            case strncmp('STARTTLS', $line, 3):
+                $this->ev_write($id, "220 Ready to start TLS\r\n");
+                $this->connections[$id]['cnx'] = EventBufferEvent::sslFilter($this->base,
+                    $this->connections[$id]['cnx'], $this->ctx,
+                    EventBufferEvent::SSL_ACCEPTING,
+                    EventBufferEvent::OPT_CLOSE_ON_FREE);
+                $this->connections[$id]['cnx']->setCallbacks([$this, "ev_read"], NULL, [$this, 'ev_error'], $id);
+                $this->connections[$id]['cnx']->enable(Event::READ | Event::WRITE);
+                break;
+
+            default:
+                echo 'unknown command: '.$line."\n";
+                break;
+        }
+    }
+}
+
+new Handler();
+]]>
+  </programlisting>
+ </example>
+</chapter>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `event` ins Deutsche, auf dem Stand des aktuellen EN-Texts (9 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236, #242 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").