### PR TITLE
[Sync EN] ui: German translation of new files

### DIFF
--- a/reference/ui/ui.controls.editablecombo.xml
+++ b/reference/ui/ui.controls.editablecombo.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.ui-controls-editablecombo" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>EditableCombo-Steuerelement</title>
+ <titleabbrev>UI\Controls\EditableCombo</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ UI\Controls\EditableCombo intro -->
+  <section xml:id="ui-controls-editablecombo.intro">
+   &reftitle.intro;
+   <para>
+    Eine EditableCombo ist eine Combo, die es dem Benutzer ermöglicht,
+    eigene Optionen einzugeben
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="ui-controls-editablecombo.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>UI\Controls\EditableCombo</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>UI\Controls\EditableCombo</classname>
+     </ooclass>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>UI\Control</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-controls-editablecombo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+
+    <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.ui-control')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.ui.ui.controls.entities.editablecombo;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ui/ui/controls/form/delete.xml
+++ b/reference/ui/ui/controls/form/delete.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ui-controls-form.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>UI\Controls\Form::delete</refname>
+  <refpurpose>Löscht ein Steuerelement</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>UI\Controls\Form::delete</methodname>
+   <methodparam><type>int</type><parameter>index</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Löscht das Steuerelement am angegebenen Index in diesem Formular
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>index</parameter></term>
+    <listitem>
+     <para>
+      Der Index des zu entfernenden Steuerelements
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Angabe über den Erfolg
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ui/ui/controls/separator/construct.xml
+++ b/reference/ui/ui/controls/separator/construct.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ui-controls-separator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>UI\Controls\Separator::__construct</refname>
+  <refpurpose>Erzeugt einen neuen Separator</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>UI\Controls\Separator::__construct</methodname>
+   <methodparam choice="opt"><type>int</type><parameter>type</parameter><initializer>UI\Controls\Separator::Horizontal</initializer></methodparam>
+  </constructorsynopsis>
+  <para>
+   Erzeugt einen neuen Separator des angegebenen Typs
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <simpara>
+      Separator::Horizontal oder Separator::Vertical
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ui/ui/draw/brush.gradient/addstop.xml
+++ b/reference/ui/ui/draw/brush.gradient/addstop.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ui-draw-brush-gradient.addstop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>UI\Draw\Brush\Gradient::addStop</refname>
+  <refpurpose>Manipulation von Stopps</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>UI\Draw\Brush\Gradient::addStop</methodname>
+   <methodparam><type>float</type><parameter>position</parameter></methodparam>
+   <methodparam><type>UI\Draw\Color</type><parameter>color</parameter></methodparam>
+  </methodsynopsis>
+  <methodsynopsis>
+   <modifier>public</modifier> <type>int</type><methodname>UI\Draw\Brush\Gradient::addStop</methodname>
+   <methodparam><type>float</type><parameter>position</parameter></methodparam>
+   <methodparam><type>int</type><parameter>color</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Fügt einen Stopp der angegebenen Farbe an der angegebenen Position hinzu
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>position</parameter></term>
+    <listitem>
+     <para>
+      Die Position für den neuen Stopp
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>color</parameter></term>
+    <listitem>
+     <para>
+      Die Farbe für den neuen Stopp, kann UI\Draw\Color oder RRGGBBAA sein
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gesamtzahl der Stopps
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ui/ui/size/getwidth.xml
+++ b/reference/ui/ui/size/getwidth.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ui-size.getwidth" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>UI\Size::getWidth</refname>
+  <refpurpose>Ruft die Breite ab</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>float</type><methodname>UI\Size::getWidth</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+  Ruft die Breite ab
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Die aktuelle Breite
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ui/ui/window/isfullscreen.xml
+++ b/reference/ui/ui/window/isfullscreen.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="ui-window.isfullscreen" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>UI\Window::isFullScreen</refname>
+  <refpurpose>Erkennung des Vollbildmodus</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>UI\Window::isFullScreen</methodname>
+   <void />
+  </methodsynopsis>
+  <simpara>
+   Erkennt, ob dieses Fenster den gesamten Bildschirm verwendet
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `ui` ins Deutsche, auf dem Stand des aktuellen EN-Texts (6 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").