### PR TITLE
[Sync EN] tidy: German translation of new files

### DIFF
--- a/reference/tidy/tidynode/isasp.xml
+++ b/reference/tidy/tidynode/isasp.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="tidynode.isasp" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tidyNode::isAsp</refname>
+  <refpurpose>Prüft, ob dieser Knoten ASP ist</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="tidyNode">
+   <modifier>public</modifier> <type>bool</type><methodname>tidyNode::isAsp</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt an, ob der aktuelle Knoten ASP ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn der Knoten ASP ist, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>ASP-Code aus einem gemischten HTML-Dokument extrahieren</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$html = <<< HTML
+<html><head>
+<?php echo '<title>title</title>'; ?>
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+</head>
+<body>
+
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+
+<!-- Comments -->
+Hello World
+</body></html>
+Outside HTML
+HTML;
+
+
+$tidy = tidy_parse_string($html);
+$num = 0;
+
+get_nodes($tidy->html());
+
+function get_nodes($node) {
+
+    // prüfen, ob der aktuelle Knoten vom gewünschten Typ ist
+    if($node->isAsp()) {
+        echo "\n\n# asp node #" . ++$GLOBALS['num'] . "\n";
+        echo $node->value;
+    }
+
+    // prüfen, ob der aktuelle Knoten Kindknoten hat
+    if($node->hasChildren()) {
+        foreach($node->child as $child) {
+            get_nodes($child);
+        }
+    }
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+# asp node #1
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tidy/tidynode/iscomment.xml
+++ b/reference/tidy/tidynode/iscomment.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="tidynode.iscomment" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tidyNode::isComment</refname>
+  <refpurpose>Prüft, ob ein Knoten einen Kommentar darstellt</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="tidyNode">
+   <modifier>public</modifier> <type>bool</type><methodname>tidyNode::isComment</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt an, ob der Knoten ein Kommentar ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn der Knoten ein Kommentar ist, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Kommentare aus einem gemischten HTML-Dokument extrahieren</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$html = <<< HTML
+<html><head>
+<?php echo '<title>title</title>'; ?>
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+</head>
+<body>
+
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+
+<!-- Comments -->
+Hello World
+</body></html>
+Outside HTML
+HTML;
+
+
+$tidy = tidy_parse_string($html);
+$num = 0;
+
+get_nodes($tidy->html());
+
+function get_nodes($node) {
+
+    // prüfen, ob der aktuelle Knoten vom gewünschten Typ ist
+    if($node->isComment()) {
+        echo "\n\n# comment node #" . ++$GLOBALS['num'] . "\n";
+        echo $node->value;
+    }
+
+    // prüfen, ob der aktuelle Knoten Kindknoten hat
+    if($node->hasChildren()) {
+        foreach($node->child as $child) {
+            get_nodes($child);
+        }
+    }
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+# comment node #1
+<!-- Comments -->
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tidy/tidynode/ishtml.xml
+++ b/reference/tidy/tidynode/ishtml.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="tidynode.ishtml" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tidyNode::isHtml</refname>
+  <refpurpose>Prüft, ob ein Knoten ein Element-Knoten ist</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="tidyNode">
+   <modifier>public</modifier> <type>bool</type><methodname>tidyNode::isHtml</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt an, ob der Knoten ein Element-Knoten ist, jedoch nicht der Wurzelknoten des Dokuments.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn der Knoten ein Element-Knoten ist, jedoch nicht der Wurzelknoten des Dokuments, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>7.3.24, 7.4.12</entry>
+      <entry>
+       Diese Funktion wurde korrigiert, sodass sie sich sinnvoll verhält. Zuvor
+       wurde nahezu jeder Knoten als HTML-Knoten gemeldet.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>HTML-Code aus einem gemischten HTML-Dokument extrahieren</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$html = <<< HTML
+<html><head>
+<?php echo '<title>title</title>'; ?>
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+</head>
+<body>
+
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+
+<!-- Comments -->
+Hello World
+</body></html>
+Outside HTML
+HTML;
+
+
+$tidy = tidy_parse_string($html);
+$num = 0;
+
+get_nodes($tidy->html());
+
+function get_nodes($node) {
+    // prüfen, ob der aktuelle Knoten vom gewünschten Typ ist
+    if($node->isHtml()) {
+        echo "\n\n# html node #" . ++$GLOBALS['num'] . "\n";
+        echo $node->value;
+    }
+
+    // prüfen, ob der aktuelle Knoten Kindknoten hat
+    if($node->hasChildren()) {
+        foreach($node->child as $child) {
+            get_nodes($child);
+        }
+    }
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+# html node #1
+<html>
+<head>
+<?php echo '<title>title</title>'; ?><#
+  /* JSTE code */
+  alert('Hello World');
+#>
+<title></title>
+</head>
+<body>
+<?php
+  // PHP code
+  echo 'hello world!';
+?><%
+  /* ASP code */
+  response.write("Hello World!")
+%><!-- Comments -->
+Hello WorldOutside HTML
+</body>
+</html>
+
+# html node #2
+<head>
+<?php echo '<title>title</title>'; ?><#
+  /* JSTE code */
+  alert('Hello World');
+#>
+<title></title>
+</head>
+
+
+# html node #3
+<title></title>
+
+
+# html node #4
+<body>
+<?php
+  // PHP code
+  echo 'hello world!';
+?><%
+  /* ASP code */
+  response.write("Hello World!")
+%><!-- Comments -->
+Hello WorldOutside HTML
+</body>
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tidy/tidynode/isjste.xml
+++ b/reference/tidy/tidynode/isjste.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="tidynode.isjste" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tidyNode::isJste</refname>
+  <refpurpose>Prüft, ob dieser Knoten JSTE ist</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="tidyNode">
+   <modifier>public</modifier> <type>bool</type><methodname>tidyNode::isJste</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt an, ob der Knoten JSTE ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn der Knoten JSTE ist, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>JSTE-Code aus einem gemischten HTML-Dokument extrahieren</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$html = <<< HTML
+<html><head>
+<?php echo '<title>title</title>'; ?>
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+</head>
+<body>
+
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+
+<!-- Comments -->
+Hello World
+</body></html>
+Outside HTML
+HTML;
+
+
+$tidy = tidy_parse_string($html);
+$num = 0;
+
+get_nodes($tidy->html());
+
+function get_nodes($node) {
+
+    // prüfen, ob der aktuelle Knoten vom gewünschten Typ ist
+    if($node->isJste()) {
+        echo "\n\n# jste node #" . ++$GLOBALS['num'] . "\n";
+        echo $node->value;
+    }
+
+    // prüfen, ob der aktuelle Knoten Kindknoten hat
+    if($node->hasChildren()) {
+        foreach($node->child as $child) {
+            get_nodes($child);
+        }
+    }
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+# jste node #1
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tidy/tidynode/isphp.xml
+++ b/reference/tidy/tidynode/isphp.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="tidynode.isphp" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tidyNode::isPhp</refname>
+  <refpurpose>Prüft, ob ein Knoten PHP ist</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="tidyNode">
+   <modifier>public</modifier> <type>bool</type><methodname>tidyNode::isPhp</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt an, ob der Knoten PHP ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn der aktuelle Knoten PHP-Code ist, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>PHP-Code aus einem gemischten HTML-Dokument extrahieren</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$html = <<< HTML
+<html><head>
+<?php echo '<title>title</title>'; ?>
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+</head>
+<body>
+
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+
+<!-- Comments -->
+Hello World
+</body></html>
+Outside HTML
+HTML;
+
+
+$tidy = tidy_parse_string($html);
+$num = 0;
+
+get_nodes($tidy->html());
+
+function get_nodes($node) {
+
+    // prüfen, ob der aktuelle Knoten vom gewünschten Typ ist
+    if($node->isPhp()) {
+        echo "\n\n# php node #" . ++$GLOBALS['num'] . "\n";
+        echo $node->value;
+    }
+
+    // prüfen, ob der aktuelle Knoten Kindknoten hat
+    if($node->hasChildren()) {
+        foreach($node->child as $child) {
+            get_nodes($child);
+        }
+    }
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+# php node #1
+<?php echo '<title>title</title>'; ?>
+
+# php node #2
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/tidy/tidynode/istext.xml
+++ b/reference/tidy/tidynode/istext.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="tidynode.istext" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>tidyNode::isText</refname>
+  <refpurpose>Prüft, ob ein Knoten Text darstellt (kein Markup)</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="tidyNode">
+   <modifier>public</modifier> <type>bool</type><methodname>tidyNode::isText</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt an, ob der Knoten einen Text darstellt (ohne jegliches Markup).
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+ 
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn der Knoten einen Text darstellt, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Text aus einem gemischten HTML-Dokument extrahieren</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$html = <<< HTML
+<html><head>
+<?php echo '<title>title</title>'; ?>
+<# 
+  /* JSTE code */
+  alert('Hello World'); 
+#>
+</head>
+<body>
+
+<?php
+  // PHP code
+  echo 'hello world!';
+?>
+
+<%
+  /* ASP code */
+  response.write("Hello World!")
+%>
+
+<!-- Comments -->
+Hello World
+</body></html>
+Outside HTML
+HTML;
+
+
+$tidy = tidy_parse_string($html);
+$num = 0;
+
+get_nodes($tidy->html());
+
+function get_nodes($node) {
+
+    // prüfen, ob der aktuelle Knoten vom gewünschten Typ ist
+    if($node->isText()) {
+        echo "\n\n# text node #" . ++$GLOBALS['num'] . "\n";
+        echo $node->value;
+    }
+
+    // prüfen, ob der aktuelle Knoten Kindknoten hat
+    if($node->hasChildren()) {
+        foreach($node->child as $child) {
+            get_nodes($child);
+        }
+    }
+}
+
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+# text node #1
+Hello World
+
+# text node #2
+Outside HTML
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `tidy` ins Deutsche, auf dem Stand des aktuellen EN-Texts (6 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #235 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").