### PR TITLE
[Sync EN] mongodb: German translation of new files

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="mongodb-driver-manager.startsession" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\Manager::startSession</refname>
+  <refpurpose>Startet eine neue Client-Sitzung zur Verwendung mit diesem Client</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Session</type><methodname>MongoDB\Driver\Manager::startSession</methodname>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt eine <classname>MongoDB\Driver\Session</classname> für die
+   angegebenen Optionen. Die Sitzung kann anschließend bei der Ausführung von
+   Befehlen, Abfragen und Schreiboperationen angegeben werden.
+  </simpara>
+  <note>
+   <simpara>
+    Eine <classname>MongoDB\Driver\Session</classname> kann nur mit dem
+    <classname>MongoDB\Driver\Manager</classname> verwendet werden, von dem sie
+    erstellt wurde.
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>options</parameter></term>
+    <listitem>
+     <para>
+      <table>
+       <title>options</title>
+       <tgroup cols="4">
+        <thead>
+         <row>
+          <entry>Option</entry>
+          <entry>Typ</entry>
+          <entry>Beschreibung</entry>
+          <entry>Standardwert</entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>causalConsistency</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <simpara>
+            Konfiguriert die kausale Konsistenz in einer Sitzung. Wenn &true;,
+            wird jede Operation in der Sitzung kausal nach der vorherigen Lese-
+            oder Schreiboperation geordnet. Auf &false; setzen, um die kausale
+            Konsistenz zu deaktivieren.
+           </simpara>
+           <simpara>
+            Weitere Informationen finden sich unter
+            <link xlink:href="&url.mongodb.docs;core/read-isolation-consistency-recency/#causal-consistency">Causal Consistency</link>
+            im MongoDB-Handbuch.
+           </simpara>
+          </entry>
+          <entry>&true;</entry>
+         </row>
+         <row>
+          <entry>defaultTransactionOptions</entry>
+          <entry><type>array</type></entry>
+          <entry>
+           <simpara>
+            Standardoptionen, die auf neu erstellte Transaktionen angewendet
+            werden. Diese Optionen werden verwendet, sofern sie nicht
+            überschrieben werden, wenn eine Transaktion mit einem anderen Wert
+            für die jeweilige Option gestartet wird.
+           </simpara>
+           <para>
+            <table>
+             <title>options</title>
+             <tgroup cols="3">
+              <thead>
+               <row>
+                <entry>Option</entry>
+                <entry>Typ</entry>
+                <entry>Beschreibung</entry>
+               </row>
+              </thead>
+              <tbody>
+               &mongodb.option.maxCommitTimeMS;
+               &mongodb.option.readConcern;
+               &mongodb.option.readPreference;
+               &mongodb.option.writeConcern;
+              </tbody>
+             </tgroup>
+            </table>
+           </para>
+           <simpara>
+            Diese Option ist ab MongoDB 4.0 verfügbar.
+           </simpara>
+          </entry>
+          <entry><literal>[]</literal></entry>
+         </row>
+         <row>
+          <entry>snapshot</entry>
+          <entry><type>bool</type></entry>
+          <entry>
+           <simpara>
+            Konfiguriert Snapshot-Lesevorgänge in einer Sitzung. Wenn &true;,
+            wird ein Zeitstempel von der ersten unterstützten Leseoperation in
+            der Sitzung bezogen (d. h. <literal>find</literal>,
+            <literal>aggregate</literal> oder nicht-shardiertes
+            <literal>distinct</literal>). Nachfolgende Leseoperationen
+            innerhalb der Sitzung verwenden dann ein
+            <literal>"snapshot"</literal>-Read-Concern-Level, um
+            mehrheitlich bestätigte Daten ab diesem Zeitstempel zu lesen. Auf
+            &false; setzen, um Snapshot-Lesevorgänge zu deaktivieren.
+           </simpara>
+           <simpara>
+            Snapshot-Lesevorgänge erfordern MongoDB 5.0 oder neuer und können
+            nicht mit kausaler Konsistenz, Transaktionen oder
+            Schreiboperationen verwendet werden. Wenn
+            <literal>"snapshot"</literal> &true; ist, wird
+            <literal>"causalConsistency"</literal> standardmäßig &false; sein.
+           </simpara>
+           <simpara>
+            Weitere Informationen finden sich unter
+            <link xlink:href="&url.mongodb.docs;reference/read-concern-snapshot/#read-concern-and-atclustertime">Read Concern "snapshot"</link>
+            im MongoDB-Handbuch.
+           </simpara>
+          </entry>
+          <entry>&false;</entry>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt eine <classname>MongoDB\Driver\Session</classname> zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Wirft eine <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname>, wenn die Optionen <literal>"causalConsistency"</literal> und <literal>"snapshot"</literal> beide &true; sind.</member>
+   <member>Wirft eine <classname>MongoDB\Driver\Exception\RuntimeException</classname>, wenn die Sitzung nicht erstellt werden konnte (z. B. weil libmongoc keine Kryptografie unterstützt).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>PECL mongodb 1.11.0</entry>
+      <entry>
+       <simpara>
+        Die Option <literal>"snapshot"</literal> wurde hinzugefügt.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.6.0</entry>
+      <entry>
+       <simpara>
+        Die Option <literal>"maxCommitTimeMS"</literal> wurde zu
+        <literal>"defaultTransactionOptions"</literal> hinzugefügt.
+       </simpara>
+      </entry>
+     </row>
+     <row>
+      <entry>PECL mongodb 1.5.0</entry>
+      <entry>
+       <simpara>
+        Die Option <literal>"defaultTransactionOptions"</literal> wurde
+        hinzugefügt.
+       </simpara>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>MongoDB\Driver\Session</classname></member>
+   <member><link xlink:href="&url.mongodb.docs;core/read-isolation-consistency-recency/#causal-consistency">Causal Consistency</link> im MongoDB-Handbuch</member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/isdefault.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="mongodb-driver-readconcern.isdefault" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ReadConcern::isDefault</refname>
+  <refpurpose>Prüft, ob dies das standardmäßige Read Concern ist</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>bool</type><methodname>MongoDB\Driver\ReadConcern::isDefault</methodname>
+   <void />
+  </methodsynopsis>
+  <simpara>
+   Gibt zurück, ob dies das standardmäßige Read Concern ist (d. h. ob keine
+   Optionen angegeben sind). Diese Methode ist in erster Linie zur Verwendung in
+   Verbindung mit
+   <methodname>MongoDB\Driver\Manager::getReadConcern</methodname> gedacht, um
+   festzustellen, ob der Manager ohne Read-Concern-Optionen konstruiert wurde.
+  </simpara>
+  <simpara>
+   Der Treiber bindet kein standardmäßiges Read Concern in seine
+   Leseoperationen ein (z. B.
+   <methodname>MongoDB\Driver\Manager::executeQuery</methodname>), damit der
+   Server seinen eigenen Standardwert anwenden kann. Bibliotheken, die auf das
+   Read Concern des Managers zugreifen, um es in ihre eigenen Lesebefehle
+   einzubinden, sollten diese Methode verwenden, um sicherzustellen, dass
+   standardmäßige Read Concerns nicht gesetzt bleiben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt &true; zurück, wenn dies das standardmäßige Read Concern ist, und
+   andernfalls &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>MongoDB\Driver\ReadConcern::isDefault</function> Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+$rc = new MongoDB\Driver\ReadConcern(null);
+var_dump($rc->isDefault());
+
+$rc = new MongoDB\Driver\ReadConcern(MongoDB\Driver\ReadConcern::MAJORITY);
+var_dump($rc->isDefault());
+
+$manager = new MongoDB\Driver\Manager('mongodb://127.0.0.1/?readConcernLevel=majority');
+$rc = $manager->getReadConcern();
+var_dump($rc->isDefault());
+
+$manager = new MongoDB\Driver\Manager('mongodb://127.0.0.1/');
+$rc = $manager->getReadConcern();
+var_dump($rc->isDefault());
+
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(true)
+bool(false)
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\Manager::getReadConcern</methodname></member>
+   <member><link xlink:href="&url.mongodb.docs.readconcern;">Read-Concern-Referenz</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/server.xml
+++ b/reference/mongodb/mongodb/driver/server.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.mongodb-driver-server" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Die Klasse MongoDB\Driver\Server</title>
+ <titleabbrev>MongoDB\Driver\Server</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\Driver\Server intro -->
+  <section xml:id="mongodb-driver-server.intro">
+   &reftitle.intro;
+   <simpara>
+
+   </simpara>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-driver-server.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\Driver\Server</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\Driver\Server</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-unknown">MongoDB\Driver\Server::TYPE_UNKNOWN</varname>
+     <initializer>0</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-standalone">MongoDB\Driver\Server::TYPE_STANDALONE</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-mongos">MongoDB\Driver\Server::TYPE_MONGOS</varname>
+     <initializer>2</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-possible-primary">MongoDB\Driver\Server::TYPE_POSSIBLE_PRIMARY</varname>
+     <initializer>3</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-rs-primary">MongoDB\Driver\Server::TYPE_RS_PRIMARY</varname>
+     <initializer>4</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-rs-secondary">MongoDB\Driver\Server::TYPE_RS_SECONDARY</varname>
+     <initializer>5</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-rs-arbiter">MongoDB\Driver\Server::TYPE_RS_ARBITER</varname>
+     <initializer>6</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-rs-other">MongoDB\Driver\Server::TYPE_RS_OTHER</varname>
+     <initializer>7</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-rs-ghost">MongoDB\Driver\Server::TYPE_RS_GHOST</varname>
+     <initializer>8</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>int</type>
+     <varname linkend="mongodb-driver-server.constants.type-load-balancer">MongoDB\Driver\Server::TYPE_LOAD_BALANCER</varname>
+     <initializer>9</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-server')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+<!-- {{{ MongoDB\Driver\Server constants -->
+  <section xml:id="mongodb-driver-server.constants">
+   &reftitle.constants;
+   <variablelist>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-unknown">
+     <term><constant>MongoDB\Driver\Server::TYPE_UNKNOWN</constant></term>
+     <listitem>
+      <simpara>Unbekannter Servertyp, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-standalone">
+     <term><constant>MongoDB\Driver\Server::TYPE_STANDALONE</constant></term>
+     <listitem>
+      <simpara>Eigenständiger Servertyp, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-mongos">
+     <term><constant>MongoDB\Driver\Server::TYPE_MONGOS</constant></term>
+     <listitem>
+      <simpara>Mongos-Servertyp, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-possible-primary">
+     <term><constant>MongoDB\Driver\Server::TYPE_POSSIBLE_PRIMARY</constant></term>
+     <listitem>
+      <simpara>Möglicher Primary-Servertyp eines Replica Sets, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Ein Server kann als möglicher Primary identifiziert werden, wenn er noch nicht überprüft wurde, ein anderes Mitglied des Replica Sets ihn jedoch für den Primary hält.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-rs-primary">
+     <term><constant>MongoDB\Driver\Server::TYPE_RS_PRIMARY</constant></term>
+     <listitem>
+      <simpara>Primary-Servertyp eines Replica Sets, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-rs-secondary">
+     <term><constant>MongoDB\Driver\Server::TYPE_RS_SECONDARY</constant></term>
+     <listitem>
+      <simpara>Secondary-Servertyp eines Replica Sets, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-rs-arbiter">
+     <term><constant>MongoDB\Driver\Server::TYPE_RS_ARBITER</constant></term>
+     <listitem>
+      <simpara>Arbiter-Servertyp eines Replica Sets, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-rs-other">
+     <term><constant>MongoDB\Driver\Server::TYPE_RS_OTHER</constant></term>
+     <listitem>
+      <simpara>Sonstiger Servertyp eines Replica Sets, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Solche Server können verborgen sein, gerade starten oder sich in der Wiederherstellung befinden. Sie können nicht abgefragt werden, ihre Host-Listen sind jedoch nützlich, um die aktuelle Konfiguration des Replica Sets zu ermitteln.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-rs-ghost">
+     <term><constant>MongoDB\Driver\Server::TYPE_RS_GHOST</constant></term>
+     <listitem>
+      <simpara>Ghost-Servertyp eines Replica Sets, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+      <simpara>Server können in mindestens drei Situationen als solche identifiziert werden: kurzzeitig während des Serverstarts; in einem nicht initialisierten Replica Set; oder wenn der Server gemieden wird (d. h. aus der Konfiguration des Replica Sets entfernt wurde). Sie können nicht abgefragt werden, und ihre Host-Liste kann auch nicht zur Ermittlung der aktuellen Konfiguration des Replica Sets verwendet werden; der Client kann diesen Server jedoch in der Hoffnung überwachen, dass er in einen nützlicheren Zustand übergeht.</simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-server.constants.type-load-balancer">
+     <term><constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant></term>
+     <listitem>
+      <simpara>Load-Balancer-Servertyp, zurückgegeben von <methodname>MongoDB\Driver\Server::getType</methodname>.</simpara>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.11.0</entry>
+       <entry>
+        <simpara>
+         Die Konstante
+         <constant>MongoDB\Driver\Server::TYPE_LOAD_BALANCER</constant>
+         wurde hinzugefügt.
+        </simpara>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+ </partintro>
+
+ &reference.mongodb.mongodb.driver.entities.server;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/session.xml
+++ b/reference/mongodb/mongodb/driver/session.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.mongodb-driver-session" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Die Klasse MongoDB\Driver\Session</title>
+ <titleabbrev>MongoDB\Driver\Session</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\Driver\Session intro -->
+  <section xml:id="mongodb-driver-session.intro">
+   &reftitle.intro;
+   <simpara>
+    Die Klasse <classname>MongoDB\Driver\Session</classname> repräsentiert eine
+    Client-Sitzung und wird von
+    <methodname>MongoDB\Driver\Manager::startSession</methodname> zurückgegeben.
+    Befehle, Abfragen und Schreiboperationen können anschließend mit der Sitzung
+    verknüpft werden.
+   </simpara>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-driver-session.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\Driver\Session</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\Driver\Session</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-session.constants.transaction-none">MongoDB\Driver\Session::TRANSACTION_NONE</varname>
+     <initializer>none</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-session.constants.transaction-starting">MongoDB\Driver\Session::TRANSACTION_STARTING</varname>
+     <initializer>starting</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-session.constants.transaction-in-progress">MongoDB\Driver\Session::TRANSACTION_IN_PROGRESS</varname>
+     <initializer>in_progress</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-session.constants.transaction-committed">MongoDB\Driver\Session::TRANSACTION_COMMITTED</varname>
+     <initializer>committed</initializer>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-session.constants.transaction-aborted">MongoDB\Driver\Session::TRANSACTION_ABORTED</varname>
+     <initializer>aborted</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-session')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+  <!-- {{{ MongoDB\Driver\Session constants -->
+  <section xml:id="mongodb-driver-session.constants">
+   &reftitle.constants;
+   <variablelist>
+
+    <varlistentry xml:id="mongodb-driver-session.constants.transaction-none">
+     <term><constant>MongoDB\Driver\Session::TRANSACTION_NONE</constant></term>
+     <listitem>
+      <simpara>
+       Es ist keine Transaktion im Gange.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-session.constants.transaction-starting">
+     <term><constant>MongoDB\Driver\Session::TRANSACTION_STARTING</constant></term>
+     <listitem>
+      <simpara>
+       Eine Transaktion wurde gestartet, aber es wurde noch keine Operation an den Server gesendet.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-session.constants.transaction-in-progress">
+     <term><constant>MongoDB\Driver\Session::TRANSACTION_IN_PROGRESS</constant></term>
+     <listitem>
+      <simpara>
+       Eine Transaktion ist im Gange.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-session.constants.transaction-committed">
+     <term><constant>MongoDB\Driver\Session::TRANSACTION_COMMITTED</constant></term>
+     <listitem>
+      <simpara>
+       Die Transaktion wurde bestätigt.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry xml:id="mongodb-driver-session.constants.transaction-aborted">
+     <term><constant>MongoDB\Driver\Session::TRANSACTION_ABORTED</constant></term>
+     <listitem>
+      <simpara>
+       Die Transaktion wurde abgebrochen.
+      </simpara>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
+  </section>
+  <!-- }}} -->
+
+ </partintro>
+
+ &reference.mongodb.mongodb.driver.entities.session;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `mongodb` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").