### PR TITLE
[Sync EN] spl: German translation of new files

### DIFF
--- a/reference/spl/arrayiterator/next.xml
+++ b/reference/spl/arrayiterator/next.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="arrayiterator.next" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>ArrayIterator::next</refname>
+  <refpurpose>Geht zum nächsten Eintrag</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ArrayIterator">
+   <modifier>public</modifier> <type>void</type><methodname>ArrayIterator::next</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+   Bewegt den Iterator zum nächsten Eintrag.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>ArrayIterator::next</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$arrayobject = new ArrayObject();
+
+$arrayobject[] = 'zero';
+$arrayobject[] = 'one';
+
+$iterator = $arrayobject->getIterator();
+
+while($iterator->valid()) {
+    echo $iterator->key() . ' => ' . $iterator->current() . "\n";
+
+    $iterator->next();
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+0 => zero
+1 => one
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/spl/recursivecallbackfilteriterator/construct.xml
+++ b/reference/spl/recursivecallbackfilteriterator/construct.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="recursivecallbackfilteriterator.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>RecursiveCallbackFilterIterator::__construct</refname>
+  <refpurpose>Erzeugt einen RecursiveCallbackFilterIterator aus einem RecursiveIterator</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="RecursiveCallbackFilterIterator">
+   <modifier>public</modifier> <methodname>RecursiveCallbackFilterIterator::__construct</methodname>
+   <methodparam><type>RecursiveIterator</type><parameter>iterator</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+  </constructorsynopsis>
+  <para>
+   Erzeugt aus einem <interfacename>RecursiveIterator</interfacename> einen
+   gefilterten Iterator, der den <parameter>callback</parameter> verwendet, um zu
+   bestimmen, welche Elemente akzeptiert oder verworfen werden.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>iterator</parameter></term>
+    <listitem>
+     <para>
+      Der zu filternde rekursive Iterator.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      Der Callback, der &true; zurückgeben sollte, um das aktuelle Element zu
+      akzeptieren, oder andernfalls &false;.
+      Siehe <link linkend="recursivecallbackfilteriterator.examples">Beispiele</link>.
+     </para>
+     <para>
+      Kann jeder gültige <type>callable</type>-Wert sein.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="recursivecallbackfilteriterator.examples">RecursiveCallbackFilterIterator-Beispiele</link></member>
+    <member><methodname>RecursiveCallbackFilterIterator::getChildren</methodname></member>
+    <member><methodname>RecursiveCallbackFilterIterator::hasChildren</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/spl/recursivecallbackfilteriterator/getchildren.xml
+++ b/reference/spl/recursivecallbackfilteriterator/getchildren.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="recursivecallbackfilteriterator.getchildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>RecursiveCallbackFilterIterator::getChildren</refname>
+  <refpurpose>Gibt die Kindelemente des inneren Iterators zurück, die in einem RecursiveCallbackFilterIterator enthalten sind</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="RecursiveCallbackFilterIterator">
+   <modifier>public</modifier> <type>RecursiveCallbackFilterIterator</type><methodname>RecursiveCallbackFilterIterator::getChildren</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Ruft die gefilterten Kindelemente des inneren Iterators ab.
+  </para>
+  <para>
+   <methodname>RecursiveCallbackFilterIterator::hasChildren</methodname> sollte verwendet
+   werden, um zu bestimmen, ob Kindelemente abgerufen werden können.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt einen <classname>RecursiveCallbackFilterIterator</classname> zurück, der
+   die Kindelemente enthält.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="recursivecallbackfilteriterator.examples">RecursiveCallbackFilterIterator-Beispiele</link></member>
+    <member><methodname>RecursiveCallbackFilterIterator::__construct</methodname></member>
+    <member><methodname>RecursiveCallbackFilterIterator::hasChildren</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/spl/recursivecallbackfilteriterator/haschildren.xml
+++ b/reference/spl/recursivecallbackfilteriterator/haschildren.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="recursivecallbackfilteriterator.haschildren" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>RecursiveCallbackFilterIterator::hasChildren</refname>
+  <refpurpose>Prüft, ob das aktuelle Element des inneren Iterators Kindelemente hat</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="RecursiveCallbackFilterIterator">
+   <modifier>public</modifier> <type>bool</type><methodname>RecursiveCallbackFilterIterator::hasChildren</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Gibt &true; zurück, wenn das aktuelle Element Kindelemente hat, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn das aktuelle Element Kindelemente hat, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example xml:id="recursivecallbackfilteriterator.haschildren.examples.basic">
+    <title>Grundlegende Verwendung von <methodname>RecursiveCallbackFilterIterator::hasChildren</methodname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$dir = new RecursiveDirectoryIterator(__DIR__);
+
+// Rekursiv über XML-Dateien iterieren
+$files = new RecursiveCallbackFilterIterator($dir, function ($current, $key, $iterator) {
+    // Rekursion in Verzeichnisse erlauben
+    if ($iterator->hasChildren()) {
+        return TRUE;
+    }
+    // Auf XML-Datei prüfen
+    if (!strcasecmp($current->getExtension(), 'xml')) {
+        return TRUE;
+    }
+    return FALSE;
+});
+
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><link linkend="recursivecallbackfilteriterator.examples">RecursiveCallbackFilterIterator-Beispiele</link></member>
+    <member><methodname>RecursiveCallbackFilterIterator::__construct</methodname></member>
+    <member><methodname>RecursiveCallbackFilterIterator::getChildren</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `spl` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").