### PR TITLE
[Sync EN] stream: German translation of new files

### DIFF
--- a/reference/stream/functions/stream-socket-server.xml
+++ b/reference/stream/functions/stream-socket-server.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.stream-socket-server" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>stream_socket_server</refname>
+  <refpurpose>Erstellt einen Internet- oder Unix-Domain-Server-Socket</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>resource</type><type>false</type></type><methodname>stream_socket_server</methodname>
+   <methodparam><type>string</type><parameter>address</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">error_code</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter role="reference">error_message</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer>STREAM_SERVER_BIND | STREAM_SERVER_LISTEN</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>resource</type><type>null</type></type><parameter>context</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Erstellt einen Stream- oder Datagramm-Socket auf der angegebenen
+   <parameter>address</parameter>.
+  </para>
+  <para>
+   Diese Funktion erstellt lediglich einen Socket; um Verbindungen
+   anzunehmen, ist <function>stream_socket_accept</function> zu verwenden.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>address</parameter></term>
+     <listitem>
+      <para>
+       Der Typ des erstellten Sockets wird durch den Transport bestimmt, der
+       mittels der Standard-URL-Formatierung angegeben wird: <literal>transport://target</literal>.
+      </para>
+      <para>
+       Für Internet-Domain-Sockets (<constant>AF_INET</constant>) wie TCP und UDP sollte der
+       <literal>target</literal>-Anteil des Parameters
+       <parameter>remote_socket</parameter> aus einem
+       Hostnamen oder einer IP-Adresse bestehen, gefolgt von einem Doppelpunkt und einer Portnummer. Für
+       Unix-Domain-Sockets sollte der <literal>target</literal>-Anteil auf
+       die Socket-Datei im Dateisystem verweisen.
+      </para>
+      <simpara>
+       Je nach Umgebung sind Unix-Domain-Sockets möglicherweise nicht verfügbar.
+       Eine Liste der verfügbaren Transporte kann mittels
+       <function>stream_get_transports</function> abgerufen werden. Siehe
+       <xref linkend="transports"/> für eine Liste der eingebauten Transporte.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>error_code</parameter></term>
+     <listitem>
+      <para>
+       Sind die optionalen Argumente <parameter>error_code</parameter> und <parameter>error_message</parameter>
+       vorhanden, werden sie so gesetzt, dass sie den tatsächlichen, auf Systemebene
+       aufgetretenen Fehler in den systemnahen Aufrufen <literal>socket()</literal>,
+       <literal>bind()</literal> und <literal>listen()</literal> angeben. Ist
+       der in <parameter>error_code</parameter> zurückgegebene Wert
+       <literal>0</literal> und gibt die Funktion &false; zurück, so ist dies ein
+       Hinweis darauf, dass der Fehler vor dem Aufruf von <literal>bind()</literal>
+       aufgetreten ist. Dies ist höchstwahrscheinlich auf ein Problem bei der Initialisierung des Sockets zurückzuführen.
+       Es ist zu beachten, dass die Argumente <parameter>error_code</parameter> und
+       <parameter>error_message</parameter> stets als Referenz übergeben werden.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>error_message</parameter></term>
+     <listitem>
+      <para>
+       Siehe die Beschreibung von <parameter>error_code</parameter>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Ein Bitmaskenfeld, das auf eine beliebige Kombination von Socket-Erstellungs-Flags
+       gesetzt werden kann.
+      </para>
+      <note>
+       <para>
+        Für UDP-Sockets muss <constant>STREAM_SERVER_BIND</constant> als
+        Parameter <parameter>flags</parameter> verwendet werden.
+       </para>
+      </note>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>context</parameter></term>
+     <listitem>
+      <para>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt den erstellten Stream zurück oder &false; im Fehlerfall.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       <parameter>context</parameter> ist jetzt nullbar.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Verwendung von TCP-Server-Sockets</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$socket = stream_socket_server("tcp://0.0.0.0:8000", $errno, $errstr);
+if (!$socket) {
+  echo "$errstr ($errno)<br />\n";
+} else {
+  while ($conn = stream_socket_accept($socket)) {
+    fwrite($conn, 'The local time is ' . date('n/j/Y g:i a') . "\n");
+    fclose($conn);
+  }
+  fclose($socket);
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+  <para>
+   Das folgende Beispiel zeigt, wie man sich als Zeitserver verhält, der auf
+   Zeitabfragen antworten kann, wie sie in einem Beispiel von <function>stream_socket_client</function> gezeigt werden.
+   <note>
+    <simpara>
+     Die meisten Systeme erfordern Root-Zugriff, um einen Server-Socket auf einem Port
+     unterhalb von 1024 zu erstellen.
+    </simpara>
+   </note>
+   <example>
+    <title>Verwendung von UDP-Server-Sockets</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$socket = stream_socket_server("udp://127.0.0.1:1113", $errno, $errstr, STREAM_SERVER_BIND);
+if (!$socket) {
+    die("$errstr ($errno)");
+}
+
+do {
+    $pkt = stream_socket_recvfrom($socket, 1, 0, $peer);
+    echo "$peer\n";
+    stream_socket_sendto($socket, date("D M j H:i:s Y\r\n"), 0, $peer);
+} while ($pkt !== false);
+
+?>
+
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &ipv6.brackets;
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>stream_socket_client</function></member>
+   <member><function>stream_set_blocking</function></member>
+   <member><function>stream_set_timeout</function></member>
+   <member><function>fgets</function></member>
+   <member><function>fgetss</function></member>
+   <member><function>fwrite</function></member>
+   <member><function>fclose</function></member>
+   <member><function>feof</function></member>
+   <member><link linkend="ref.curl">Curl-Erweiterung</link></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/stream/functions/stream-wrapper-unregister.xml
+++ b/reference/stream/functions/stream-wrapper-unregister.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.stream-wrapper-unregister" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>stream_wrapper_unregister</refname>
+  <refpurpose>Hebt die Registrierung eines URL-Wrappers auf</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>stream_wrapper_unregister</methodname>
+   <methodparam><type>string</type><parameter>protocol</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Ermöglicht das Deaktivieren eines bereits definierten Stream-Wrappers. Sobald der Wrapper
+   deaktiviert wurde, kann er mit einem benutzerdefinierten Wrapper mittels
+   <function>stream_wrapper_register</function> überschrieben oder später mit
+   <function>stream_wrapper_restore</function> wieder aktiviert werden.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>protocol</parameter></term>
+     <listitem>
+      <para>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+</refentry>
+
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/stream/streamwrapper/dir-readdir.xml
+++ b/reference/stream/streamwrapper/dir-readdir.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="streamwrapper.dir-readdir" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>streamWrapper::dir_readdir</refname>
+  <refpurpose>Liest einen Eintrag aus einem Verzeichnis-Handle</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type class="union"><type>string</type><type>bool</type></type><methodname>streamWrapper::dir_readdir</methodname>
+   <void />
+  </methodsynopsis>
+  <para>
+   Diese Methode wird als Reaktion auf <function>readdir</function> aufgerufen.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Sollte einen <type>string</type> zurückgeben, der den nächsten Dateinamen darstellt, oder
+   &false;, falls es keine nächste Datei gibt.
+  </para>
+  <warning>
+   <simpara>
+    Die Rückgabe von <type>true</type> oder <type>false</type> hat dieselbe
+    Wirkung und signalisiert, dass es keine nächste Datei gibt. Von der Rückgabe von
+    <type>true</type> wird jedoch abgeraten, und stattdessen sollte <type>false</type>
+    verwendet werden, um diesen Zustand zu signalisieren.
+   </simpara>
+  </warning>
+  <note>
+   <para>
+    Ein nicht-boolescher Rückgabewert wird in einen <type>string</type> umgewandelt.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="errors"><!-- {{{ -->
+  &reftitle.errors;
+  &userstream.not.implemented.warning;
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Auflisten von Dateien aus tar-Archiven</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class streamWrapper {
+    protected $fp;
+
+    public function dir_opendir($path, $options) {
+        $url = parse_url($path);
+
+        $path = $url["host"] . $url["path"];
+
+        if (!is_readable($path)) {
+            trigger_error("$path ist für mich nicht lesbar", E_USER_NOTICE);
+            return false;
+        }
+        if (!is_file($path)) {
+            trigger_error("$path ist keine Datei", E_USER_NOTICE);
+            return false;
+        }
+
+        $this->fp = fopen($path, "rb");
+        return true;
+    }
+
+    public function dir_readdir() {
+        // Den Header für diesen Eintrag extrahieren
+        $header      = fread($this->fp, 512);
+        $data = unpack("a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/a8checksum/a1filetype/a100link/a100linkedfile", $header);
+
+        // Den Dateinamen und die Dateigröße kürzen
+        $filename    = trim($data["filename"]);
+
+        // Kein Dateiname? Wir sind am Ende des Archivs angelangt
+        if (!$filename) {
+            return false;
+        }
+
+        $octal_bytes = trim($data["size"]);
+        // Die Dateigröße ist in Oktetten definiert
+        $bytes       = octdec($octal_bytes);
+
+        // tar rundet Dateigrößen auf ein Vielfaches von 512 Bytes auf (mit Nullen gefüllt)
+        $rest        = $bytes % 512;
+        if ($rest > 0) {
+            $bytes      += 512 - $rest;
+        }
+
+        // Über die Datei hinwegspringen
+        fseek($this->fp, $bytes, SEEK_CUR);
+
+        return $filename;
+    }
+
+    public function dir_closedir() {
+        return fclose($this->fp);
+    }
+
+    public function dir_rewinddir() {
+        return fseek($this->fp, 0, SEEK_SET);
+    }
+}
+
+stream_wrapper_register("tar", "streamWrapper");
+$handle = opendir("tar://example.tar");
+while (false !== ($file = readdir($handle))) {
+    var_dump($file);
+}
+
+echo "Rewinding..\n";
+rewind($handle);
+var_dump(readdir($handle));
+
+closedir($handle);
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+string(13) "construct.xml"
+string(16) "dir-closedir.xml"
+string(15) "dir-opendir.xml"
+string(15) "dir-readdir.xml"
+string(17) "dir-rewinddir.xml"
+string(9) "mkdir.xml"
+string(10) "rename.xml"
+string(9) "rmdir.xml"
+string(15) "stream-cast.xml"
+string(16) "stream-close.xml"
+string(14) "stream-eof.xml"
+string(16) "stream-flush.xml"
+string(15) "stream-lock.xml"
+string(15) "stream-open.xml"
+string(15) "stream-read.xml"
+string(15) "stream-seek.xml"
+string(21) "stream-set-option.xml"
+string(15) "stream-stat.xml"
+string(15) "stream-tell.xml"
+string(16) "stream-write.xml"
+string(10) "unlink.xml"
+string(12) "url-stat.xml"
+Rewinding..
+string(13) "construct.xml"
+
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>readdir</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/stream/streamwrapper/url-stat.xml
+++ b/reference/stream/streamwrapper/url-stat.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="streamwrapper.url-stat" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>streamWrapper::url_stat</refname>
+  <refpurpose>Ruft Informationen über eine Datei ab</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>streamWrapper::url_stat</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Diese Methode wird als Reaktion auf alle Funktionen aufgerufen, die mit
+   <function>stat</function> zusammenhängen, wie etwa:
+   <simplelist>
+    <member><function>copy</function></member>
+    <member><function>fileperms</function></member>
+    <member><function>fileinode</function></member>
+    <member><function>filesize</function></member>
+    <member><function>fileowner</function></member>
+    <member><function>filegroup</function></member>
+    <member><function>fileatime</function></member>
+    <member><function>filemtime</function></member>
+    <member><function>filectime</function></member>
+    <member><function>filetype</function></member>
+    <member><function>is_writable</function></member>
+    <member><function>is_readable</function></member>
+    <member><function>is_executable</function></member>
+    <member><function>is_file</function></member>
+    <member><function>is_dir</function></member>
+    <member><function>is_link</function></member>
+    <member><function>file_exists</function></member>
+    <member><function>lstat</function></member>
+    <member><function>stat</function></member>
+    <member><methodname>SplFileInfo::getPerms</methodname></member>
+    <member><methodname>SplFileInfo::getInode</methodname></member>
+    <member><methodname>SplFileInfo::getSize</methodname></member>
+    <member><methodname>SplFileInfo::getOwner</methodname></member>
+    <member><methodname>SplFileInfo::getGroup</methodname></member>
+    <member><methodname>SplFileInfo::getATime</methodname></member>
+    <member><methodname>SplFileInfo::getMTime</methodname></member>
+    <member><methodname>SplFileInfo::getCTime</methodname></member>
+    <member><methodname>SplFileInfo::getType</methodname></member>
+    <member><methodname>SplFileInfo::isWritable</methodname></member>
+    <member><methodname>SplFileInfo::isReadable</methodname></member>
+    <member><methodname>SplFileInfo::isExecutable</methodname></member>
+    <member><methodname>SplFileInfo::isFile</methodname></member>
+    <member><methodname>SplFileInfo::isDir</methodname></member>
+    <member><methodname>SplFileInfo::isLink</methodname></member>
+    <member><methodname>RecursiveDirectoryIterator::hasChildren</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>path</parameter></term>
+     <listitem>
+      <para>
+       Der Dateipfad oder die URL, deren Status ermittelt werden soll. Es ist zu beachten, dass es sich im Fall einer URL um eine durch :// getrennte
+       URL handeln muss. Andere URL-Formen werden nicht unterstützt.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Enthält zusätzliche Flags, die von der Streams-API gesetzt werden. Es kann einen oder mehrere
+       der folgenden Werte enthalten, mit ODER verknüpft.
+       <informaltable>
+        <tgroup cols="2">
+         <thead>
+          <row>
+           <entry>Flag</entry>
+           <entry>Beschreibung</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry>STREAM_URL_STAT_LINK</entry>
+           <entry>
+            Für Ressourcen mit der Fähigkeit, auf eine andere Ressource zu verweisen
+            (wie etwa eine HTTP-Location:-Weiterleitung oder ein
+            Symlink im Dateisystem). Dieses Flag gibt an, dass nur Informationen
+            über den Link selbst zurückgegeben werden sollen, nicht über die
+            Ressource, auf die der Link verweist. Dieses Flag wird als
+            Reaktion auf Aufrufe von <function>lstat</function>,
+            <function>is_link</function> oder <function>filetype</function> gesetzt.
+           </entry>
+          </row>
+          <row>
+           <entry>STREAM_URL_STAT_QUIET</entry>
+           <entry>Ist dieses Flag gesetzt, sollte der Wrapper keinerlei
+            Fehler auslösen. Ist dieses Flag nicht gesetzt, ist man dafür verantwortlich,
+            Fehler mittels der Funktion <function>trigger_error</function>
+            während der Statusermittlung des Pfads zu melden.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </informaltable>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Sollte ein &array; mit denselben Elementen zurückgeben wie <function>stat</function>.
+   Unbekannte oder nicht verfügbare Werte sollten auf einen sinnvollen Wert gesetzt werden
+   (üblicherweise <literal>0</literal>). Besondere Aufmerksamkeit sollte
+   <literal>mode</literal> gewidmet werden, wie unter <function>stat</function> dokumentiert.
+   Sollte im Fehlerfall &false; zurückgeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors"><!-- {{{ -->
+  &reftitle.errors;
+  &userstream.not.implemented.warning;
+ </refsect1><!-- }}} -->
+
+ <!-- {{{
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>streamWrapper::url_stat</function> example</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+/* ... */
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+...
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ }}}-->
+
+ <refsect1 role="notes"><!-- {{{ -->
+  &reftitle.notes;
+  &userstream.updates.context;
+ </refsect1><!-- }}} -->
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>stat</function></member>
+    <member><methodname>streamwrapper::stream_stat</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `stream` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #235 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").