### PR TITLE
[Sync EN] reflection: German translation of new files

### DIFF
--- a/reference/reflection/reflectionclass/isiterateable.xml
+++ b/reference/reflection/reflectionclass/isiterateable.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="reflectionclass.isiterateable" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionClass::isIterateable</refname>
+  <refpurpose>&Alias; <methodname>ReflectionClass::isIterable</methodname></refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&Alias; <methodname>ReflectionClass::isIterable</methodname></para>
+  <simpara>
+   Seit PHP 7.2.0 sollte anstelle der falsch geschriebenen Methode <methodname>RefectionClass::isIterateable</methodname>
+   die Methode <methodname>ReflectionClass::isIterable</methodname> bevorzugt werden.
+  </simpara>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionmethod/construct.xml
+++ b/reference/reflection/reflectionmethod/construct.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="reflectionmethod.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionMethod::__construct</refname>
+  <refpurpose>Erzeugt ein ReflectionMethod-Objekt</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <constructorsynopsis role="ReflectionMethod">
+   <modifier>public</modifier> <methodname>ReflectionMethod::__construct</methodname>
+   <methodparam><type class="union"><type>object</type><type>string</type></type><parameter>objectOrMethod</parameter></methodparam>
+   <methodparam><type>string</type><parameter>method</parameter></methodparam>
+  </constructorsynopsis>
+  <simpara>Alternative Signatur (wird mit benannten Argumenten nicht unterstützt):</simpara>
+  <constructorsynopsis role="ReflectionMethod">
+   <modifier>public</modifier> <methodname>ReflectionMethod::__construct</methodname>
+   <methodparam><type>string</type><parameter>classMethod</parameter></methodparam>
+  </constructorsynopsis>
+  <warning>
+   <simpara>
+    Die alternative Signatur ist seit PHP 8.4.0 veraltet;
+    stattdessen sollte <methodname>ReflectionMethod::createFromMethodName</methodname>
+    verwendet werden.
+   </simpara>
+  </warning>
+  <para>
+   Erzeugt eine neue <classname>ReflectionMethod</classname>.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>objectOrMethod</parameter></term>
+     <listitem>
+      <para>
+       Klassenname oder Objekt (Instanz der Klasse), das die Methode enthält.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>method</parameter></term>
+     <listitem>
+      <para>
+       Name der Methode.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>classMethod</parameter></term>
+     <listitem>
+      <para>
+       Klassenname und Methodenname, getrennt durch <literal>::</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Es wird eine <classname>ReflectionException</classname> ausgelöst, wenn die angegebene Methode nicht existiert.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Beispiel für <methodname>ReflectionMethod::__construct</methodname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Counter
+{
+    private static $c = 0;
+
+    /**
+     * Increment counter
+     *
+     * @final
+     * @static
+     * @access  public
+     * @return  int
+     */
+    final public static function increment()
+    {
+        return ++self::$c;
+    }
+}
+
+// Eine Instanz der Klasse ReflectionMethod erzeugen
+$method = new ReflectionMethod('Counter', 'increment');
+
+// Grundlegende Informationen ausgeben
+printf(
+    "===> The %s%s%s%s%s%s%s method '%s' (which is %s)\n" .
+    "     declared in %s\n" .
+    "     lines %d to %d\n" .
+    "     having the modifiers %d[%s]\n",
+        $method->isInternal() ? 'internal' : 'user-defined',
+        $method->isAbstract() ? ' abstract' : '',
+        $method->isFinal() ? ' final' : '',
+        $method->isPublic() ? ' public' : '',
+        $method->isPrivate() ? ' private' : '',
+        $method->isProtected() ? ' protected' : '',
+        $method->isStatic() ? ' static' : '',
+        $method->getName(),
+        $method->isConstructor() ? 'the constructor' : 'a regular method',
+        $method->getFileName(),
+        $method->getStartLine(),
+        $method->getEndline(),
+        $method->getModifiers(),
+        implode(' ', Reflection::getModifierNames($method->getModifiers()))
+);
+
+// Doc-Kommentar ausgeben
+printf("---> Documentation:\n %s\n", var_export($method->getDocComment(), true));
+
+// Statische Variablen ausgeben, sofern vorhanden
+if ($statics= $method->getStaticVariables()) {
+    printf("---> Static variables: %s\n", var_export($statics, true));
+}
+
+// Die Methode aufrufen
+printf("---> Invocation results in: ");
+var_dump($method->invoke(NULL));
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+===> The user-defined final public static method 'increment' (which is a regular method)
+     declared in /Users/philip/cvs/phpdoc/test.php
+     lines 14 to 17
+     having the modifiers 261[final public static]
+---> Documentation:
+ '/**
+     * Increment counter
+     *
+     * @final
+     * @static
+     * @access  public
+     * @return  int
+     */'
+---> Invocation results in: int(1)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionMethod::export</methodname></member>
+    <member><link linkend="language.oop5.decon.constructor">Konstruktoren</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionproperty/getdefaultvalue.xml
+++ b/reference/reflection/reflectionproperty/getdefaultvalue.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="reflectionproperty.getdefaultvalue" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::getDefaultValue</refname>
+  <refpurpose>Gibt den für eine Eigenschaft deklarierten Standardwert zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionProperty">
+   <modifier>public</modifier> <type>mixed</type><methodname>ReflectionProperty::getDefaultValue</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Ermittelt den implizit oder explizit deklarierten Standardwert einer Eigenschaft.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Der Standardwert, sofern die Eigenschaft einen Standardwert hat (einschließlich &null;).
+   Wenn es keinen Standardwert gibt, wird &null; zurückgegeben. Es ist nicht möglich, zwischen
+   einem Standardwert &null; und einer nicht initialisierten typisierten Eigenschaft zu unterscheiden.
+   Um den Unterschied zu erkennen, ist <methodname>ReflectionProperty::hasDefaultValue</methodname> zu verwenden.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.5.0</entry>
+      <entry>
+       Der Aufruf von <methodname>ReflectionProperty::getDefaultValue</methodname>
+       für Eigenschaften ohne Standardwert wurde als veraltet markiert.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+ <title>Beispiel für <methodname>ReflectionProperty::getDefaultValue</methodname></title>
+ <programlisting role="php">
+<![CDATA[
+<?php
+class Foo {
+    public $bar = 1;
+    public ?int $baz;
+    public int $boing = 0;
+    public function __construct(public string $bak = "default") { }
+}
+
+$ro = new ReflectionClass(Foo::class);
+var_dump($ro->getProperty('bar')->getDefaultValue());
+var_dump($ro->getProperty('baz')->getDefaultValue());
+var_dump($ro->getProperty('boing')->getDefaultValue());
+var_dump($ro->getProperty('bak')->getDefaultValue());
+?>
+]]>
+ </programlisting>
+ &example.outputs;
+ <screen>
+<![CDATA[
+int(1)
+NULL
+int(0)
+NULL
+]]>
+ </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionProperty::hasDefaultValue</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/reflection/reflectionproperty/getdoccomment.xml
+++ b/reference/reflection/reflectionproperty/getdoccomment.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="reflectionproperty.getdoccomment" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionProperty::getDocComment</refname>
+  <refpurpose>Ermittelt den Doc-Kommentar einer Eigenschaft</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionProperty">
+   <modifier>public</modifier> <type class="union"><type>string</type><type>false</type></type><methodname>ReflectionProperty::getDocComment</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Ermittelt den Doc-Kommentar einer Eigenschaft.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Der Doc-Kommentar, sofern er existiert, andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Beispiel für <methodname>ReflectionProperty::getDocComment</methodname></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Str
+{
+    /**
+     * @var int  The length of the string
+     */
+    public $length = 5;
+}
+
+$prop = new ReflectionProperty('Str', 'length');
+
+var_dump($prop->getDocComment());
+
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+string(53) "/**
+     * @var int  The length of the string
+     */"
+]]>
+    </screen>
+   </example>
+  </para>
+
+  <para>
+   <example>
+    <title>Mehrere Eigenschaftsdeklarationen</title>
+    <simpara>
+     Wenn mehreren Eigenschaftsdeklarationen ein einzelner Doc-Kommentar vorangestellt ist,
+     bezieht sich der Doc-Kommentar nur auf die erste Eigenschaft.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+class Foo
+{
+    /** @var string */
+    public $a, $b;
+}
+$class = new \ReflectionClass('Foo');
+foreach ($class->getProperties() as $property) {
+    echo $property->getName() . ': ' . var_export($property->getDocComment(), true) . PHP_EOL;
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+a: '/** @var string */'
+b: false
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionProperty::getModifiers</methodname></member>
+    <member><methodname>ReflectionProperty::getName</methodname></member>
+    <member><methodname>ReflectionProperty::getValue</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `reflection` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #235 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").