### PR TITLE
[Sync EN] snmp: German translation of new files

### DIFF
--- a/reference/snmp/functions/snmpgetnext.xml
+++ b/reference/snmp/functions/snmpgetnext.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.snmpgetnext">
+ <refnamediv>
+  <refname>snmpgetnext</refname>
+  <refpurpose>
+   Liest das <acronym>SNMP</acronym>-Objekt, das auf die angegebene Object ID (OID) folgt
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>mixed</type><methodname>snmpgetnext</methodname>
+   <methodparam><type>string</type><parameter>hostname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>community</parameter></methodparam>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>object_id</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>retries</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+
+  <simpara>
+   Die Funktion <function>snmpgetnext</function> wird verwendet, um den
+   Wert des <acronym>SNMP</acronym>-Objekts zu lesen, das auf die angegebene
+   <parameter>object_id</parameter> folgt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>hostname</parameter></term>
+    <listitem><simpara>Der Hostname des <acronym>SNMP</acronym>-Agenten (Servers).</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>community</parameter></term>
+    <listitem><simpara>Die Lese-Community.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>object_id</parameter></term>
+    <listitem><simpara>Die Object ID (OID) des <acronym>SNMP</acronym>-Objekts, das dem gewünschten vorangeht.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem><simpara>Die Anzahl der Mikrosekunden bis zur ersten Zeitüberschreitung.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>retries</parameter></term>
+    <listitem><simpara>Die Anzahl der Wiederholungsversuche, falls Zeitüberschreitungen auftreten.</simpara></listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg den Wert des <acronym>SNMP</acronym>-Objekts zurück oder &false; im Fehlerfall.
+   Im Fehlerfall wird eine E_WARNING-Meldung ausgegeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Verwendung von <function>snmpgetnext</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$nameOfSecondInterface = snmpgetnext('localhost', 'public', 'IF-MIB::ifName.1');
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>snmpget</function></member>
+   <member><function>snmpwalk</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/snmp/snmp/getnext.xml
+++ b/reference/snmp/snmp/getnext.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.getnext">
+ <refnamediv>
+  <refname>SNMP::getnext</refname>
+  <refpurpose>Liest ein <acronym>SNMP</acronym>-Objekt, das
+  auf die angegebene Object ID (OID) folgt
+  </refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+
+  <methodsynopsis role="SNMP">
+   <modifier>public</modifier> <type>mixed</type><methodname>SNMP::getnext</methodname>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>objectId</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Liest ein <acronym>SNMP</acronym>-Objekt, das auf die angegebene <parameter>objectId</parameter> folgt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <simpara>
+  Ist <parameter>objectId</parameter> eine Zeichenkette, so gibt <methodname>SNMP::getnext</methodname>
+  das <acronym>SNMP</acronym>-Objekt als Zeichenkette zurück. Ist
+  <parameter>objectId</parameter> ein Array, so werden alle angeforderten <acronym>SNMP</acronym>-Objekte
+  als assoziatives Array der Object IDs (OIDs) der <acronym>SNMP</acronym>-Objekte und ihrer
+  Werte zurückgegeben.
+  </simpara>
+  <variablelist>
+  <varlistentry>
+   <term><parameter>objectId</parameter></term>
+   <listitem>
+    <simpara>
+     Das <acronym>SNMP</acronym>-Objekt (OID) oder die Objekte
+    </simpara>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt die angeforderten <acronym>SNMP</acronym>-Objekte als Zeichenkette oder Array
+   zurück, abhängig vom Typ der <parameter>objectId</parameter>, oder &false; im Fehlerfall.
+  </simpara>
+ </refsect1>
+
+ &snmp.methods.exceptions_enable.refsect;
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="snmp.getnext.example.singleoid">
+   <title>Einzelnes <acronym>SNMP</acronym>-Objekt</title>
+   <simpara>
+     Ein einzelnes <acronym>SNMP</acronym>-Objekt kann auf zwei Arten angefordert werden: als
+     Zeichenkette, was einen Rückgabewert vom Typ Zeichenkette ergibt, oder als einelementiges Array
+     mit einem assoziativen Array als Ausgabe.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
+  $nsysdescr = $session->getnext("sysDescr.0");
+  echo "$nsysdescr\n";
+  $nsysdescr = $session->getnext(array("sysDescr.0"));
+  print_r($nsysdescr);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+OID: NET-SNMP-MIB::netSnmpAgentOIDs.8
+Array
+(
+    [SNMPv2-MIB::sysObjectID.0] => OID: NET-SNMP-MIB::netSnmpAgentOIDs.8
+)
+]]>
+   </screen>
+  </example>
+  <example xml:id="snmp.getnext.example.oidarray">
+   <title>Mehrere <acronym>SNMP</acronym>-Objekte</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
+  $results = $session->getnext(array("sysDescr.0", "sysName.0"));
+  print_r($results);
+  $session->close();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [SNMPv2-MIB::sysObjectID.0] => OID: NET-SNMP-MIB::netSnmpAgentOIDs.8
+    [SNMPv2-MIB::sysLocation.0] => STRING: Nowhere
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SNMP::getErrno</methodname></member>
+   <member><methodname>SNMP::getError</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/snmp/snmp/walk.xml
+++ b/reference/snmp/snmp/walk.xml
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="snmp.walk">
+ <refnamediv>
+  <refname>SNMP::walk</refname>
+  <refpurpose>Liest einen <acronym>SNMP</acronym>-Objektteilbaum</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+
+  <methodsynopsis role="SNMP">
+   <modifier>public</modifier> <type class="union"><type>array</type><type>false</type></type><methodname>SNMP::walk</methodname>
+   <methodparam><type class="union"><type>array</type><type>string</type></type><parameter>objectId</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>suffixAsKey</parameter><initializer>&false;</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>maxRepetitions</parameter><initializer>-1</initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>nonRepeaters</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <methodname>SNMP::walk</methodname> wird verwendet, um den <acronym>SNMP</acronym>-Teilbaum zu lesen, dessen Wurzel die angegebene <parameter>objectId</parameter> ist.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>objectId</parameter></term>
+    <listitem>
+     <simpara>
+      Wurzel des zu lesenden Teilbaums
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>suffixAsKey</parameter></term>
+    <listitem>
+     <simpara>
+      Standardmäßig wird die vollständige OID-Notation für die Schlüssel im Ausgabe-Array verwendet.
+      Ist dieser Parameter auf &true; gesetzt, wird der Teilbaum-Präfix aus den Schlüsseln entfernt, sodass nur das Suffix der object_id übrig bleibt.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>nonRepeaters</parameter></term>
+    <listitem>
+     <simpara>
+      Dies gibt die Anzahl der übergebenen Variablen an, über die nicht iteriert werden soll.
+      Standardmäßig wird dieser Wert aus dem <acronym>SNMP</acronym>-Objekt verwendet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>maxRepetitions</parameter></term>
+    <listitem>
+     <simpara>
+       Dies gibt die maximale Anzahl der Iterationen über die sich wiederholenden Variablen an.
+       Standardmäßig wird dieser Wert aus dem <acronym>SNMP</acronym>-Objekt verwendet.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg ein assoziatives Array der Object IDs (OIDs) der <acronym>SNMP</acronym>-Objekte und ihrer Werte zurück oder &false; im Fehlerfall.
+   Tritt ein <acronym>SNMP</acronym>-Fehler auf, können <methodname>SNMP::getErrno</methodname> und
+   <methodname>SNMP::getError</methodname> verwendet werden, um die Fehlernummer
+   (spezifisch für die SNMP-Erweiterung, siehe die Klassenkonstanten) beziehungsweise die
+   Fehlermeldung abzurufen.
+  </simpara>
+ </refsect1>
+
+ &snmp.methods.exceptions_enable.refsect;
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example xml:id="snmp.walk.example.basic">
+   <title>Beispiel für <methodname>SNMP::walk</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
+  $fulltree = $session->walk(".");
+  print_r($fulltree);
+  $session->close();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [SNMPv2-MIB::sysDescr.0] => STRING: Test server
+    [SNMPv2-MIB::sysObjectID.0] => OID: NET-SNMP-MIB::netSnmpAgentOIDs.8
+    [DISMAN-EVENT-MIB::sysUpTimeInstance] => Timeticks: (1150681750) 133 days, 4:20:17.50
+    [SNMPv2-MIB::sysContact.0] => STRING: Nobody
+    [SNMPv2-MIB::sysName.0] => STRING: server.localdomain
+    ...
+)
+]]>
+   </screen>
+  </example>
+  <example xml:id="snmp.walk.example.suffix-as-key">
+   <title>Beispiel für <parameter>suffixAsKey</parameter></title>
+   <simpara>
+     <parameter>suffixAsKey</parameter> kann verwendet werden, wenn mehrere <acronym>SNMP</acronym>-Teilbäume zu einem zusammengeführt werden.
+     Dieses Beispiel ordnet Schnittstellennamen ihrem Typ zu.
+   </simpara>
+   <programlisting role="php">
+<![CDATA[
+<?php
+  $session = new SNMP(SNMP::VERSION_1, "127.0.0.1", "public");
+  $session->valueretrieval = SNMP_VALUE_PLAIN;
+  $ifDescr = $session->walk(".1.3.6.1.2.1.2.2.1.2", TRUE);
+  $session->valueretrieval = SNMP_VALUE_LIBRARY;
+  $ifType = $session->walk(".1.3.6.1.2.1.2.2.1.3", TRUE);
+  print_r($ifDescr);
+  print_r($ifType);
+  $result = array();
+  foreach($ifDescr as $i => $n) {
+    $result[$n] = $ifType[$i];
+  }
+  print_r($result);
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Array
+(
+    [1] => igb0
+    [2] => igb1
+    [3] => ipfw0
+    [4] => lo0
+    [5] => lagg0
+)
+Array
+(
+    [1] => INTEGER: ieee8023adLag(161)
+    [2] => INTEGER: ieee8023adLag(161)
+    [3] => INTEGER: ethernetCsmacd(6)
+    [4] => INTEGER: softwareLoopback(24)
+    [5] => INTEGER: ethernetCsmacd(6)
+)
+Array
+(
+    [igb0] => INTEGER: ieee8023adLag(161)
+    [igb1] => INTEGER: ieee8023adLag(161)
+    [ipfw0] => INTEGER: ethernetCsmacd(6)
+    [lo0] => INTEGER: softwareLoopback(24)
+    [lagg0] => INTEGER: ethernetCsmacd(6)
+)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>SNMP::getErrno</methodname></member>
+   <member><methodname>SNMP::getError</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt neue (zuvor nicht übersetzte) Dateien (snmp) ins Deutsche, auf dem Stand des aktuellen EN-Texts (3 Datei(en)). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #235 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").