### PR TITLE
[Sync EN] gmp: German translation of new files

### DIFF
--- a/reference/gmp/functions/gmp-add.xml
+++ b/reference/gmp/functions/gmp-add.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.gmp-add" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_add</refname>
+  <refpurpose>Addiert Zahlen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_add</methodname>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num1</parameter></methodparam>
+   <methodparam><type class="union"><type>GMP</type><type>int</type><type>string</type></type><parameter>num2</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Addiert zwei Zahlen.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>num1</parameter></term>
+     <listitem>
+      <simpara>
+       Der erste Summand.
+      </simpara>
+      &gmp.parameter;
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>num2</parameter></term>
+     <listitem>
+      <para>
+       Der zweite Summand.
+      </para>
+      &gmp.parameter;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Eine GMP-Zahl, die die Summe der Argumente darstellt.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>gmp_add</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$sum = gmp_add("123456789012345", "76543210987655");
+echo gmp_strval($sum) . "\n";
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+200000000000000
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gmp/functions/gmp-init.xml
+++ b/reference/gmp/functions/gmp-init.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.gmp-init" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>gmp_init</refname>
+  <refpurpose>Erzeugt eine GMP-Zahl</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_init</methodname>
+   <methodparam><type class="union"><type>int</type><type>string</type></type><parameter>num</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>base</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Erzeugt eine GMP-Zahl aus einer Ganzzahl oder einer Zeichenkette.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>num</parameter></term>
+    <listitem>
+     <simpara>
+      Eine Ganzzahl oder eine Zeichenkette. Die Zeichenkettendarstellung kann
+      dezimal, hexadezimal, oktal oder binär sein.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>base</parameter></term>
+    <listitem>
+     <simpara>
+      Die Basis, die für die Umwandlung einer <type>string</type>-Darstellung
+      verwendet werden soll.
+     </simpara>
+     <simpara>
+      Eine explizite Basis kann zwischen <literal>2</literal> und
+      <literal>62</literal> liegen. Bei Basen bis <literal>36</literal> wird die
+      Groß-/Kleinschreibung ignoriert; Groß- und Kleinbuchstaben haben denselben
+      Wert. Bei den Basen <literal>37</literal> bis <literal>62</literal>
+      stehen Großbuchstaben für die Werte <literal>10</literal> bis
+      <literal>35</literal> und Kleinbuchstaben für die Werte
+      <literal>36</literal> bis <literal>61</literal>.
+     </simpara>
+     <simpara>
+      Ist <parameter>base</parameter> gleich <literal>0</literal>, so wird die
+      tatsächliche Basis anhand der führenden Zeichen von
+      <parameter>num</parameter> bestimmt. Sind die ersten beiden Zeichen
+      <literal>0x</literal> oder <literal>0X</literal>, wird die Zeichenkette als
+      hexadezimale Ganzzahl interpretiert. Sind die ersten beiden Zeichen
+      <literal>0b</literal> oder <literal>0B</literal>, wird die Zeichenkette als
+      binäre Ganzzahl interpretiert. Sind die ersten beiden Zeichen
+      <literal>0o</literal> oder <literal>0O</literal>, wird die Zeichenkette als
+      oktale Ganzzahl interpretiert. Ist außerdem das erste Zeichen
+      <literal>0</literal>, wird die Zeichenkette ebenfalls als oktale Ganzzahl
+      interpretiert. In allen anderen Fällen wird die Zeichenkette als dezimale
+      Ganzzahl interpretiert.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &gmp.return;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>
+       Die Unterstützung für explizite Oktalpräfixe <literal>0o</literal> und
+       <literal>0O</literal> wurde für <parameter>num</parameter>-Zeichenketten
+       hinzugefügt. Die Interpretation solcher Präfixe, wenn
+       <parameter>base</parameter> gleich <literal>0</literal> ist, wurde
+       ebenfalls hinzugefügt.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Erzeugen einer GMP-Zahl</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$a = gmp_init(123456);
+$b = gmp_init("0xFFFFDEBACDFEDF7200");
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="notes">
+  &reftitle.notes;
+  <note>
+   <para>
+    Es ist nicht notwendig, diese Funktion aufzurufen, um Ganzzahlen oder
+    Zeichenketten anstelle von GMP-Zahlen in GMP-Funktionen (wie etwa
+    <function>gmp_add</function>) zu verwenden. Funktionsargumente werden
+    automatisch in GMP-Zahlen umgewandelt, sofern eine solche Umwandlung möglich
+    und nötig ist, wobei dieselben Regeln wie bei
+    <function>gmp_init</function> angewendet werden.
+   </para>
+  </note>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>GMP::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/gmp/functions/gmp-random-bits.xml
+++ b/reference/gmp/functions/gmp-random-bits.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.gmp-random-bits">
+ <refnamediv>
+  <refname>gmp_random_bits</refname>
+  <refpurpose>Zufallszahl</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>GMP</type><methodname>gmp_random_bits</methodname>
+   <methodparam><type>int</type><parameter>bits</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Erzeugt eine Zufallszahl. Die Zahl liegt zwischen
+   <literal>0</literal> und
+   <literal>2<superscript>$bits</superscript> - 1</literal>.
+  </para>
+  <simpara>
+   <parameter>bits</parameter> muss größer als 0 sein,
+   und der maximale Wert wird durch den verfügbaren Speicher begrenzt.
+  </simpara>
+  &caution.cryptographically-insecure;
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>bits</parameter></term>
+     <listitem>
+      <para>
+       Die Anzahl der zu erzeugenden Zufallsbits.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Eine zufällige GMP-Zahl.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Ist <parameter>bits</parameter> kleiner als <literal>1</literal>,
+   wird ein <exceptionname>ValueError</exceptionname> geworfen.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>gmp_random_bits</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$rand1 = gmp_random_bits(3); // Zufallszahl von 0 bis 7
+$rand2 = gmp_random_bits(5); // Zufallszahl von 0 bis 31
+
+echo gmp_strval($rand1) . "\n";
+echo gmp_strval($rand2) . "\n";
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+3
+15
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt neue (zuvor nicht übersetzte) Dateien (gmp) ins Deutsche, auf dem Stand des aktuellen EN-Texts (3 Datei(en)). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").