### PR TITLE
[Sync EN] eio: German translation of new files

### DIFF
--- a/reference/eio/functions/eio-fallocate.xml
+++ b/reference/eio/functions/eio-fallocate.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-fallocate">
+ <refnamediv>
+  <refname>eio_fallocate</refname>
+  <refpurpose>Ermöglicht es dem Aufrufer, den für eine Datei allozierten
+  Plattenspeicher direkt zu manipulieren</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_fallocate</methodname>
+   <methodparam><type>mixed</type><parameter>fd</parameter></methodparam>
+   <methodparam><type>int</type><parameter>mode</parameter></methodparam>
+   <methodparam><type>int</type><parameter>offset</parameter></methodparam>
+   <methodparam><type>int</type><parameter>length</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>pri</parameter><initializer>EIO_PRI_DEFAULT</initializer></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter><initializer>NULL</initializer></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+
+  </methodsynopsis>
+
+  <simpara>
+  <function>eio_fallocate</function> ermöglicht es dem Aufrufer, den allozierten
+  Plattenspeicher für die durch den Dateideskriptor <parameter>fd</parameter>
+  angegebene Datei für den Bytebereich, der bei <parameter>offset</parameter>
+  beginnt und sich über <parameter>length</parameter> Bytes erstreckt, direkt
+  zu manipulieren.
+  </simpara>
+
+  <note xmlns="http://docbook.org/ns/docbook">
+  <title>Die Datei sollte zum Schreiben geöffnet sein</title>
+  <simpara><constant>EIO_O_CREAT</constant> sollte logisch mit
+      <constant>EIO_O_WRONLY</constant> oder <constant>EIO_O_RDWR</constant>
+      <emphasis>ODER</emphasis>-verknüpft werden
+  </simpara>
+  </note>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fd</parameter></term>
+    <listitem>
+     <simpara>
+     Eine Stream-Ressource, eine Socket-Ressource oder ein numerischer
+     Dateideskriptor, z. B. zurückgegeben von <function>eio_open</function>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+     <simpara>Derzeit wird für mode nur ein einziges Flag unterstützt:
+     <constant>EIO_FALLOC_FL_KEEP_SIZE</constant> (dasselbe wie die
+       POSIX-Konstante <constant>FALLOC_FL_KEEP_SIZE</constant>).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+     Gibt den Beginn des Bytebereichs an.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>length</parameter></term>
+    <listitem>
+     <simpara>
+     Gibt die Länge des Bytebereichs an.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pri</parameter></term>
+    <listitem>
+    &eio.request.pri.values;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     &eio.callback.proto;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+     Eine beliebige Variable, die an <parameter>callback</parameter> übergeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_fallocate</function> gibt bei Erfolg eine Anfrage-Ressource zurück,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-open.xml
+++ b/reference/eio/functions/eio-open.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-open">
+ <refnamediv>
+  <refname>eio_open</refname>
+  <refpurpose>Öffnet eine Datei</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>eio_open</methodname>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+   <methodparam><type>int</type><parameter>flags</parameter></methodparam>
+   <methodparam><type>int</type><parameter>mode</parameter></methodparam>
+   <methodparam><type>int</type><parameter>pri</parameter></methodparam>
+   <methodparam><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam choice="opt"><type>mixed</type><parameter>data</parameter><initializer>NULL</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+  <function>eio_open</function> öffnet die durch <parameter>path</parameter>
+  angegebene Datei im Zugriffsmodus <parameter>mode</parameter> mit den
+  angegebenen <parameter>flags</parameter>.
+  </simpara>
+
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>path</parameter></term>
+    <listitem>
+     <para>
+     Der Pfad der zu öffnenden Datei.
+     <warning><simpara>
+     In einigen SAPIs (z. B. <emphasis>PHP-FPM</emphasis>) kann dies
+     fehlschlagen, wenn kein vollständiger Pfad angegeben wird.
+     </simpara></warning>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>flags</parameter></term>
+    <listitem>
+    <simpara>Eine der <emphasis>EIO_O_*</emphasis>-Konstanten oder eine
+    Kombination daraus. Die <emphasis>EIO_O_*</emphasis>-Konstanten haben
+    dieselbe Bedeutung wie ihre entsprechenden <emphasis>O_*</emphasis>-Pendants,
+    die in der C-Headerdatei <literal>fnctl.h</literal> definiert sind.
+    Der Standardwert ist <constant>EIO_O_RDWR</constant>.
+    </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>mode</parameter></term>
+    <listitem>
+    <simpara>Eine der <emphasis>EIO_S_I*</emphasis>-Konstanten oder eine
+    Kombination daraus (über den bitweisen ODER-Operator). Die Konstanten haben
+    dieselbe Bedeutung wie ihre <emphasis>S_I*</emphasis>-Pendants, die in der
+    C-Headerdatei <link xlink:href="&url.sys.stat.header;">sys/stat.h</link>
+    definiert sind. Erforderlich, wenn eine Datei erstellt wird. Andernfalls
+    wird der Wert ignoriert.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>pri</parameter></term>
+    <listitem>
+    &eio.request.pri.values;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     &eio.callback.proto;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>data</parameter></term>
+    <listitem>
+     <simpara>
+      Eine beliebige Variable, die an <parameter>callback</parameter> übergeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   <function>eio_open</function> gibt bei Erfolg den Dateideskriptor im
+   Argument <parameter>result</parameter> von <parameter>callback</parameter>
+   zurück; andernfalls ist <parameter>result</parameter> gleich <constant>-1</constant>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>eio_open</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$temp_filename = "eio-temp-file.tmp";
+
+/* Wird aufgerufen, wenn eio_close() beendet wird */
+function my_close_cb($data, $result) {
+ // Null zeigt Erfolg an
+    var_dump($result == 0);
+ @unlink($data);
+}
+
+/* Wird aufgerufen, wenn eio_open() beendet wird */
+function my_file_opened_callback($data, $result) {
+ // $result sollte den Dateideskriptor enthalten
+    var_dump($result > 0);
+
+    if ($result > 0) {
+  // Die Datei schließen
+        eio_close($result, EIO_PRI_DEFAULT, "my_close_cb", $data);
+        eio_event_loop();
+    }
+}
+
+// Eine neue Datei zum Lesen und Schreiben erstellen
+// Gruppe und anderen jeglichen Zugriff auf diese Datei verweigern
+eio_open($temp_filename, EIO_O_CREAT | EIO_O_RDWR, EIO_S_IRUSR | EIO_S_IWUSR,
+  EIO_PRI_DEFAULT, "my_file_opened_callback", $temp_filename);
+eio_event_loop();
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+bool(true)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_mknod</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/eio/functions/eio-poll.xml
+++ b/reference/eio/functions/eio-poll.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.eio-poll">
+ <refnamediv>
+  <refname>eio_poll</refname>
+  <refpurpose>Kann immer dann aufgerufen werden, wenn ausstehende Anfragen vorliegen, die abgeschlossen werden müssen</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>eio_poll</methodname>
+   <void/>
+  </methodsynopsis>
+  <simpara>
+  <function>eio_poll</function> kann verwendet werden, um eine spezielle
+  Ereignisschleife zu implementieren. Dafür kann <function>eio_nreqs</function>
+  verwendet werden, um zu prüfen, ob unbearbeitete Anfragen vorliegen.
+  </simpara>
+
+  <note><simpara>Nur anwendbar, wenn eine Ereignisschleife im Userspace implementiert wird.</simpara></note>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+  Wenn ein Anfrageaufruf einen Wert ungleich null zurückgibt, wird dieser Wert
+  zurückgegeben. Andernfalls wird <literal>0</literal> zurückgegeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>eio_poll</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function res_cb($data, $result) {
+    var_dump($data);
+    var_dump($result);
+}
+
+eio_nop(EIO_PRI_DEFAULT, "res_cb", "1");
+eio_nop(EIO_PRI_DEFAULT, "res_cb", "2");
+eio_nop(EIO_PRI_DEFAULT, "res_cb", "3");
+
+while (eio_nreqs()) {
+    // Eine spezifische IPC oder Ähnliches
+    eio_poll();
+}
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+string(1) "1"
+int(0)
+string(1) "3"
+int(0)
+string(1) "2"
+int(0)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>eio_nreqs</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt neue (zuvor nicht übersetzte) Dateien (eio) ins Deutsche, auf dem Stand des aktuellen EN-Texts (3 Datei(en)). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").