### PR TITLE
[Sync EN] image: German translation of new files

### DIFF
--- a/reference/image/functions/imagecopymerge.xml
+++ b/reference/image/functions/imagecopymerge.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.imagecopymerge" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imagecopymerge</refname>
+  <refpurpose>Kopiert und führt einen Teil eines Bildes zusammen</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>true</type><methodname>imagecopymerge</methodname>
+   <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
+   <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dst_y</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_x</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_y</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_width</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_height</parameter></methodparam>
+   <methodparam><type>int</type><parameter>pct</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Kopiert einen Teil von <parameter>src_image</parameter> auf
+   <parameter>dst_image</parameter>, beginnend bei den x,y-Koordinaten
+   <parameter>src_x</parameter>, <parameter>src_y</parameter> mit
+   einer Breite von <parameter>src_width</parameter> und einer Höhe von
+   <parameter>src_height</parameter>. Der so definierte Bereich wird auf
+   die x,y-Koordinaten <parameter>dst_x</parameter> und
+   <parameter>dst_y</parameter> kopiert.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>dst_image</parameter></term>
+     <listitem>
+      <para>&gd.image.destination;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_image</parameter></term>
+     <listitem>
+      <para>&gd.image.source;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>dst_x</parameter></term>
+     <listitem>
+      <para>
+       Die x-Koordinate des Zielpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>dst_y</parameter></term>
+     <listitem>
+      <para>
+       Die y-Koordinate des Zielpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_x</parameter></term>
+     <listitem>
+      <para>
+       Die x-Koordinate des Quellpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_y</parameter></term>
+     <listitem>
+      <para>
+       Die y-Koordinate des Quellpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_width</parameter></term>
+     <listitem>
+      <para>&gd.source.width;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_height</parameter></term>
+     <listitem>
+      <para>&gd.source.height;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>pct</parameter></term>
+     <listitem>
+      <simpara>
+       Die beiden Bilder werden entsprechend <parameter>pct</parameter>
+       zusammengeführt, der einen Wert von 0 bis 100 annehmen kann. Bei
+       <parameter>pct</parameter> = 0 wird keine Aktion ausgeführt, bei 100
+       verhält sich diese Funktion bei Palette-Bildern identisch zu
+       <function>imagecopy</function>, abgesehen davon, dass
+       Alpha-Komponenten ignoriert werden, während sie bei True-Color-Bildern
+       Alpha-Transparenz umsetzt.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>dst_image</parameter> und <parameter>src_image</parameter> erwarten
+       nun eine Instanz von <classname>GdImage</classname>; zuvor wurde eine
+       <type>resource</type> erwartet.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Zusammenführen zweier Kopien des PHP.net-Logos mit 75 % Transparenz</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Bildinstanzen erzeugen
+$dest = imagecreatefromgif('php.gif');
+$src = imagecreatefromgif('php.gif');
+
+// Kopieren und zusammenführen
+imagecopymerge($dest, $src, 10, 10, 0, 0, 100, 47, 75);
+
+// Ausgeben
+header('Content-Type: image/gif');
+imagegif($dest);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/functions/imagecopymergegray.xml
+++ b/reference/image/functions/imagecopymergegray.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.imagecopymergegray" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imagecopymergegray</refname>
+  <refpurpose>Kopiert und führt einen Teil eines Bildes in Graustufen zusammen</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>true</type><methodname>imagecopymergegray</methodname>
+   <methodparam><type>GdImage</type><parameter>dst_image</parameter></methodparam>
+   <methodparam><type>GdImage</type><parameter>src_image</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dst_x</parameter></methodparam>
+   <methodparam><type>int</type><parameter>dst_y</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_x</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_y</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_width</parameter></methodparam>
+   <methodparam><type>int</type><parameter>src_height</parameter></methodparam>
+   <methodparam><type>int</type><parameter>pct</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>imagecopymergegray</function> kopiert einen Teil von <parameter>src_image</parameter> auf
+   <parameter>dst_image</parameter>, beginnend bei den x,y-Koordinaten
+   <parameter>src_x</parameter>, <parameter>src_y</parameter> mit
+   einer Breite von <parameter>src_width</parameter> und einer Höhe von
+   <parameter>src_height</parameter>. Der so definierte Bereich wird auf
+   die x,y-Koordinaten <parameter>dst_x</parameter> und
+   <parameter>dst_y</parameter> kopiert.
+  </para>
+  <para>
+   Diese Funktion ist identisch zu <function>imagecopymerge</function>, mit der
+   Ausnahme, dass sie beim Zusammenführen den Farbton der Quelle bewahrt, indem
+   die Pixel des Zielbildes vor dem Kopiervorgang in Graustufen umgewandelt werden.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>dst_image</parameter></term>
+     <listitem>
+      <para>&gd.image.destination;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_image</parameter></term>
+     <listitem>
+      <para>&gd.image.source;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>dst_x</parameter></term>
+     <listitem>
+      <para>
+       Die x-Koordinate des Zielpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>dst_y</parameter></term>
+     <listitem>
+      <para>
+       Die y-Koordinate des Zielpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_x</parameter></term>
+     <listitem>
+      <para>
+       Die x-Koordinate des Quellpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_y</parameter></term>
+     <listitem>
+      <para>
+       Die y-Koordinate des Quellpunkts.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_width</parameter></term>
+     <listitem>
+      <para>&gd.source.width;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>src_height</parameter></term>
+     <listitem>
+      <para>&gd.source.height;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>pct</parameter></term>
+     <listitem>
+      <simpara>
+        Das <parameter>src_image</parameter> wird entsprechend
+        <parameter>pct</parameter> in Graustufen umgewandelt, wobei 0
+        vollständig in Graustufen und 100 unverändert bedeutet. Bei
+        <parameter>pct</parameter> = 100 verhält sich diese Funktion bei
+        Palette-Bildern identisch zu <function>imagecopy</function>, abgesehen
+        davon, dass Alpha-Komponenten ignoriert werden, während sie bei
+        True-Color-Bildern Alpha-Transparenz umsetzt.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.true.always;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>dst_image</parameter> und <parameter>src_image</parameter> erwarten
+       nun eine Instanz von <classname>GdImage</classname>; zuvor wurde eine
+       <type>resource</type> erwartet.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Verwendung von <function>imagecopymergegray</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Bildinstanzen erzeugen
+$dest = imagecreatefromgif('php.gif');
+$src = imagecreatefromgif('php.gif');
+
+// Kopieren und zusammenführen - Grau = 20%
+imagecopymergegray($dest, $src, 10, 10, 0, 0, 100, 47, 20);
+
+// Ausgeben
+header('Content-Type: image/gif');
+imagegif($dest);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/functions/imagefilter.xml
+++ b/reference/image/functions/imagefilter.xml
@@ -1,0 +1,503 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.imagefilter" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imagefilter</refname>
+  <refpurpose>Wendet einen Filter auf ein Bild an</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>imagefilter</methodname>
+   <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
+   <methodparam><type>int</type><parameter>filter</parameter></methodparam>
+   <methodparam rep="repeat"><type class="union"><type>array</type><type>int</type><type>float</type><type>bool</type></type><parameter>args</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>imagefilter</function> wendet den angegebenen Filter
+   <parameter>filter</parameter> auf das Bild <parameter>image</parameter> an.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    &gd.image.description;
+    <varlistentry>
+     <term><parameter>filter</parameter></term>
+     <listitem>
+      <para>
+       <parameter>filter</parameter> kann einer der folgenden Werte sein:
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_NEGATE</constant>: Kehrt alle Farben des
+          Bildes um.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_GRAYSCALE</constant>: Wandelt das Bild in
+          Graustufen um, indem die Rot-, Grün- und Blau-Komponenten in ihre
+          gewichtete Summe umgewandelt werden, wobei dieselben Koeffizienten wie
+          bei der Berechnung der REC.601-Luma (Y') verwendet werden. Die
+          Alpha-Komponenten werden beibehalten. Bei Palette-Bildern kann das
+          Ergebnis aufgrund der Beschränkungen der Palette abweichen.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_BRIGHTNESS</constant>: Verändert die Helligkeit
+          des Bildes. Über <parameter>args</parameter> wird der Grad der
+          Helligkeit festgelegt. Der Wertebereich für die Helligkeit reicht von -255 bis 255.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_CONTRAST</constant>: Verändert den Kontrast des
+          Bildes. Über <parameter>args</parameter> wird der Grad des
+          Kontrasts festgelegt.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_COLORIZE</constant>: Wie
+          <constant>IMG_FILTER_GRAYSCALE</constant>, nur dass die Farbe
+          angegeben werden kann. Es werden <parameter>args</parameter>, <parameter>arg2</parameter> und
+          <parameter>arg3</parameter> in der Form
+          <parameter>red</parameter>, <parameter>green</parameter>,
+          <parameter>blue</parameter> und <parameter>arg4</parameter> für den
+          <parameter>alpha</parameter>-Kanal verwendet. Der Wertebereich für jede Farbe reicht von 0 bis 255.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_EDGEDETECT</constant>: Verwendet Kantenerkennung, um
+          die Kanten im Bild hervorzuheben.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_EMBOSS</constant>: Prägt das Bild.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_GAUSSIAN_BLUR</constant>: Macht das Bild mit der
+          Gauß-Methode unscharf.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SELECTIVE_BLUR</constant>: Macht das Bild unscharf.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_MEAN_REMOVAL</constant>: Verwendet die
+          Mittelwertentfernung, um einen „skizzenhaften“ Effekt zu erzielen.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SMOOTH</constant>: Macht das Bild weicher.
+          Über <parameter>args</parameter> wird der Grad der Weichheit festgelegt.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_PIXELATE</constant>: Wendet einen Verpixelungseffekt
+          auf das Bild an; über <parameter>args</parameter> wird die Blockgröße
+          und über <parameter>arg2</parameter> der Modus des Verpixelungseffekts festgelegt.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SCATTER</constant>: Wendet einen Streuungseffekt
+          auf das Bild an; über <parameter>args</parameter> und
+          <parameter>arg2</parameter> wird die Stärke des Effekts definiert und
+          zusätzlich über <parameter>arg3</parameter>, dass der Effekt nur auf
+          ausgewählte Pixelfarben angewendet wird.
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>args</parameter></term>
+     <listitem>
+      <para>
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_BRIGHTNESS</constant>: Helligkeitsstufe.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_CONTRAST</constant>: Kontraststufe.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_COLORIZE</constant>: &gd.value.red;
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SMOOTH</constant>: Weichheitsstufe.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_PIXELATE</constant>: Blockgröße in Pixeln.
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SCATTER</constant>: Subtraktionsstufe des Effekts.
+          Diese darf nicht höher oder gleich der Additionsstufe sein, die mit
+          <parameter>arg2</parameter> festgelegt wird.
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>arg2</parameter></term>
+     <listitem>
+      <para>
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_COLORIZE</constant>: &gd.value.green;
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_PIXELATE</constant>: Ob der erweiterte
+          Verpixelungseffekt verwendet werden soll oder nicht (Standardwert ist &false;).
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SCATTER</constant>: Additionsstufe des Effekts.
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>arg3</parameter></term>
+     <listitem>
+      <para>
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_COLORIZE</constant>: &gd.value.blue;
+         </simpara>
+        </listitem>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_SCATTER</constant>: Optionales Array mit indizierten Farbwerten,
+          auf die der Effekt angewendet werden soll.
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>arg4</parameter></term>
+     <listitem>
+      <para>
+       <itemizedlist>
+        <listitem>
+         <simpara>
+          <constant>IMG_FILTER_COLORIZE</constant>: Alpha-Kanal, ein Wert
+          zwischen 0 und 127. 0 bedeutet vollständig deckend, während 127
+          vollständig transparent bedeutet.
+         </simpara>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Wirft einen <classname>ValueError</classname>,
+   wenn <parameter>sub</parameter> oder <parameter>plus</parameter> beim
+   <parameter>filter</parameter> <constant>IMG_FILTER_SCATTER</constant> einen
+   Über- bzw. Unterlauf verursachen würden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Wirft nun einen <classname>ValueError</classname>,
+        wenn <parameter>sub</parameter> oder <parameter>plus</parameter> beim
+        <parameter>filter</parameter> <constant>IMG_FILTER_SCATTER</constant> einen
+        Über- bzw. Unterlauf verursachen würden.
+       </entry>
+      </row>
+      &gd.changelog.image-param;
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Die Unterstützung für Streuung (<constant>IMG_FILTER_SCATTER</constant>) wurde hinzugefügt.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Graustufen-Beispiel für <function>imagefilter</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$im = imagecreatefrompng('dave.png');
+
+if($im && imagefilter($im, IMG_FILTER_GRAYSCALE))
+{
+    echo 'Bild in Graustufen umgewandelt.';
+
+    imagepng($im, 'dave.png');
+}
+else
+{
+    echo 'Umwandlung in Graustufen fehlgeschlagen.';
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Helligkeits-Beispiel für <function>imagefilter</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$im = imagecreatefrompng('sean.png');
+
+if($im && imagefilter($im, IMG_FILTER_BRIGHTNESS, 20))
+{
+    echo 'Bildhelligkeit verändert.';
+
+    imagepng($im, 'sean.png');
+}
+else
+{
+    echo 'Veränderung der Bildhelligkeit fehlgeschlagen.';
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Einfärbungs-Beispiel für <function>imagefilter</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$im = imagecreatefrompng('philip.png');
+
+/* R, G, B, also ist 0, 255, 0 grün */
+if($im && imagefilter($im, IMG_FILTER_COLORIZE, 0, 255, 0))
+{
+    echo 'Bild erfolgreich grün eingefärbt.';
+
+    imagepng($im, 'philip.png');
+}
+else
+{
+    echo 'Grüneinfärbung fehlgeschlagen.';
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Negativ-Beispiel für <function>imagefilter</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Unsere Negativ-Funktion definieren, damit sie auch für
+// PHP-Versionen ohne imagefilter() portabel ist
+function negate($im)
+{
+    if(function_exists('imagefilter'))
+    {
+        return imagefilter($im, IMG_FILTER_NEGATE);
+    }
+
+    for($x = 0; $x < imagesx($im); ++$x)
+    {
+        for($y = 0; $y < imagesy($im); ++$y)
+        {
+            $index = imagecolorat($im, $x, $y);
+            $rgb = imagecolorsforindex($index);
+            $color = imagecolorallocate($im, 255 - $rgb['red'], 255 - $rgb['green'], 255 - $rgb['blue']);
+
+            imagesetpixel($im, $x, $y, $color);
+        }
+    }
+
+    return(true);
+}
+
+$im = imagecreatefromjpeg('kalle.jpg');
+
+if($im && negate($im))
+{
+    echo 'Bild erfolgreich in Negativfarben umgewandelt.';
+
+    imagejpeg($im, 'kalle.jpg', 100);
+}
+else
+{
+    echo 'Umwandlung in Negativfarben fehlgeschlagen.';
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Verpixelungs-Beispiel für <function>imagefilter</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Das PHP-Logo laden; es werden zwei Instanzen benötigt,
+// um die Unterschiede zu zeigen
+$logo1 = imagecreatefrompng('./php.png');
+$logo2 = imagecreatefrompng('./php.png');
+
+// Die Bildinstanz erzeugen, auf der die
+// Unterschiede gezeigt werden sollen
+$output = imagecreatetruecolor(imagesx($logo1) * 2, imagesy($logo1));
+
+// Verpixelung auf jede Instanz anwenden, mit einer
+// Blockgröße von 3
+imagefilter($logo1, IMG_FILTER_PIXELATE, 3);
+imagefilter($logo2, IMG_FILTER_PIXELATE, 3, true);
+
+// Die Unterschiede auf das Ausgabebild zusammenführen
+imagecopy($output, $logo1, 0, 0, 0, 0, imagesx($logo1) - 1, imagesy($logo1) - 1);
+imagecopy($output, $logo2, imagesx($logo2), 0, 0, 0, imagesx($logo2) - 1, imagesy($logo2) - 1);
+
+// Die Unterschiede ausgeben
+header('Content-Type: image/png');
+imagepng($output);
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <mediaobject>
+     <alt>Ausgabe des Beispiels: imagefilter() Verpixelung</alt>
+     <imageobject>
+      <imagedata fileref="en/reference/image/figures/imagefilterpixelate.png"/>
+     </imageobject>
+    </mediaobject>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Streuungs-Beispiel für <function>imagefilter</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Das Bild laden
+$logo = imagecreatefrompng('./php.png');
+
+// Einen sehr sanften Streuungseffekt auf das Bild anwenden
+imagefilter($logo, IMG_FILTER_SCATTER, 3, 5);
+
+// Das Bild mit dem Streuungseffekt ausgeben
+header('Content-Type: image/png');
+imagepng($logo);
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <mediaobject>
+     <alt>Ausgabe des Beispiels: imagefilter() Streuung</alt>
+     <imageobject>
+      <imagedata fileref="en/reference/image/figures/scatter.png"/>
+     </imageobject>
+    </mediaobject>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <simpara>
+    Das Ergebnis von <constant>IMG_FILTER_SCATTER</constant> ist immer zufällig.
+   </simpara>
+  </note>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>imageconvolution</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/functions/imageftbbox.xml
+++ b/reference/image/functions/imageftbbox.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.imageftbbox" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imageftbbox</refname>
+  <refpurpose>Liefert das umgebende Rechteck eines Textes, der mit Schriften über FreeType 2 gesetzt wird</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>false</type></type><methodname>imageftbbox</methodname>
+   <methodparam><type>float</type><parameter>size</parameter></methodparam>
+   <methodparam><type>float</type><parameter>angle</parameter></methodparam>
+   <methodparam><type>string</type><parameter>font_filename</parameter></methodparam>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>[]</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Diese Funktion berechnet das umgebende Rechteck eines FreeType-Textes in
+   Pixeln und gibt es zurück.
+  </para>
+  <note>
+   <para>
+    Vor PHP 8.0.0 war <function>imageftbbox</function> eine erweiterte Variante von
+    <function>imagettfbbox</function>, die zusätzlich die
+    <parameter>options</parameter> unterstützte.
+    Seit PHP 8.0.0 ist <function>imagettfbbox</function> ein Alias von <function>imageftbbox</function>.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>size</parameter></term>
+     <listitem>
+      <para>&gd.font.size;</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>angle</parameter></term>
+     <listitem>
+      <para>
+       Der Winkel in Grad, in dem <parameter>string</parameter> gemessen
+       wird.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>font_filename</parameter></term>
+     <listitem>
+      <para>
+       Der Name der TrueType-Schriftdatei (kann eine URL sein). Abhängig davon,
+       welche Version der GD-Bibliothek von PHP verwendet wird, kann der Versuch
+       unternommen werden, nach Dateien zu suchen, die nicht mit einem führenden
+       '/' beginnen, indem '.ttf' an den Dateinamen angehängt und entlang eines
+       von der Bibliothek definierten Schriftpfades gesucht wird.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>string</parameter></term>
+     <listitem>
+      <para>
+       Die zu messende Zeichenkette.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>options</parameter></term>
+     <listitem>
+      <para>
+       <table>
+       <title>Mögliche Array-Indizes für <parameter>options</parameter></title>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry>Schlüssel</entry>
+           <entry>Typ</entry>
+           <entry>Bedeutung</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry><literal>linespacing</literal></entry>
+           <entry><type>float</type></entry>
+           <entry>Legt den Zeilenabstand beim Zeichnen fest</entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </table>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <function>imageftbbox</function> gibt ein Array mit 8
+   Elementen zurück, die vier Punkte darstellen, die das umgebende Rechteck des
+   Textes bilden:
+   <informaltable>
+    <tgroup cols="2">
+     <tbody>
+      <row>
+       <entry>0</entry>
+       <entry>untere linke Ecke, X-Position</entry>
+      </row>
+      <row>
+       <entry>1</entry>
+       <entry>untere linke Ecke, Y-Position</entry>
+      </row>
+      <row>
+       <entry>2</entry>
+       <entry>untere rechte Ecke, X-Position</entry>
+      </row>
+      <row>
+       <entry>3</entry>
+       <entry>untere rechte Ecke, Y-Position</entry>
+      </row>
+      <row>
+       <entry>4</entry>
+       <entry>obere rechte Ecke, X-Position</entry>
+      </row>
+      <row>
+       <entry>5</entry>
+       <entry>obere rechte Ecke, Y-Position</entry>
+      </row>
+      <row>
+       <entry>6</entry>
+       <entry>obere linke Ecke, X-Position</entry>
+      </row>
+      <row>
+       <entry>7</entry>
+       <entry>obere linke Ecke, Y-Position</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+  <para>
+   Die Punkte sind relativ zum <emphasis>Text</emphasis>, unabhängig vom
+   <parameter>angle</parameter>, daher bedeutet „oben links“ in der oberen
+   linken Ecke, wenn der Text horizontal betrachtet wird.
+  </para>
+  <para>
+   Im Fehlerfall wird &false; zurückgegeben.
+  </para>
+ </refsect1>
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Beispiel für <function>imageftbbox</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Ein 300x150-Bild erzeugen
+$im = imagecreatetruecolor(300, 150);
+$black = imagecolorallocate($im, 0, 0, 0);
+$white = imagecolorallocate($im, 255, 255, 255);
+
+// Den Hintergrund weiß setzen
+imagefilledrectangle($im, 0, 0, 299, 299, $white);
+
+// Pfad zu unserer Schriftdatei
+$font = './arial.ttf';
+
+// Zuerst erstellen wir unser umgebendes Rechteck
+$bbox = imageftbbox(10, 0, $font, 'The PHP Documentation Group');
+
+// Das sind unsere Koordinaten für X und Y
+$x = $bbox[0] + (imagesx($im) / 2) - ($bbox[4] / 2) - 5;
+$y = $bbox[1] + (imagesy($im) / 2) - ($bbox[5] / 2) - 5;
+
+imagefttext($im, 10, 0, $x, $y, $black, $font, 'The PHP Documentation Group');
+
+// An den Browser ausgeben
+header('Content-Type: image/png');
+
+imagepng($im);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &note.freetype;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>imagefttext</function></member>
+   <member><function>imagettfbbox</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/functions/imagepalettetotruecolor.xml
+++ b/reference/image/functions/imagepalettetotruecolor.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.imagepalettetotruecolor" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>imagepalettetotruecolor</refname>
+  <refpurpose>Wandelt ein palettenbasiertes Bild in True Color um</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>imagepalettetotruecolor</methodname>
+   <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Wandelt ein palettenbasiertes Bild, das von Funktionen wie
+   <function>imagecreate</function> erzeugt wurde, in ein True-Color-Bild um, wie
+   <function>imagecreatetruecolor</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    &gd.image.description;
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt &true; zurück, wenn die Umwandlung abgeschlossen wurde oder wenn das Quellbild bereits
+   ein True-Color-Bild ist, andernfalls wird &false; zurückgegeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &gd.changelog.image-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>
+     Wandelt ein beliebiges Bildobjekt in True Color um
+    </title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+// Abwärtskompatibilität
+if(!function_exists('imagepalettetotruecolor'))
+{
+    function imagepalettetotruecolor(&$src)
+    {
+        if(imageistruecolor($src))
+        {
+            return(true);
+        }
+
+        $dst = imagecreatetruecolor(imagesx($src), imagesy($src));
+
+        imagecopy($dst, $src, 0, 0, 0, 0, imagesx($src), imagesy($src));
+
+        $src = $dst;
+
+        return(true);
+    }
+}
+
+// Helfer-Closure
+$typeof = function() use($im)
+{
+    echo 'typeof($im) = ' . (imageistruecolor($im) ? 'true color' : 'palette'), PHP_EOL;
+};
+
+// Ein palettenbasiertes Bild erzeugen
+$im = imagecreate(100, 100);
+$typeof();
+
+// In True Color umwandeln
+imagepalettetotruecolor($im);
+$typeof();
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+typeof($im) = palette
+typeof($im) = true color
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>imagecreatetruecolor</function></member>
+   <member><function>imageistruecolor</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/image/functions/imageresolution.xml
+++ b/reference/image/functions/imageresolution.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.imageresolution" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>imageresolution</refname>
+  <refpurpose>Liest oder setzt die Auflösung des Bildes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description"><!-- {{{ -->
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>array</type><type>true</type></type><methodname>imageresolution</methodname>
+   <methodparam><type>GdImage</type><parameter>image</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>resolution_x</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>resolution_y</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>imageresolution</function> ermöglicht es, die Auflösung eines
+   Bildes in DPI (dots per inch, Punkte pro Zoll) zu setzen und zu lesen. Sind die optionalen Parameter &null;,
+   wird die aktuelle Auflösung als indiziertes Array zurückgegeben. Ist nur
+   <parameter>resolution_x</parameter> nicht &null;, werden die horizontale und vertikale Auflösung
+   auf diesen Wert gesetzt. Ist keiner der optionalen Parameter &null;, werden die horizontale
+   und vertikale Auflösung jeweils auf diese Werte gesetzt.
+  </para>
+  <simpara>
+   Die Auflösung wird nur als Metainformation verwendet, wenn Bilder aus
+   Formaten gelesen und in Formate geschrieben werden, die diese Art von
+   Information unterstützen (derzeit PNG und JPEG). Sie hat keine Auswirkung auf
+   Zeichenoperationen. Die Standardauflösung für neue Bilder beträgt 96 DPI.
+  </simpara>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="parameters"><!-- {{{ -->
+  &reftitle.parameters;
+  <variablelist>
+   &gd.image.description;
+   <varlistentry>
+    <term><parameter>resolution_x</parameter></term>
+    <listitem>
+     <para>
+      Die horizontale Auflösung in DPI.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>resolution_y</parameter></term>
+    <listitem>
+     <para>
+      Die vertikale Auflösung in DPI.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="returnvalues"><!-- {{{ -->
+  &reftitle.returnvalues;
+  <para>
+   Bei Verwendung als Getter
+   gibt sie im Erfolgsfall ein indiziertes Array der horizontalen und vertikalen Auflösung zurück.
+   Bei Verwendung als Setter gibt sie immer &true; zurück.
+  </para>
+ </refsect1><!-- }}} -->
+
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>resolution_x</parameter> und <parameter>resolution_y</parameter> sind nun nullbar.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples"><!-- {{{ -->
+  &reftitle.examples;
+  <example xml:id="imageresolution.example.basic"><!-- {{{ -->
+   <title>Setzen und Lesen der Auflösung eines Bildes</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$im = imagecreatetruecolor(100, 100);
+imageresolution($im, 200);
+print_r(imageresolution($im));
+imageresolution($im, 300, 72);
+print_r(imageresolution($im));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+Array
+(
+    [0] => 200
+    [1] => 200
+)
+Array
+(
+    [0] => 300
+    [1] => 72
+)
+]]>
+   </screen>
+  </example><!-- }}} -->
+ </refsect1><!-- }}} -->
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `image` ins Deutsche, auf dem Stand des aktuellen EN-Texts (6 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #235 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").