### PR TITLE
[Sync EN] gearman: German translation of new files

### DIFF
--- a/reference/gearman/gearmanclient/jobstatus.xml
+++ b/reference/gearman/gearmanclient/jobstatus.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanclient.jobstatus">
+ <refnamediv>
+  <refname>GearmanClient::jobStatus</refname>
+  <refname>gearman_job_status</refname>
+  <refpurpose>Ermittelt den Status eines Hintergrund-Jobs</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <simpara>&style.oop; (Methode):</simpara>
+   <methodsynopsis role="GearmanClient">
+    <modifier>public</modifier> <type>array</type><methodname>GearmanClient::jobStatus</methodname>
+    <methodparam><type>string</type><parameter>job_handle</parameter></methodparam>
+   </methodsynopsis>
+   <simpara>
+    Ermittelt anhand eines Job-Handles den Status eines Hintergrund-Jobs. Die
+    Statusinformationen geben an, ob der Job bekannt ist, ob der Job derzeit
+    ausgeführt wird, und den prozentualen Fertigstellungsgrad.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>job_handle</parameter></term>
+    <listitem>
+     <simpara>
+      &gearman.parameter.jobhandle;
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ein Array mit Statusinformationen zu dem Job, der zum angegebenen Job-Handle
+   gehört. Das erste Array-Element ist ein Boolescher Wert, der angibt, ob der
+   Job überhaupt bekannt ist, das zweite ist ein Boolescher Wert, der angibt, ob
+   der Job noch ausgeführt wird, und das dritte und vierte Element entsprechen
+   dem Zähler bzw. dem Nenner des prozentualen Fertigstellungsgrads als Bruch.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Überwachung des Status eines lang laufenden Hintergrund-Jobs</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+/* Unser Objekt erstellen */
+$gmclient= new GearmanClient();
+
+/* Den Standardserver hinzufügen */
+$gmclient->addServer();
+
+/* Den Reverse-Client ausführen */
+$job_handle = $gmclient->doBackground("reverse", "this is a test");
+
+if ($gmclient->returnCode() != GEARMAN_SUCCESS)
+{
+  echo "bad return code\n";
+  exit;
+}
+
+$done = false;
+do
+{
+   sleep(3);
+   $stat = $gmclient->jobStatus($job_handle);
+   if (!$stat[0]) // Der Job ist bekannt, also ist er nicht fertig
+      $done = true;
+   echo "Running: " . ($stat[1] ? "true" : "false") . ", numerator: " . $stat[2] . ", denominator: " . $stat[3] . "\n";
+}
+while(!$done);
+
+echo "done!\n";
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Running: true, numerator: 3, denominator: 14
+Running: true, numerator: 6, denominator: 14
+Running: true, numerator: 9, denominator: 14
+Running: true, numerator: 12, denominator: 14
+Running: false, numerator: 0, denominator: 0
+done!
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>GearmanClient::doStatus</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gearman/gearmanclient/setdata.xml
+++ b/reference/gearman/gearmanclient/setdata.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanclient.setdata">
+ <refnamediv>
+  <refname>GearmanClient::setData</refname>
+  <refpurpose>Setzt anwendungsspezifische Daten (veraltet)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>GearmanClient::setData</methodname>
+   <methodparam><type>string</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Setzt beliebige anwendungsspezifische Daten, die später mit
+   <methodname>GearmanClient::data</methodname> abgerufen werden können.
+  </simpara>
+  <note>
+   <simpara>
+    Diese Methode wurde im Release 0.6.0 der Gearman-Erweiterung durch
+    <methodname>GearmanClient::setContext</methodname> ersetzt.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt immer &true; zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>GearmanClient::data</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gearman/gearmanjob/sendstatus.xml
+++ b/reference/gearman/gearmanjob/sendstatus.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanjob.sendstatus">
+ <refnamediv>
+  <refname>GearmanJob::sendStatus</refname>
+  <refpurpose>Sendet den Status</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="GearmanJob">
+   <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::sendStatus</methodname>
+   <methodparam><type>int</type><parameter>numerator</parameter></methodparam>
+   <methodparam><type>int</type><parameter>denominator</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sendet Statusinformationen an den Job-Server und an alle wartenden Clients.
+   Damit kann angegeben werden, zu welchem Prozentsatz der Job abgeschlossen
+   wurde.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>numerator</parameter></term>
+    <listitem>
+     <simpara>
+      Der Zähler des als Bruch ausgedrückten prozentualen
+      Fertigstellungsgrads.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>denominator</parameter></term>
+    <listitem>
+     <simpara>
+      Der Nenner des als Bruch ausgedrückten prozentualen
+      Fertigstellungsgrads.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>GearmanClient::jobStatus</methodname></member>
+   <member><methodname>GearmanTask::taskDenominator</methodname></member>
+   <member><methodname>GearmanTask::taskNumerator</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gearman/gearmanjob/status.xml
+++ b/reference/gearman/gearmanjob/status.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanjob.status">
+ <refnamediv>
+  <refname>GearmanJob::status</refname>
+  <refpurpose>Sendet den Status (veraltet)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>GearmanJob::status</methodname>
+   <methodparam><type>int</type><parameter>numerator</parameter></methodparam>
+   <methodparam><type>int</type><parameter>denominator</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sendet Statusinformationen an den Job-Server und an alle wartenden Clients.
+   Damit kann angegeben werden, zu welchem Prozentsatz der Job abgeschlossen
+   wurde.
+  </simpara>
+  <note>
+   <simpara>
+    Diese Methode wurde im Release 0.6.0 der Gearman-Erweiterung durch
+    <methodname>GearmanJob::sendStatus</methodname> ersetzt.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>numerator</parameter></term>
+    <listitem>
+     <simpara>
+      Der Zähler des als Bruch ausgedrückten prozentualen
+      Fertigstellungsgrads.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>denominator</parameter></term>
+    <listitem>
+     <simpara>
+      Der Nenner des als Bruch ausgedrückten prozentualen
+      Fertigstellungsgrads.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>GearmanClient::jobStatus</methodname></member>
+   <member><methodname>GearmanTask::taskDenominator</methodname></member>
+   <member><methodname>GearmanTask::taskNumerator</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gearman/gearmanworker/timeout.xml
+++ b/reference/gearman/gearmanworker/timeout.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="gearmanworker.timeout">
+ <refnamediv>
+  <refname>GearmanWorker::timeout</refname>
+  <refpurpose>Ermittelt das Timeout für die Socket-E/A-Aktivität</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="GearmanWorker">
+   <modifier>public</modifier> <type>int</type><methodname>GearmanWorker::timeout</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Gibt die aktuelle Wartezeit in Millisekunden für die Socket-E/A-Aktivität
+   zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Eine Zeitspanne in Millisekunden. Ein negativer Wert kennzeichnet ein
+   unendliches Timeout.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>GearmanWorker::setTimeout</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `gearman` ins Deutsche, auf dem Stand des aktuellen EN-Texts (5 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").