### PR TITLE
[Sync EN] enchant: German translation of new files

### DIFF
--- a/reference/enchant/functions/enchant-broker-dict-exists.xml
+++ b/reference/enchant/functions/enchant-broker-dict-exists.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-dict-exists">
+ <refnamediv>
+  <refname>enchant_broker_dict_exists</refname>
+  <refpurpose>Ob ein Wörterbuch existiert oder nicht</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>enchant_broker_dict_exists</methodname>
+   <methodparam><type>EnchantBroker</type><parameter>broker</parameter></methodparam>
+   <methodparam><type>string</type><parameter>tag</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Gibt anhand eines nicht leeren Tags an, ob ein Wörterbuch existiert oder nicht.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &enchant.param.broker;
+   <varlistentry>
+    <term><parameter>tag</parameter></term>
+    <listitem>
+     <simpara>
+      Nicht leeres Tag im LOCALE-Format, z. B. us_US, ch_DE usw.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt &true; zurück, wenn das Tag existiert, andernfalls &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &enchant.changelog.broker-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Ein Beispiel für <function>enchant_broker_dict_exists</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$tag = 'en_US';
+$r = enchant_broker_init();
+if (enchant_broker_dict_exists($r,$tag)) {
+    echo $tag . " dictionary found.\n";
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>enchant_broker_describe</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-broker-init.xml
+++ b/reference/enchant/functions/enchant-broker-init.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-init">
+ <refnamediv>
+  <refname>enchant_broker_init</refname>
+  <refpurpose>Erzeugt ein neues Broker-Objekt</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>EnchantBroker</type><type>false</type></type><methodname>enchant_broker_init</methodname>
+   <void/>
+  </methodsynopsis>
+
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <simpara>
+  </simpara>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg eine Broker-Ressource zurück oder &false;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Bei Erfolg gibt diese Funktion nun eine <classname>EnchantBroker</classname>-Instanz zurück;
+       zuvor wurde eine &resource; zurückgegeben.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>enchant_broker_free</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
+++ b/reference/enchant/functions/enchant-broker-request-pwl-dict.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-broker-request-pwl-dict">
+ <refnamediv>
+  <refname>enchant_broker_request_pwl_dict</refname>
+  <refpurpose>Erzeugt ein Wörterbuch mithilfe einer PWL-Datei</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>EnchantDictionary</type><type>false</type></type><methodname>enchant_broker_request_pwl_dict</methodname>
+   <methodparam><type>EnchantBroker</type><parameter>broker</parameter></methodparam>
+   <methodparam><type>string</type><parameter>filename</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt ein Wörterbuch mithilfe einer PWL-Datei. Eine PWL-Datei ist eine persönliche Wortdatei mit einem Wort pro Zeile.
+  </simpara>
+
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &enchant.param.broker;
+   <varlistentry>
+    <term><parameter>filename</parameter></term>
+    <listitem>
+     <simpara>
+      Pfad zur PWL-Datei.
+      Falls keine solche Datei vorhanden ist, wird nach Möglichkeit eine neue erzeugt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg eine Wörterbuch-Ressource zurück&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &enchant.changelog.broker-param;
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Bei Erfolg gibt diese Funktion nun eine <classname>EnchantDictionary</classname>-Instanz zurück;
+       zuvor wurde eine &resource; zurückgegeben.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>enchant_dict_describe</function></member>
+   <member><function>enchant_broker_dict_exists</function></member>
+   <member><function>enchant_broker_free_dict</function></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/enchant/functions/enchant-dict-store-replacement.xml
+++ b/reference/enchant/functions/enchant-dict-store-replacement.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.enchant-dict-store-replacement">
+ <refnamediv>
+  <refname>enchant_dict_store_replacement</refname>
+  <refpurpose>Fügt eine Korrektur für ein Wort hinzu</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>enchant_dict_store_replacement</methodname>
+   <methodparam><type>EnchantDictionary</type><parameter>dictionary</parameter></methodparam>
+   <methodparam><type>string</type><parameter>misspelled</parameter></methodparam>
+   <methodparam><type>string</type><parameter>correct</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Fügt eine Korrektur für 'mis' mithilfe von 'cor' hinzu.
+    Vermerkt, dass @mis durch @cor ersetzt wurde, sodass es möglicherweise wahrscheinlicher ist,
+    dass künftige Vorkommen von @mis durch @cor ersetzt werden. Dadurch kann @cor in der
+    Vorschlagsliste nach oben rücken.
+  </simpara>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   &enchant.param.dictionary;
+   <varlistentry>
+    <term><parameter>misspelled</parameter></term>
+    <listitem>
+     <simpara>
+      Das zu korrigierende Wort
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>correct</parameter></term>
+    <listitem>
+     <simpara>
+      Das korrekte Wort
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &enchant.changelog.dictionary-param;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien der Erweiterung `enchant` ins Deutsche, auf dem Stand des aktuellen EN-Texts (4 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").