### PR TITLE
[Sync EN] intl: German translation of new files

### DIFF
--- a/reference/intl/intlcalendar/getavailablelocales.xml
+++ b/reference/intl/intlcalendar/getavailablelocales.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="intlcalendar.getavailablelocales" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getAvailableLocales</refname>
+  <refpurpose>Liefert ein Array der Locales, für die Daten vorhanden sind</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <modifier>static</modifier> <type>array</type><methodname>IntlCalendar::getAvailableLocales</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type>array</type><methodname>intlcal_get_available_locales</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Liefert die Liste der Locales, für die Kalender installiert sind. Ab ICU 51
+   ist dies die Liste aller installierten ICU-Locales.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Ein <type>array</type> von <type>string</type>s, eines für jede Locale.
+  </simpara>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getAvailableLocales</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(IntlCalendar::getAvailableLocales());
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => af
+    [1] => af_NA
+    [2] => af_ZA
+    [3] => agq
+    [4] => agq_CM
+    [5] => ak
+    [6] => ak_GH
+    [7] => am
+    [8] => am_ET
+    [9] => ar
+    [10] => ar_001
+    [11] => ar_AE
+    [12] => ar_BH
+    [13] => ar_DJ
+    … output abbreviated …
+    [595] => zh_Hant_HK
+    [596] => zh_Hant_MO
+    [597] => zh_Hant_TW
+    [598] => zu
+    [599] => zu_ZA
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getkeywordvaluesforlocale.xml
+++ b/reference/intl/intlcalendar/getkeywordvaluesforlocale.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="intlcalendar.getkeywordvaluesforlocale" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getKeywordValuesForLocale</refname>
+  <refpurpose>Liefert die Menge der Schlüsselwortwerte einer Locale</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <modifier>static</modifier> <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>IntlCalendar::getKeywordValuesForLocale</methodname>
+   <methodparam><type>string</type><parameter>keyword</parameter></methodparam>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>onlyCommon</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>IntlIterator</type><type>false</type></type><methodname>intlcal_get_keyword_values_for_locale</methodname>
+   <methodparam><type>string</type><parameter>keyword</parameter></methodparam>
+   <methodparam><type>string</type><parameter>locale</parameter></methodparam>
+   <methodparam><type>bool</type><parameter>onlyCommon</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Liefert für einen gegebenen Locale-Schlüssel die Menge der Werte für diesen
+   Schlüssel, die zu einem unterschiedlichen Verhalten führen würden. Derzeit
+   wird nur das Schlüsselwort <literal>'calendar'</literal> unterstützt.
+  </para>
+  <para>
+   Diese Funktion erfordert ICU 4.2 oder höher.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>keyword</parameter></term>
+    <listitem>
+     <para>
+      Das Locale-Schlüsselwort, für das die relevanten Werte abgefragt werden
+      sollen. Es wird nur <literal>'calendar'</literal> unterstützt.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>locale</parameter></term>
+    <listitem>
+     <para>
+      Die Locale, an die das Schlüsselwort/Wert-Paar angehängt werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>onlyCommon</parameter></term>
+    <listitem>
+     <para>
+      Ob nur die für die angegebene Locale üblicherweise verwendeten Werte
+      angezeigt werden sollen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Ein Iterator, der Zeichenketten mit den Werten des
+   Locale-Schlüsselworts liefert&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title><function>IntlCalendar::getKeywordValuesForLocale</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(
+        iterator_to_array(
+                IntlCalendar::getKeywordValuesForLocale(
+                        'calendar', 'fa_IR', true)));
+print_r(
+        iterator_to_array(
+                IntlCalendar::getKeywordValuesForLocale(
+                        'calendar', 'fa_IR', false)));
+
+
+
+
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Array
+(
+    [0] => persian
+    [1] => gregorian
+    [2] => islamic
+    [3] => islamic-civil
+)
+Array
+(
+    [0] => persian
+    [1] => gregorian
+    [2] => islamic
+    [3] => islamic-civil
+    [4] => japanese
+    [5] => buddhist
+    [6] => roc
+    [7] => hebrew
+    [8] => chinese
+    [9] => indian
+    [10] => coptic
+    [11] => ethiopic
+    [12] => ethiopic-amete-alem
+)
+
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/intlcalendar/getleastmaximum.xml
+++ b/reference/intl/intlcalendar/getleastmaximum.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="intlcalendar.getleastmaximum" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlCalendar::getLeastMaximum</refname>
+  <refpurpose>Liefert das kleinste lokale Maximum für ein Feld</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>
+   &style.oop;
+  </para>
+  <methodsynopsis role="IntlCalendar">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>false</type></type><methodname>IntlCalendar::getLeastMaximum</methodname>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   &style.procedural;
+  </para>
+  <methodsynopsis>
+   <type class="union"><type>int</type><type>false</type></type><methodname>intlcal_get_least_maximum</methodname>
+   <methodparam><type>IntlCalendar</type><parameter>calendar</parameter></methodparam>
+   <methodparam><type>int</type><parameter>field</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Liefert das kleinste lokale Maximum für ein Feld. Dies sollte ein Wert sein,
+   der kleiner oder gleich dem von
+   <function>IntlCalendar::getActualMaximum</function> zurückgegebenen Wert ist,
+   welcher wiederum kleiner oder gleich dem von
+   <function>IntlCalendar::getMaximum</function> zurückgegebenen Wert ist.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>calendar</parameter></term>
+    <listitem>
+     &intl.parameter.intl-calendar;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>field</parameter></term>
+    <listitem>
+     &reference.intl.incfieldparam;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Ein <type>int</type>, der einen Feldwert in der Einheit des Feldes
+   darstellt&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+   <title>Beispiele für Maxima</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+ini_set('date.timezone', 'UTC');
+ini_set('intl.default_locale', 'it_IT');
+
+$cal = new IntlGregorianCalendar(2013, 3 /* April */, 6);
+var_dump(
+    $cal->getLeastMaximum(IntlCalendar::FIELD_DAY_OF_MONTH),  // 28
+    $cal->getActualMaximum(IntlCalendar::FIELD_DAY_OF_MONTH), // 30
+    $cal->getMaximum(IntlCalendar::FIELD_DAY_OF_MONTH)        // 31
+);
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+int(28)
+int(30)
+int(31)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>IntlCalendar::getActualMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getMaximum</methodname></member>
+    <member><methodname>IntlCalendar::getGreatestMinimum</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt neue (zuvor nicht übersetzte) Dateien (intl) ins Deutsche, auf dem Stand des aktuellen EN-Texts (3 Datei(en)). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236, #242 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").