### PR TITLE
[Sync EN] uopz: German translation of new files

### DIFF
--- a/reference/uopz/functions/uopz-extend.xml
+++ b/reference/uopz/functions/uopz-extend.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.uopz-extend" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>uopz_extend</refname>
+  <refpurpose>Erweitert eine Klasse zur Laufzeit</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>uopz_extend</methodname>
+   <methodparam><type>string</type><parameter>class</parameter></methodparam>
+   <methodparam><type>string</type><parameter>parent</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Bewirkt, dass <parameter>class</parameter> die Klasse <parameter>parent</parameter> erweitert
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>class</parameter></term>
+    <listitem>
+     <para>
+      Der Name der zu erweiternden Klasse
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>parent</parameter></term>
+    <listitem>
+     <para>
+      Der Name der zu erbenden Klasse
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Ab PHP 7.4.0 wirft <function>uopz_extend</function> eine <classname>RuntimeException</classname>,
+   wenn <link linkend="book.opcache">OPcache</link> aktiviert ist
+   und der Klasseneintrag von entweder <parameter>class</parameter>
+   oder <parameter>parent</parameter> (sofern es ein Trait ist) unveränderlich ist.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>uopz_extend</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+class A {}
+class B {}
+
+uopz_extend(A::class, B::class);
+
+var_dump(class_parents(A::class));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  ["B"]=>
+  string(1) "B"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uopz/functions/uopz-get-static.xml
+++ b/reference/uopz/functions/uopz-get-static.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.uopz-get-static" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>uopz_get_static</refname>
+  <refpurpose>Ermittelt die statischen Variablen aus dem Gültigkeitsbereich einer Funktion oder Methode</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="procedural">
+   <type>array</type><methodname>uopz_get_static</methodname>
+   <methodparam><type>string</type><parameter>class</parameter></methodparam>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
+  </methodsynopsis>
+  <methodsynopsis role="procedural">
+   <type>array</type><methodname>uopz_get_static</methodname>
+   <methodparam><type>string</type><parameter>function</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ermittelt die statischen Variablen aus dem Gültigkeitsbereich einer Funktion oder Methode.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>class</parameter></term>
+    <listitem>
+     <para>
+      Der Name der Klasse.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>function</parameter></term>
+    <listitem>
+     <para>
+      Der Name der Funktion oder Methode.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt im Erfolgsfall ein assoziatives <type>array</type> aus Variablennamen,
+   die ihren aktuellen Werten zugeordnet sind, zurück, oder &null;, wenn die
+   Funktion oder Methode nicht existiert.
+  </para>
+  <simpara>
+   Ab PHP 8.3.0 werden statische Initialisierer entweder zur Kompilierzeit berechnet
+   oder, falls das nicht möglich ist, erst dann, wenn die Funktion oder Methode zum
+   ersten Mal ausgeführt wird; in diesem Fall wird der Wert der statischen Variable
+   vor dem ersten Aufruf als &null; gemeldet.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="uopz-get-static.example.basic">
+   <title>Grundlegende Verwendung von <function>uopz_get_static</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function foo() {
+    static $bar = 'baz';
+}
+var_dump(uopz_get_static('foo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  ["bar"]=>
+  string(3) "baz"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>ReflectionFunctionAbstract::getStaticVariables</methodname></member>
+   <member><function>uopz_set_static</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/uopz/functions/uopz-implement.xml
+++ b/reference/uopz/functions/uopz-implement.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="function.uopz-implement" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>uopz_implement</refname>
+  <refpurpose>Implementiert eine Schnittstelle zur Laufzeit</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>uopz_implement</methodname>
+   <methodparam><type>string</type><parameter>class</parameter></methodparam>
+   <methodparam><type>string</type><parameter>interface</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Bewirkt, dass <parameter>class</parameter> die Schnittstelle <parameter>interface</parameter> implementiert
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>class</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>interface</parameter></term>
+    <listitem>
+     <para>
+
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Ab PHP 7.4.0 wirft <function>uopz_implement</function> eine <classname>RuntimeException</classname>,
+   wenn <link linkend="book.opcache">OPcache</link> aktiviert ist
+   und der Klasseneintrag von <parameter>class</parameter> unveränderlich ist.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>uopz_implement</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+interface myInterface {}
+
+class myClass {}
+
+uopz_implement(myClass::class, myInterface::class);
+
+var_dump(class_implements(myClass::class));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+array(1) {
+  ["myInterface"]=>
+  string(11) "myInterface"
+}
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt neue (zuvor nicht übersetzte) Dateien (uopz) ins Deutsche, auf dem Stand des aktuellen EN-Texts (3 Datei(en)). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").