### PR TITLE
[Sync EN] swoole: German translation of new files

### DIFF
--- a/reference/swoole/swoole/buffer/read.xml
+++ b/reference/swoole/swoole/buffer/read.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="swoole-buffer.read" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Buffer::read</refname>
+  <refpurpose>Liest Daten aus dem Speicherpuffer anhand von Versatz und Länge.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>string</type><methodname>Swoole\Buffer::read</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam><type>int</type><parameter>length</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <para>
+      Der Versatz.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>length</parameter></term>
+    <listitem>
+     <para>
+      Die Länge.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die aus dem Speicherpuffer gelesenen Daten.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/buffer/substr.xml
+++ b/reference/swoole/swoole/buffer/substr.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="swoole-buffer.substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Buffer::substr</refname>
+  <refpurpose>Liest Daten aus dem Speicherpuffer anhand von Versatz und Länge oder entfernt Daten aus dem Speicherpuffer.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>string</type><methodname>Swoole\Buffer::substr</methodname>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>length</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>remove</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Wenn $remove auf true und $offset auf 0 gesetzt ist, werden die Daten aus dem Puffer entfernt.
+    Der zum Speichern der Daten verwendete Speicher wird freigegeben, sobald das Pufferobjekt zerstört wird.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <para>
+      Der Versatz.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>length</parameter></term>
+    <listitem>
+     <para>
+      Die Länge.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>remove</parameter></term>
+    <listitem>
+     <para>
+      Ob die Daten aus dem Speicherpuffer entfernt werden sollen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die aus dem Speicherpuffer gelesenen Daten beziehungsweise die gelesene Zeichenkette.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/channel/push.xml
+++ b/reference/swoole/swoole/channel/push.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="swoole-channel.push" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Channel::push</refname>
+  <refpurpose>Schreibt Daten und fügt sie in einen Swoole-Channel ein.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Swoole\Channel::push</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Bei den Daten kann es sich um eine beliebige, nicht leere PHP-Variable handeln; die Variable wird serialisiert, sofern sie nicht vom Typ string ist.
+  </para>
+  <para>
+    Ist die Größe der Daten größer als 8 KB, verwendet der Swoole-Channel temporäre Dateien zur Speicherung.
+  </para>
+  <para>
+    Die Funktion gibt true zurück, wenn der Schreibvorgang erfolgreich war, oder false, wenn nicht genügend Platz vorhanden ist.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <para>
+      Die Daten, die in den Swoole-Channel eingefügt werden sollen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ob die Daten in den Swoole-Channel eingefügt wurden.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/lock/construct.xml
+++ b/reference/swoole/swoole/lock/construct.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="swoole-lock.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Lock::__construct</refname>
+  <refpurpose>Erzeugt eine Speichersperre.</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Swoole\Lock::__construct</methodname>
+   <methodparam choice="opt"><type>string</type><parameter>type</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>file_lock_location</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>
+    Die Swoole-Sperre dient der Datensynchronisation zwischen mehreren Threads oder Prozessen.
+  </simpara>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>type</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>file_lock_location</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <!-- Return values commented out, as constructors generally don't return a
+      value. Uncomment this if you do need a return values section (for
+      example, because there's also a procedural version of the method).
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+ -->
+
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/swoole/swoole/table/next.xml
+++ b/reference/swoole/swoole/table/next.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="swoole-table.next" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Swoole\Table::next</refname>
+  <refpurpose>Bewegt den Iterator zur nächsten Zeile</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>void</type><methodname>Swoole\Table::next</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `swoole` ins Deutsche, auf dem Stand des aktuellen EN-Texts (5 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").