### PR TITLE
[Sync EN] fann: German translation of new files

### DIFF
--- a/reference/fann/functions/fann-get-cascade-output-change-fraction.xml
+++ b/reference/fann/functions/fann-get-cascade-output-change-fraction.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.fann-get-cascade-output-change-fraction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fann_get_cascade_output_change_fraction</refname>
+  <refpurpose>Gibt den Änderungsanteil der Kaskadenausgabe zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>fann_get_cascade_output_change_fraction</methodname>
+   <methodparam><type>resource</type><parameter>ann</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Der Änderungsanteil der Kaskadenausgabe ist eine Zahl zwischen 0 und 1, die bestimmt, wie groß der Anteil des Wertes von <function>fann_get_MSE</function>
+   sein muss, der sich innerhalb von <function>fann_get_cascade_output_stagnation_epochs</function> während des Trainings der Ausgabeverbindungen ändert,
+   damit das Training nicht stagniert. Stagniert das Training, so wird das Training der Ausgabeverbindungen
+   beendet und es werden neue Kandidaten vorbereitet.
+  </para>
+  <para>
+   Das bedeutet, dass wenn sich der MSE während eines Zeitraums von <function>fann_get_cascade_output_stagnation_epochs</function> nicht um einen Anteil von <function>fann_get_cascade_output_change_fraction</function>
+   ändert, das Training der Ausgabeverbindungen gestoppt wird, weil das Training stagniert ist.
+  </para>
+  <para>
+   Ist der Änderungsanteil der Kaskadenausgabe niedrig, so werden die Ausgabeverbindungen stärker trainiert, und ist der Anteil hoch,
+   so werden sie weniger trainiert.
+  </para>
+  <simpara>
+   Der voreingestellte Änderungsanteil der Kaskadenausgabe ist 0.01, was einer Änderung des MSE um 1 % entspricht.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ann</parameter></term>
+    <listitem>
+     &fann.ann.description;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Der Änderungsanteil der Kaskadenausgabe oder &false; im Fehlerfall.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fann_set_cascade_output_change_fraction</function></member>
+    <member><function>fann_get_MSE</function></member>
+    <member><function>fann_get_cascade_output_stagnation_epochs</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fann/functions/fann-get-layer-array.xml
+++ b/reference/fann/functions/fann-get-layer-array.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.fann-get-layer-array" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fann_get_layer_array</refname>
+  <refpurpose>Ermittelt die Anzahl der Neuronen in jeder Schicht des Netzes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>fann_get_layer_array</methodname>
+   <methodparam><type>resource</type><parameter>ann</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ermittelt die Anzahl der Neuronen in jeder Schicht des neuronalen Netzes.
+  </para>
+  <para>
+   Der Bias wird nicht berücksichtigt, sodass die Schichten zu den fann_create-Funktionen passen.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ann</parameter></term>
+    <listitem>
+     &fann.ann.description;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ein Array mit der Anzahl der Neuronen in jeder Schicht.
+  </simpara>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fann/functions/fann-get-num-layers.xml
+++ b/reference/fann/functions/fann-get-num-layers.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.fann-get-num-layers" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fann_get_num_layers</refname>
+  <refpurpose>Ermittelt die Anzahl der Schichten des neuronalen Netzes</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>fann_get_num_layers</methodname>
+   <methodparam><type>resource</type><parameter>ann</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ermittelt die Anzahl der Schichten des neuronalen Netzes.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ann</parameter></term>
+    <listitem>
+     &fann.ann.description;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die Anzahl der Schichten des neuronalen Netzes oder &false; im Fehlerfall.
+  </simpara>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fann/functions/fann-train-epoch.xml
+++ b/reference/fann/functions/fann-train-epoch.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.fann-train-epoch" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>fann_train_epoch</refname>
+  <refpurpose>Trainiert eine Epoche mit einem Satz von Trainingsdaten</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>float</type><methodname>fann_train_epoch</methodname>
+   <methodparam><type>resource</type><parameter>ann</parameter></methodparam>
+   <methodparam><type>resource</type><parameter>data</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Trainiert eine Epoche mit den in data gespeicherten Trainingsdaten. Eine Epoche ist
+   ein Durchlauf, bei dem alle Trainingsdaten genau einmal berücksichtigt werden.
+  </para>
+  <simpara>
+   Diese Funktion gibt den MSE-Fehler zurück, wie er entweder vor oder während des eigentlichen Trainings berechnet wird.
+   Dies ist nicht der tatsächliche MSE nach der Trainingsepoche, aber da dessen Berechnung erfordern würde, den
+   gesamten Trainingssatz noch einmal zu durchlaufen, ist es mehr als ausreichend, diesen Wert während des Trainings zu verwenden.
+  </simpara>
+  <para>
+   Der von dieser Funktion verwendete Trainingsalgorithmus wird durch die Funktion <function>fann_set_training_algorithm</function>
+   ausgewählt.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ann</parameter></term>
+    <listitem>
+     &fann.ann.description;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     &fann.train.description;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Der MSE oder &false; im Fehlerfall.
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fann_train_on_data</function></member>
+    <member><function>fann_test_data</function></member>
+    <member><function>fann_get_MSE</function></member>
+    <member><function>fann_set_training_algorithm</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `fann` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").