### PR TITLE
[Sync EN] ev: German translation of new files

### DIFF
--- a/reference/ev/ev/feedsignal.xml
+++ b/reference/ev/ev/feedsignal.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.feedsignal">
+ <refnamediv>
+  <refname>Ev::feedSignal</refname>
+  <refpurpose>Speist ein Signalereignis in Ev ein</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>void</type>
+   <methodname>Ev::feedSignal</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>signum</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Simuliert den Empfang eines Signals. Diese Funktion kann jederzeit und aus
+   jedem Kontext heraus gefahrlos aufgerufen werden, einschließlich
+   Signal-Handlern oder beliebigen Threads. Ihr Hauptzweck besteht darin, die
+   Signalbehandlung im Prozess anzupassen.
+  </simpara>
+  <simpara>
+   Im Gegensatz zu
+   <methodname>Ev::feedSignalEvent</methodname>
+   funktioniert dies unabhängig davon, welcher Loop das Signal registriert hat.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>signum</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Die Signalnummer. Einzelheiten finden sich auf der Manpage zu
+      <literal>signal(7)</literal>.
+      Es können die von der Erweiterung
+      <literal>pcntl</literal>
+      exportierten Konstanten verwendet werden.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>Ev::feedSignalEvent</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/ev/now.xml
+++ b/reference/ev/ev/now.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.now">
+ <refnamediv>
+  <refname>Ev::now</refname>
+  <refpurpose>Gibt den Zeitpunkt zurück, zu dem die letzte Iteration des
+  Standard-Event-Loops begonnen hat</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>float</type>
+   <methodname>Ev::now</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt den Zeitpunkt zurück, zu dem die letzte Iteration des
+   Standard-Event-Loops begonnen hat. Dies ist der Zeitpunkt, auf dem die
+   Timer (
+   <classname>EvTimer</classname>
+   und
+   <classname>EvPeriodic</classname>)
+   basieren, und der Zugriff darauf ist in der Regel schneller als der Aufruf
+   von
+   <methodname>Ev::time</methodname>.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt die Anzahl der Sekunden (als Bruchteil) zurück, die den Zeitpunkt
+   darstellt, zu dem die letzte Iteration des Standard-Event-Loops begonnen
+   hat.
+  </simpara>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>Ev::nowUpdate</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/ev/recommendedbackends.xml
+++ b/reference/ev/ev/recommendedbackends.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.recommendedbackends">
+ <refnamediv>
+  <refname>Ev::recommendedBackends</refname>
+  <refpurpose>Gibt eine Bitmaske der für die aktuelle Plattform empfohlenen
+  Backends zurück</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>int</type>
+   <methodname>Ev::recommendedBackends</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt die Menge aller Backends zurück, die in dieses Binary von
+   <literal>libev</literal>
+   einkompiliert wurden und außerdem für diese Plattform empfohlen werden, was
+   bedeutet, dass sie für die meisten Dateideskriptortypen funktionieren. Diese
+   Menge ist oft kleiner als die von
+   <function>ev_supported_backends</function>
+   zurückgegebene, da zum Beispiel
+   <literal>kqueue</literal>
+   auf den meisten
+   <literal>BSD</literal>-Systemen
+   fehlerhaft ist und nicht automatisch erkannt wird, sofern es nicht explizit
+   angefordert wird. Dies ist die Menge der Backends, die
+   <literal>libev</literal>
+   prüft, wenn keine Backends explizit angegeben werden.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt eine Bitmaske zurück, die
+   <link linkend="ev.constants.watcher-backends">Backend-Flags</link>
+   enthalten kann, die mit dem bitweisen
+   <emphasis>ODER</emphasis>-Operator
+   kombiniert werden.
+  </simpara>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+ <example>
+   <title>Einbetten eines Loops in einen anderen</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+/*
+* Versucht, einen einbettbaren Event-Loop zu erhalten und ihn in den
+* Standard-Event-Loop einzubetten. Ist dies nicht möglich, wird der
+* Standard-Loop verwendet. Der Standard-Loop wird in $loop_hi gespeichert,
+* während der einbettbare Loop in $loop_lo gespeichert wird (das $loop_hi
+* entspricht, falls kein einbettbarer Loop verwendet werden kann).
+*
+* Beispiel übersetzt nach PHP
+* http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#Examples_CONTENT-9
+*/
+$loop_hi = EvLoop::defaultLoop();
+$loop_lo = NULL;
+$embed   = NULL;
+
+/*
+* Prüft, ob die Chance besteht, einen funktionierenden zu erhalten
+* (ein Flag-Wert von 0 bedeutet automatische Erkennung)
+*/
+$loop_lo = Ev::embeddableBackends() & Ev::recommendedBackends()
+ ? new EvLoop(Ev::embeddableBackends() & Ev::recommendedBackends())
+ : 0;
+
+if ($loop_lo) {
+ $embed = new EvEmbed($loop_lo, function () {});
+} else {
+ $loop_lo = $loop_hi;
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <classname>EvEmbed</classname>
+   </member>
+   <member>
+    <methodname>Ev::embeddableBackends</methodname>
+   </member>
+   <member>
+    <methodname>Ev::supportedBackends</methodname>
+   </member>
+   <member>
+    <link linkend="ev.constants.watcher-backends">Backend-Flags</link>
+   </member>
+   <member>
+    <link linkend="ev.examples">Beispiele</link>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/ev/resume.xml
+++ b/reference/ev/ev/resume.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.resume">
+ <refnamediv>
+  <refname>Ev::resume</refname>
+  <refpurpose>Setzt einen zuvor angehaltenen Standard-Event-Loop fort</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>void</type>
+   <methodname>Ev::resume</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Die Methoden
+   <methodname>Ev::suspend</methodname>
+   und
+   <methodname>Ev::resume</methodname>
+   halten einen Loop an bzw. setzen ihn fort.
+  </simpara>
+  <simpara>
+   Alle Timer-Watcher werden um die Zeit verzögert, die zwischen
+   <emphasis>suspend</emphasis>
+   und
+   <emphasis>resume</emphasis>
+   vergeht, und alle
+   <emphasis>periodischen</emphasis>
+   Watcher werden neu eingeplant (das heißt, sie verlieren alle Ereignisse, die
+   während des angehaltenen Zustands aufgetreten wären).
+  </simpara>
+  <simpara>
+   Nach dem Aufruf von
+   <methodname>Ev::suspend</methodname>
+   ist es nicht erlaubt, eine andere Funktion auf dem betreffenden Loop
+   aufzurufen als
+   <methodname>Ev::resume</methodname>.
+   Außerdem ist es nicht erlaubt,
+   <methodname>Ev::resume</methodname>
+   ohne einen vorherigen Aufruf von
+   <methodname>Ev::suspend</methodname>
+   aufzurufen.
+  </simpara>
+  <simpara>
+   Der Aufruf von
+   <emphasis>suspend</emphasis>
+   /
+   <emphasis>resume</emphasis>
+   hat als Nebeneffekt die Aktualisierung der Event-Loop-Zeit (siehe
+   <methodname>Ev::nowUpdate</methodname>
+   ).
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>Ev::suspend</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/ev/suspend.xml
+++ b/reference/ev/ev/suspend.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.suspend">
+ <refnamediv>
+  <refname>Ev::suspend</refname>
+  <refpurpose>Hält den Standard-Event-Loop an</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>void</type>
+   <methodname>Ev::suspend</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Die Methoden
+   <methodname>Ev::suspend</methodname>
+   und
+   <methodname>Ev::resume</methodname>
+   halten den Standard-Loop an bzw. setzen ihn fort.
+  </simpara>
+  <simpara>
+   Alle Timer-Watcher werden um die Zeit verzögert, die zwischen
+   <emphasis>suspend</emphasis>
+   und
+   <emphasis>resume</emphasis>
+   vergeht, und alle
+   <emphasis>periodischen</emphasis>
+   Watcher werden neu eingeplant (das heißt, sie verlieren alle Ereignisse, die
+   während des angehaltenen Zustands aufgetreten wären).
+  </simpara>
+  <simpara>
+   Nach dem Aufruf von
+   <methodname>Ev::suspend</methodname>
+   ist es nicht erlaubt, eine andere Funktion auf dem betreffenden Loop
+   aufzurufen als
+   <methodname>Ev::resume</methodname>.
+   Außerdem ist es nicht erlaubt,
+   <methodname>Ev::resume</methodname>
+   ohne einen vorherigen Aufruf von
+   <methodname>Ev::suspend</methodname>
+   aufzurufen.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>Ev::resume</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/evprepare/construct.xml
+++ b/reference/ev/evprepare/construct.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evprepare.construct">
+ <refnamediv>
+  <refname>EvPrepare::__construct</refname>
+  <refpurpose>Erzeugt ein EvPrepare-Watcher-Objekt</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier>
+   <methodname>EvPrepare::__construct</methodname>
+   <methodparam>
+    <type>string</type>
+    <parameter>callback</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>string</type>
+    <parameter>data</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>string</type>
+    <parameter>priority</parameter>
+   </methodparam>
+  </constructorsynopsis>
+  <simpara>
+   Erzeugt ein EvPrepare-Watcher-Objekt und startet den Watcher automatisch.
+   Wird ein angehaltener Watcher benötigt, sollte
+   <methodname>EvPrepare::createStopped</methodname>
+   verwendet werden.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>callback</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Siehe
+      <link linkend="ev.watcher-callbacks">Watcher-Callbacks</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>data</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Mit dem Watcher verknüpfte benutzerdefinierte Daten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>priority</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      <link linkend="ev.constants.watcher-pri">Watcher-Priorität</link>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <classname>EvCheck</classname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/evprepare/createstopped.xml
+++ b/reference/ev/evprepare/createstopped.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evprepare.createstopped">
+ <refnamediv>
+  <refname>EvPrepare::createStopped</refname>
+  <refpurpose>Erzeugt eine angehaltene Instanz eines EvPrepare-Watchers</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>EvPrepare</type>
+   <methodname>EvPrepare::createStopped</methodname>
+   <methodparam>
+    <type>callable</type>
+    <parameter>callback</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>mixed</type>
+    <parameter>data</parameter>
+    <initializer>&null;</initializer>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>int</type>
+    <parameter>priority</parameter>
+    <initializer>0</initializer>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt eine angehaltene Instanz eines EvPrepare-Watchers. Im Gegensatz zu
+   <methodname>EvPrepare::__construct</methodname>
+   startet diese Methode den Watcher nicht automatisch.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>callback</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Siehe
+      <link linkend="ev.watcher-callbacks">Watcher-Callbacks</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>data</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Mit dem Watcher verknüpfte benutzerdefinierte Daten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>priority</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      <link linkend="ev.constants.watcher-pri">Watcher-Priorität</link>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg ein EvPrepare-Objekt zurück.
+  </simpara>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EvPrepare::__construct</methodname>
+   </member>
+   <member>
+    <methodname>EvWatcher::start</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/evsignal/createstopped.xml
+++ b/reference/ev/evsignal/createstopped.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="evsignal.createstopped">
+ <refnamediv>
+  <refname>EvSignal::createStopped</refname>
+  <refpurpose>Erzeugt ein angehaltenes EvSignal-Watcher-Objekt</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier>
+   <modifier>public</modifier>
+   <modifier>static</modifier>
+   <type>EvSignal</type>
+   <methodname>EvSignal::createStopped</methodname>
+   <methodparam>
+    <type>int</type>
+    <parameter>signum</parameter>
+   </methodparam>
+   <methodparam>
+    <type>callable</type>
+    <parameter>callback</parameter>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>mixed</type>
+    <parameter>data</parameter>
+    <initializer>&null;</initializer>
+   </methodparam>
+   <methodparam choice="opt">
+    <type>int</type>
+    <parameter>priority</parameter>
+    <initializer>0</initializer>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt ein angehaltenes EvSignal-Watcher-Objekt. Im Gegensatz zu
+   <methodname>EvSignal::__construct</methodname>
+   startet diese Methode den Watcher nicht automatisch.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term>
+     <parameter>signum</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Die Signalnummer. Siehe die von der Erweiterung
+      <emphasis>pcntl</emphasis>
+      exportierten Konstanten. Siehe auch die Manpage zu
+      <literal>signal(7)</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>callback</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Siehe
+      <link linkend="ev.watcher-callbacks">Watcher-Callbacks</link>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>data</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      Mit dem Watcher verknüpfte benutzerdefinierte Daten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     <parameter>priority</parameter>
+    </term>
+    <listitem>
+     <simpara>
+      <link linkend="ev.constants.watcher-pri">Watcher-Priorität</link>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg ein EvSignal-Objekt zurück.
+  </simpara>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member>
+    <methodname>EvWatcher::start</methodname>
+   </member>
+   <member>
+    <methodname>EvSignal::__construct</methodname>
+   </member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ev/watcher-callbacks.xml
+++ b/reference/ev/watcher-callbacks.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="ev.watcher-callbacks">
+ <title>Watcher-Callbacks</title>
+ <simpara>
+  Alle Watcher können aktiv (auf Ereignisse wartend) oder inaktiv (pausiert)
+  sein. Nur bei aktiven Watchern werden die Callbacks aufgerufen. Alle Callbacks
+  werden mit mindestens zwei Argumenten aufgerufen:
+  <parameter>watcher</parameter>
+  - der Watcher, und
+  <parameter>revents</parameter>
+  eine Bitmaske der empfangenen Ereignisse.
+ </simpara>
+ <simpara>
+  Watcher-Callbacks werden an die Watcher-Konstruktoren übergeben (die von
+  <classname>EvWatcher</classname>
+  abgeleiteten Klassen -
+  <methodname>EvCheck::__construct</methodname>,
+  <methodname>EvChild::__construct</methodname>
+  usw.). Ein Watcher-Callback sollte dem folgenden Prototyp entsprechen:
+ </simpara>
+ <methodsynopsis>
+  <type>void</type>
+  <methodname>callback</methodname>
+  <methodparam choice="opt">
+   <type>object</type>
+   <parameter>watcher</parameter>
+   <initializer>NULL</initializer>
+  </methodparam>
+  <methodparam choice="opt">
+   <type>int</type>
+   <parameter>revents</parameter>
+   <initializer>NULL</initializer>
+  </methodparam>
+ </methodsynopsis>
+ <variablelist>
+  <varlistentry>
+   <term>
+    <parameter>watcher</parameter>
+   </term>
+   <listitem>
+    <simpara>
+     Die Watcher-Instanz (einer von
+     <classname>EvWatcher</classname>
+     abgeleiteten Klasse).
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>
+    <parameter>revents</parameter>
+   </term>
+   <listitem>
+    <simpara>
+     <link linkend="ev.constants.watcher-revents">Vom Watcher empfangene Ereignisse</link>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ <simpara>
+  Jeder Watcher-Typ hat sein zugehöriges Bit in
+  <parameter>revents</parameter>,
+  sodass derselbe Callback für mehrere Watcher verwendet werden kann. Die
+  Ereignismaske ist nach dem Typ benannt, d. h.
+  <classname>EvChild</classname>
+  (oder
+  <methodname>EvLoop::child</methodname>)
+  setzt
+  <constant>Ev::CHILD</constant>,
+  <classname>EvPrepare</classname>
+  (oder
+  <methodname>EvLoop::prepare</methodname>)
+  setzt
+  <constant>Ev::PREPARE</constant>,
+  <classname>EvPeriodic</classname>
+  (oder
+  <methodname>EvLoop::periodic</methodname>)
+  setzt
+  <constant>Ev::PERIODIC</constant>
+  und so weiter, mit Ausnahme von E/A-Ereignissen (die sowohl das Bit
+  <constant>Ev::READ</constant>
+  als auch
+  <constant>Ev::WRITE</constant>
+  setzen können).
+ </simpara>
+</chapter>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `ev` ins Deutsche, auf dem Stand des aktuellen EN-Texts (9 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").