### PR TITLE
[Sync EN] yaf: German translation of new files

### DIFF
--- a/reference/yaf/yaf-loader.xml
+++ b/reference/yaf/yaf-loader.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.yaf-loader" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Die Klasse Yaf_Loader</title>
+ <titleabbrev>Yaf_Loader</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Yaf_Loader intro -->
+  <section xml:id="yaf-loader.intro">
+   &reftitle.intro;
+   <para>
+    <classname>Yaf_Loader</classname> stellt eine umfassende Autoloading-Lösung
+    für Yaf bereit.
+   </para>
+   <para>
+    Beim ersten Abruf einer Instanz von <classname>Yaf_Application</classname>
+    erzeugt <classname>Yaf_Loader</classname> ein Singleton und registriert sich
+    selbst bei spl_autoload. Eine Instanz wird mittels
+    <methodname>Yaf_Loader::getInstance</methodname> abgerufen.
+   </para>
+   <para>
+    <classname>Yaf_Loader</classname> versucht, eine Klasse nur einmal zu laden;
+    schlägt dies fehl, hängt das Verhalten von <link
+     linkend="ini.yaf.use-spl-autoload">yaf.use_spl_autoload</link> ab: Ist diese
+    Konfiguration On, gibt <methodname>Yaf_Loader::autoload</methodname>
+    &false; zurück und gibt damit anderen Autoload-Funktionen eine Chance. Ist sie
+    Off (Standard), gibt <methodname>Yaf_Loader::autoload</methodname>
+    &true; zurück, und, was wichtiger ist, es wird eine sehr nützliche Warnung
+    ausgelöst (sehr nützlich, um herauszufinden, warum eine Klasse nicht geladen
+    werden konnte).
+    <note>
+     <para>
+      yaf.use_spl_autoload sollte Off bleiben, es sei denn, eine Bibliothek
+      verfügt über einen eigenen Autoload-Mechanismus, der nicht umgeschrieben
+      werden kann.
+     </para>
+    </note>
+   </para>
+   <para>
+    Standardmäßig nimmt <classname>Yaf_Loader</classname> an, dass alle
+    Bibliotheken (Skripte mit Klassendefinitionen) im <link linkend="ini.yaf.library">globalen
+     Bibliotheksverzeichnis</link> liegen, das in der php.ini (yaf.library)
+    definiert ist.
+   </para>
+
+   <para>
+    Soll <classname>Yaf_Loader</classname> bestimmte Klassen (Bibliotheken) im
+    <link linkend="yaf-loader.props.library">lokalen Klassenverzeichnis</link>
+    suchen (das in der application.ini definiert ist und standardmäßig
+    <link
+     linkend="configuration.yaf.directory">application.directory</link> . "/library" lautet),
+    so muss das Klassenpräfix mittels
+    <methodname>Yaf_Loader::registerLocalNameSpace</methodname> registriert werden.
+   </para>
+
+   <para>
+    Sehen wir uns einige Beispiele an (es wird angenommen, dass APPLICATION_PATH dem
+    <link
+     linkend="configuration.yaf.directory">application.directory</link> entspricht):
+    <example>
+     <title>Konfigurationsbeispiel</title>
+      <programlisting role="shell">
+<![CDATA[
+// Angenommen, die folgende Konfiguration steht in der php.ini:
+yaf.library = "/global_dir"
+
+// Angenommen, die folgende Konfiguration steht in der application.ini
+application.library = APPLICATION_PATH "/library"
+]]>
+     </programlisting>
+    </example>
+
+    Angenommen, der folgende lokale Namensraum ist registriert:
+    <example>
+     <title>localnamespace registrieren</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class Bootstrap extends Yaf_Bootstrap_Abstract{
+     public function _initLoader($dispatcher) {
+          Yaf_Loader::getInstance()->registerLocalNameSpace(array("Foo", "Bar"));
+     }
+}
+?>
+]]>
+     </programlisting>
+    </example>
+
+   Dann die Autoload-Beispiele:
+    <example>
+     <title>Beispiel zum Laden einer Klasse</title>
+      <programlisting role="shell">
+<![CDATA[
+class Foo_Bar_Test =>
+  // APPLICATION_PATH/library/Foo/Bar/Test.php
+
+class GLO_Name  =>
+  // /global_dir/Glo/Name.php
+
+class BarNon_Test
+  // /global_dir/Barnon/Test.php
+]]>
+      </programlisting>
+    </example>
+
+   <example>
+    <title>Beispiel zum Laden einer Klasse mit Namensraum</title>
+    <programlisting role="shell">
+<![CDATA[
+class \Foo\Bar\Dummy =>
+   // APPLICATION_PATH/library/Foo/Bar/Dummy.php
+
+class \FooBar\Bar\Dummy =>
+   // /global_dir/FooBar/Bar/Dummy.php
+]]>
+    </programlisting>
+   </example>
+  </para>
+
+  <para>
+    Möglicherweise ist aufgefallen, dass alle Ordner mit einem Großbuchstaben
+    beginnen; sie können in Kleinbuchstaben umgewandelt werden, indem in der php.ini
+    <link linkend="ini.yaf.lowcase-path">yaf.lowcase_path</link> = On gesetzt wird.
+  </para>
+
+  <para>
+   <classname>Yaf_Loader</classname> ist auch dafür ausgelegt, die MVC-Klassen zu
+   laden; die Regel lautet:
+   <example>
+    <title>Beispiel zum Laden von MVC-Klassen</title>
+    <programlisting role="shell">
+<![CDATA[
+Controller Classes =>
+// APPLICATION_PATH/controllers/
+
+Model Classes =>
+// APPLICATION_PATH/models/
+
+Plugin Classes =>
+// APPLICATION_PATH/plugins/
+]]>
+    </programlisting>
+   </example>
+
+   Yaf erkennt das Suffix einer Klasse (dies ist der Standard; es kann über die
+   Konfiguration <link
+    linkend="ini.yaf.name-suffix">yaf.name_suffix</link> auch auf das Präfix
+   umgestellt werden), um zu entscheiden, ob es sich um eine MVC-Klasse handelt:
+   <example>
+    <title>Unterscheidung von MVC-Klassen</title>
+   <programlisting role="shell">
+<![CDATA[
+Controller Classes =>
+    // ***Controller
+
+Model Classes =>
+    // ***Model
+
+Plugin Classes =>
+    // ***Plugin
+]]>
+   </programlisting>
+  </example>
+
+   einige Beispiele:
+   <example>
+    <title>Beispiel zum Laden von MVC-Klassen</title>
+    <programlisting role="shell">
+<![CDATA[
+class IndexController
+    // APPLICATION_PATH/controllers/Index.php
+
+class DataModel =>
+   // APPLICATION_PATH/models/Data.php
+
+class DummyPlugin =>
+  // APPLICATION_PATH/plugins/Dummy.php
+
+class A_B_TestModel =>
+  // APPLICATION_PATH/models/A/B/Test.php
+]]>
+    </programlisting>
+  </example>
+
+  <note>
+   <para>
+    Seit Version 2.1.18 unterstützt Yaf das Autoloading von Controllern auf der
+    Seite des Benutzerskripts (das heißt, das durch das PHP-Skript des Benutzers
+    ausgelöste Autoloading, z. B. der Zugriff auf eine statische Eigenschaft eines
+    Controllers in einem Bootstrap oder in Plugins), aber der Autoloader versucht
+    nur, das Skript der Controller-Klasse im Ordner des Standardmoduls zu finden,
+    der "APPLICATION_PATH/controllers/" lautet.
+   </para>
+  </note>
+   Außerdem wird das Verzeichnis durch <link linkend="ini.yaf.lowcase-path">yaf.lowcase_path</link> beeinflusst.
+  </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="yaf-loader.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>Yaf_Loader</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>Yaf_Loader</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>protected</modifier>
+     <varname linkend="yaf-loader.props.local-ns">_local_ns</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>protected</modifier>
+     <varname linkend="yaf-loader.props.library">_library</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>protected</modifier>
+     <varname linkend="yaf-loader.props.global-library">_global_library</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>static</modifier>
+     <varname linkend="yaf-loader.props.instance">_instance</varname>
+    </fieldsynopsis>
+
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-loader')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])" />
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaf-loader')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[1])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+
+<!-- {{{ Yaf_Loader properties -->
+  <section xml:id="yaf-loader.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="yaf-loader.props.local-ns">
+     <term><varname>_local_ns</varname></term>
+     <listitem>
+      <para></para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="yaf-loader.props.library">
+     <term><varname>_library</varname></term>
+     <listitem>
+      <para>
+       Standardmäßig lautet dieser Wert <link
+        linkend="configuration.yaf.directory">application.directory</link> . "/library";
+       er kann entweder in der application.ini (application.library) oder durch einen Aufruf von
+      <methodname>Yaf_Loader::setLibraryPath</methodname> geändert werden.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="yaf-loader.props.global-library">
+     <term><varname>_global_library</varname></term>
+     <listitem>
+      <para></para>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="yaf-loader.props.instance">
+     <term><varname>_instance</varname></term>
+     <listitem>
+      <para></para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+
+ </partintro>
+
+
+ &reference.yaf.entities.yaf-loader;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaf/yaf_application/construct.xml
+++ b/reference/yaf/yaf_application/construct.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="yaf-application.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaf_Application::__construct</refname>
+  <refpurpose>Konstruktor von Yaf_Application</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Yaf_Application::__construct</methodname>
+   <methodparam><type>mixed</type><parameter>config</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>environ</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Erzeugt eine Instanz von <classname>Yaf_Application</classname>.
+  </para>
+
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>config</parameter></term>
+    <listitem>
+     <para>
+       Ein Pfad zu einer ini-Konfigurationsdatei oder ein Konfigurationsarray.
+     </para>
+     <para>
+       Handelt es sich um eine ini-Konfigurationsdatei, so sollte es einen
+       Abschnitt geben, der so benannt ist, wie er durch
+       <link linkend="ini.yaf.environ">yaf.environ</link> definiert ist und der
+       standardmäßig "product" lautet.
+      <note>
+       <para>
+        Wird eine ini-Konfigurationsdatei als Konfigurationscontainer der
+        Anwendung verwendet, sollte <link
+         linkend="ini.yaf.cache-config">yaf.cache_config</link> aktiviert werden,
+        um die Leistung zu verbessern.
+       </para>
+      </note>
+     </para>
+     <para>
+       Und die Liste der Konfigurationseinträge (samt ihren Standardwerten):
+      <example>
+       <title>Beispiel einer ini-Konfigurationsdatei</title>
+       <programlisting role="ini" xml:id="yaf.application.ini">
+<![CDATA[
+[product]
+; dieser Eintrag sollte stets definiert sein und hat keinen Standardwert
+application.directory=APPLICATION_PATH
+
+; die folgenden Konfigurationen haben einen Standardwert, müssen also nicht definiert werden
+application.library = APPLICATION_PATH . "/library"
+application.dispatcher.throwException=1
+application.dispatcher.catchException=1
+
+application.baseUri=""
+
+; die Erweiterung der PHP-Skripte
+ap.ext=php
+
+; die Erweiterung der View-Templates
+ap.view.ext=phtml
+
+ap.dispatcher.defaultModule=Index
+ap.dispatcher.defaultController=Index
+ap.dispatcher.defaultAction=index
+
+; definierte Module
+ap.modules=Index
+]]>
+       </programlisting>
+      </example>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>environ</parameter></term>
+    <listitem>
+     <para>
+      Welcher Abschnitt als endgültige Konfiguration geladen wird.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>Yaf_Application::__construct</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+defined('APPLICATION_PATH')                  // APPLICATION_PATH wird in der ini-Konfigurationsdatei verwendet
+    || define('APPLICATION_PATH', __DIR__);
+
+$application = new Yaf_Application(APPLICATION_PATH.'/conf/application.ini');
+$application->bootstrap()->run();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Beispiel für <function>Yaf_Application::__construct</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$config = array(
+    "application" => array(
+        "directory" => realpath(dirname(__FILE__)) . "/application",
+    ),
+);
+
+/** Yaf_Application */
+$application = new Yaf_Application($config);
+$application->bootstrap()->run();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>Yaf_Config_Ini</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaf/yaf_route_rewrite/construct.xml
+++ b/reference/yaf/yaf_route_rewrite/construct.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="yaf-route-rewrite.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaf_Route_Rewrite::__construct</refname>
+  <refpurpose>Konstruktor von Yaf_Route_Rewrite</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis>
+   <modifier>public</modifier> <methodname>Yaf_Route_Rewrite::__construct</methodname>
+   <methodparam><type>string</type><parameter>match</parameter></methodparam>
+   <methodparam><type>array</type><parameter>route</parameter></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter>verify</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>match</parameter></term>
+    <listitem>
+     <para>
+       Ein Muster, das zum Abgleich mit einer Anfrage-URI verwendet wird; wenn es
+       nicht passt, gibt <classname>Yaf_Route_Rewrite</classname>
+       &false; zurück.
+     </para>
+     <para>
+      Es kann der Stil :name verwendet werden, um die abgeglichenen Segmente zu
+      benennen, und * verwendet werden, um die restlichen URL-Segmente abzugleichen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>route</parameter></term>
+    <listitem>
+     <para>
+      Wenn das Muster match auf die Anfrage-URI passt, verwendet
+      <classname>Yaf_Route_Rewrite</classname> dies, um zu entscheiden, welches
+      Modul/welcher Controller/welche Aktion das Ziel ist.
+     </para>
+     <para>
+      Jeder Eintrag module/controller/action in diesem Array ist optional; wird
+      kein bestimmter Wert zugewiesen, wird zur Standardwahl geroutet.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>verify</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <classname>Yaf_Route_Rewrite</classname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+   /**
+    * Eine Rewrite-Route zum Routen-Stack von Yaf_Router hinzufügen
+    */
+    Yaf_Dispatcher::getInstance()->getRouter()->addRoute("name",
+        new Yaf_Route_Rewrite(
+           "/product/:name/:id/*", // gleicht Anfrage-URIs ab, die mit "/product" beginnen
+           array(
+               'controller' => "product",  // routet zum Controller product,
+           ),
+        )
+    );
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+/* for http://yourdomain.com/product/foo/22/foo/bar
+ * route will result in following values:
+ */
+array(
+  "controller" => "product",
+  "module"     => "index", //(default)
+  "action"     => "index", //(default)
+)
+
+/**
+ * and request parameters:
+ */
+array(
+  "name" => "foo",
+  "id"   => 22,
+  "foo"  => bar
+)
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Beispiel für <classname>Yaf_Route_Rewrite</classname></title>
+   <programlisting role="php">
+<![CDATA[
+    <?php
+   /**
+    * Eine Rewrite-Route zum Routen-Stack von Yaf_Router durch Aufruf von addconfig hinzufügen
+    */
+    $config = array(
+        "name" => array(
+           "type"  => "rewrite",        // Route Yaf_Route_Rewrite
+           "match" => "/user-list/:id", // gleicht nur /user/list/?/ ab
+           "route" => array(
+               'controller' => "user",  // routet zum Controller user,
+               'action'     => "list",  // routet zur Aktion list
+           ),
+        ),
+    );
+    Yaf_Dispatcher::getInstance()->getRouter()->addConfig(
+        new Yaf_Config_Simple($config));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+/* for http://yourdomain.com/user-list/22
+ * route will result in following values:
+ */
+array(
+  "controller" => "user",
+  "action"     => "list",
+  "module"     => "index", //(default)
+)
+
+/**
+ * and request parameters:
+ */
+array(
+  "id"   => 22,
+)
+]]>
+   </screen>
+  </example>
+  <example>
+   <title>Beispiel für <classname>Yaf_Route_Rewrite</classname> (ab Version 2.3.0)</title>
+   <programlisting role="php">
+<![CDATA[
+    <?php
+   /**
+    * Eine Rewrite-Route hinzufügen, die das Abgleichsergebnis als m/c/a-Namen nutzt
+    */
+    $config = array(
+        "name" => array(
+           "type"  => "rewrite",
+           "match" => "/user-list/:a/:id", // gleicht nur /user-list/* ab
+           "route" => array(
+               'controller' => "user",   // routet zum Controller user,
+               'action'     => ":a",     // routet zur Aktion :a
+           ),
+        ),
+    );
+    Yaf_Dispatcher::getInstance()->getRouter()->addConfig(
+        new Yaf_Config_Simple($config));
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+/* for http://yourdomain.com/user-list/list/22
+ * route will result in following values:
+ */
+array(
+  "controller" => "user",
+  "action"     => "list",
+  "module"     => "index", //(default)
+)
+
+/**
+ * and request parameters:
+ */
+array(
+  "id"   => 22,
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Yaf_Router::addRoute</methodname></member>
+   <member><methodname>Yaf_Router::addConfig</methodname></member>
+   <member><classname>Yaf_Route_Static</classname></member>
+   <member><classname>Yaf_Route_Supervar</classname></member>
+   <member><classname>Yaf_Route_Simple</classname></member>
+   <member><classname>Yaf_Route_Regex</classname></member>
+   <member><classname>Yaf_Route_Map</classname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaf/yaf_view_simple/assignref.xml
+++ b/reference/yaf/yaf_view_simple/assignref.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="yaf-view-simple.assignref" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yaf_View_Simple::assignRef</refname>
+  <refpurpose>Der Zweck von assignRef</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Yaf_View_Simple::assignRef</methodname>
+   <methodparam><type>string</type><parameter>name</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter role="reference">value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+    Anders als <methodname>Yaf_View_Simple::assign</methodname> weist diese Methode
+    der Engine einen Referenzwert zu.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>name</parameter></term>
+    <listitem>
+     <simpara>
+       Ein Zeichenkettenname, der für den Zugriff auf den Wert im Template
+       verwendet wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>value</parameter></term>
+    <listitem>
+     <para>
+      Wert vom Typ mixed
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>Yaf_View_Simple::assignRef</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class IndexController extends Yaf_Controller_Abstract {
+    public function indexAction() {
+        $value = "bar";
+        $this->getView()->assign("foo", $value);
+
+        /* bitte beachten, dass es vor Yaf 2.1.4 einen Fehler gab,
+         * durch den die folgende Ausgabe "bar" lautet;
+         */
+        $dummy = $this->getView()->render("index/index.phtml");
+        echo $value;
+
+        // verhindert das automatische Rendern
+        Yaf_Dispatcher::getInstance()->autoRender(FALSE);
+    }
+}
+?>
+]]>
+   </programlisting>
+  </example>
+  <example>
+   <title>Beispiel für ein Template</title>
+   <programlisting role="php">
+<![CDATA[
+<html>
+ <head>
+  <title><?php echo $foo;  $foo = "changed"; ?></title>
+ </head>
+<body>
+</body>
+</html>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+/* access the index controller will result: */
+changed
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Yaf_View_Simple::assign</methodname></member>
+   <member><methodname>Yaf_View_Simple::__set</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `yaf` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #242 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").