### PR TITLE
[Sync EN] cubrid: German translation of new files

### DIFF
--- a/reference/cubrid/constants.xml
+++ b/reference/cubrid/constants.xml
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<appendix xml:id="cubrid.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ &reftitle.constants;
+ &extension.constants;
+  <para>
+  Die folgenden Konstanten können beim Ausführen einer SQL-Anweisung verwendet
+  werden. Sie können an <function>cubrid_prepare</function> und
+  <function>cubrid_execute</function> übergeben werden.
+  <table>
+   <title>CUBRID-Flags für die SQL-Ausführung</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_INCLUDE_OID</constant></entry>
+       <entry>Legt fest, ob während der Abfrageausführung die OID ermittelt werden soll.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_ASYNC</constant></entry>
+       <entry>Führt die Abfrage im asynchronen Modus aus.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_EXEC_QUERY_ALL</constant></entry>
+       <entry>Führt die Abfrage im synchronen Modus aus. Dieses Flag muss
+        gesetzt werden, wenn mehrere SQL-Anweisungen ausgeführt werden.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+  Die folgenden Konstanten können beim Abrufen der Ergebnisse verwendet werden,
+  um das Abrufverhalten festzulegen. Sie können an
+  <function>cubrid_fetch</function> und
+  <function>cubrid_fetch_array</function> übergeben werden.
+  <table>
+   <title>CUBRID-Flags für das Abrufen</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_NUM</constant></entry>
+       <entry>Ruft das Abfrageergebnis als numerisches Array ab (0-Standard).</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_ASSOC</constant></entry>
+       <entry>Ruft das Abfrageergebnis als assoziatives Array ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_BOTH</constant></entry>
+       <entry>Ruft das Abfrageergebnis sowohl als numerisches als auch als assoziatives Array ab (Standardwert).</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_OBJECT</constant></entry>
+       <entry>Ruft das Abfrageergebnis als Objekt ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_LOB</constant></entry>
+       <entry>Die Konstante CUBRID_LOB kann verwendet werden, wenn Sie mit dem
+        LOB-Objekt arbeiten möchten. Sie kann an
+        <function>cubrid_fetch</function>,
+        <function>cubrid_fetch_row</function>,
+        <function>cubrid_fetch_array</function>,
+        <function>cubrid_fetch_assoc</function> und
+        <function>cubrid_fetch_object</function> übergeben werden.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Positionieren des Cursors in
+   Abfrageergebnissen verwendet werden. Sie können an
+   <function>cubrid_move_cursor</function> übergeben oder von dieser Funktion
+   zurückgegeben werden.
+  <table>
+   <title>CUBRID-Flags für die Cursorposition</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_CURSOR_FIRST</constant></entry>
+       <entry>Bewegt den aktuellen Cursor an die erste Position im Ergebnis.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_CURSOR_CURRENT</constant></entry>
+       <entry>Bewegt den aktuellen Cursor als Standardwert, wenn der Ursprung nicht angegeben ist.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_CURSOR_LAST</constant></entry>
+       <entry>Bewegt den aktuellen Cursor an die letzte Position im Ergebnis.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_CURSOR_SUCCESS</constant></entry>
+       <entry>Rückgabewert der Funktion <function>cubrid_move_cursor</function>
+        im Erfolgsfall. Dieses Flag wurde ab 8.4.1 entfernt.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_NO_MORE_DATA</constant></entry>
+       <entry>Rückgabewert der Funktion <function>cubrid_move_cursor</function>
+        im Fehlerfall. Dieses Flag wurde ab 8.4.1 entfernt.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_CURSOR_ERROR</constant></entry>
+       <entry>Rückgabewert der Funktion <function>cubrid_move_cursor</function>
+        im Fehlerfall. Dieses Flag wurde ab 8.4.1 entfernt.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Festlegen des Auto-Commit-Modus für die
+   Datenbankverbindung verwendet werden. Sie können an
+   <function>cubrid_set_autocommit</function> übergeben oder von
+   <function>cubrid_get_autocommit</function> zurückgegeben werden.
+  <table>
+   <title>CUBRID-Flags für den Auto-Commit-Modus</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_AUTOCOMMIT_TRUE</constant></entry>
+       <entry>Aktiviert den Auto-Commit-Modus.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_AUTOCOMMIT_FALSE</constant></entry>
+       <entry>Deaktiviert den Auto-Commit-Modus.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Festlegen des Datenbankparameters
+   verwendet werden. Sie können an
+   <function>cubrid_set_db_parameter</function> übergeben werden.
+  <table>
+   <title>CUBRID-Parameter-Flags</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_PARAM_ISOLATION_LEVEL</constant></entry>
+       <entry>Transaktionsisolationsgrad für die Datenbankverbindung.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_PARAM_LOCK_TIMEOUT</constant></entry>
+       <entry>Transaktions-Timeout in Sekunden.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Festlegen des
+   Transaktionsisolationsgrads verwendet werden. Sie können an
+   <function>cubrid_set_db_parameter</function> übergeben oder von
+   <function>cubrid_get_db_parameter</function> zurückgegeben werden.
+  <table>
+   <title>CUBRID-Flags für den Isolationsgrad</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>TRAN_COMMIT_CLASS_UNCOMMIT_INSTANCE</constant></entry>
+       <entry>Der niedrigste Isolationsgrad (1). Für das Tupel kann ein Dirty
+        Read, Non-Repeatable Read oder Phantom Read auftreten, und für die
+        Tabelle kann ebenfalls ein Non-Repeatable Read auftreten.</entry>
+      </row>
+      <row>
+       <entry><constant>TRAN_COMMIT_CLASS_COMMIT_INSTANCE</constant></entry>
+       <entry>Ein relativ niedriger Isolationsgrad (2). Ein Dirty Read tritt
+        nicht auf, aber ein Non-Repeatable Read oder Phantom Read kann
+        auftreten.</entry>
+      </row>
+      <row>
+       <entry><constant>TRAN_REP_CLASS_UNCOMMIT_INSTANCE</constant></entry>
+       <entry>Die Standardisolation von CUBRID (3). Für das Tupel kann ein
+        Dirty Read, Non-Repeatable Read oder Phantom Read auftreten, aber für
+        die Tabelle ist ein Repeatable Read gewährleistet.</entry>
+      </row>
+      <row>
+       <entry><constant>TRAN_REP_CLASS_COMMIT_INSTANCE</constant></entry>
+       <entry>Ein relativ niedriger Isolationsgrad (4). Ein Dirty Read tritt
+        nicht auf, aber ein Non-Repeatable Read oder Phantom Read kann.</entry>
+      </row>
+      <row>
+       <entry><constant>TRAN_REP_CLASS_REP_INSTANCE</constant></entry>
+       <entry>Ein relativ hoher Isolationsgrad (5). Ein Dirty Read oder
+       Non-Repeatable Read tritt nicht auf, aber ein Phantom Read kann.</entry>
+      </row>
+      <row>
+       <entry><constant>TRAN_SERIALIZABLE</constant></entry>
+       <entry>Der höchste Isolationsgrad (6). Probleme im Zusammenhang mit der
+       Nebenläufigkeit (z. B. Dirty Read, Non-Repeatable Read, Phantom Read
+       usw.) treten nicht auf.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Abrufen von Schemainformationen
+   verwendet werden. Sie können an <function>cubrid_schema</function> übergeben
+   werden.
+  <table>
+   <title>CUBRID-Schema-Flags</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_SCH_CLASS</constant></entry>
+       <entry>Ruft den Namen und Typ einer Tabelle in CUBRID ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_VCLASS</constant></entry>
+       <entry>Ruft den Namen und Typ einer Sicht in CUBRID ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_QUERY_SPEC</constant></entry>
+       <entry>Ruft die Abfragedefinition einer Sicht ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_ATTRIBUTE</constant></entry>
+       <entry>Ruft die Attribute einer Tabellenspalte ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_CLASS_ATTRIBUTE</constant></entry>
+       <entry>Ruft die Attribute einer Tabelle ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_METHOD</constant></entry>
+       <entry>Ruft die Instanzmethode ab. Die Instanzmethode ist eine Methode,
+       die von einer Klasseninstanz aufgerufen wird. Sie wird häufiger
+       verwendet als die Klassenmethode, da die meisten Operationen in der
+       Instanz ausgeführt werden.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_CLASS_METHOD</constant></entry>
+       <entry>Ruft die Klassenmethode ab. Die Klassenmethode ist eine Methode,
+        die von einem Klassenobjekt aufgerufen wird. Sie wird üblicherweise
+        verwendet, um eine neue Klasseninstanz zu erstellen oder zu
+        initialisieren. Sie wird auch verwendet, um auf Klassenattribute
+        zuzugreifen oder diese zu aktualisieren.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_METHOD_FILE</constant></entry>
+       <entry>Ruft die Informationen der Datei ab, in der die Methode der
+        Tabelle definiert ist.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_SUPERCLASS</constant></entry>
+       <entry>Ruft den Namen und Typ der Tabelle ab, von der eine Tabelle
+        Attribute erbt.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_SUBCLASS</constant></entry>
+       <entry>Ruft den Namen und Typ der Tabelle ab, die Attribute von dieser
+        Tabelle erbt.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_CONSTRAINT</constant></entry>
+       <entry>Ruft die Tabellenbeschränkungen ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_TRIGGER</constant></entry>
+       <entry>Ruft die Tabellentrigger ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_CLASS_PRIVILEGE</constant></entry>
+       <entry>Ruft die Berechtigungsinformationen einer Tabelle ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_ATTR_PRIVILEGE</constant></entry>
+       <entry>Ruft die Berechtigungsinformationen einer Spalte ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_DIRECT_SUPER_CLASS</constant></entry>
+       <entry>Ruft die direkte übergeordnete Tabelle einer Tabelle ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_PRIMARY_KEY</constant></entry>
+       <entry>Ruft den Primärschlüssel einer Tabelle ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_IMPORTED_KEYS</constant></entry>
+       <entry>Ruft die importierten Schlüssel einer Tabelle ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_EXPORTED_KEYS</constant></entry>
+       <entry>Ruft die exportierten Schlüssel einer Tabelle ab.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_SCH_CROSS_REFERENCE</constant></entry>
+       <entry>Ruft die Referenzbeziehung zweier Tabellen ab.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+  Die folgenden Konstanten können beim Melden von Fehlern verwendet werden. Sie
+  können von <function>cubrid_error_code_facility</function> zurückgegeben
+  werden.
+  <table>
+   <title>CUBRID-Fehlerquellencode</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><constant>CUBRID_FACILITY_DBMS</constant></entry>
+       <entry>Der Fehler ist im CUBRID-DBMS aufgetreten.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_FACILITY_CAS</constant></entry>
+       <entry>Der Fehler ist im CUBRID-Broker-CAS aufgetreten.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_FACILITY_CCI</constant></entry>
+       <entry>Der Fehler ist im CUBRID-CCI aufgetreten.</entry>
+      </row>
+      <row>
+       <entry><constant>CUBRID_FACILITY_CLIENT</constant></entry>
+       <entry>Der Fehler ist im CUBRID-PHP-Client aufgetreten.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+</appendix>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cubrid/functions/cubrid-connect-with-url.xml
+++ b/reference/cubrid/functions/cubrid-connect-with-url.xml
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="function.cubrid-connect-with-url">
+ <refnamediv>
+  <refname>cubrid_connect_with_url</refname>
+  <refpurpose>Bereitet die Umgebung für die Verbindung zu einem CUBRID-Server vor</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>cubrid_connect_with_url</methodname>
+   <methodparam><type>string</type><parameter>conn_url</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>userid</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>passwd</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>new_link</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Die Funktion <function>cubrid_connect_with_url</function> wird verwendet, um
+   die Umgebung für die Verbindung zu Ihrem Server vorzubereiten, wobei die
+   Verbindungsinformationen über ein URL-Zeichenkettenargument übergeben
+   werden. Wenn in CUBRID die HA-Funktion aktiviert ist, müssen Sie die
+   Verbindungsinformationen des Standby-Servers, der bei einem Ausfall für das
+   Failover verwendet wird, im URL-Zeichenkettenargument dieser Funktion
+   angeben. Wenn kein Benutzername und kein Passwort angegeben werden, wird
+   standardmäßig die Verbindung "PUBLIC" hergestellt.
+  </simpara>
+  <simpara>
+   &lt;url&gt; ::= CUBRID:&lt;host&gt;:&lt;db_name&gt;:&lt;db_user&gt;:&lt;db_password&gt;:[?&lt;properties&gt;]
+  </simpara>
+  <simpara>
+   &lt;properties&gt; ::= &lt;property&gt; [&amp;&lt;property&gt;]
+  </simpara>
+  <simpara>
+   &lt;properties&gt; ::= alhosts=&lt;alternative_hosts&gt;[ &amp;rctime=&lt;time&gt;]
+  </simpara>
+  <simpara>
+   &lt;properties&gt; ::= login_timeout=&lt;milli_sec&gt;
+  </simpara>
+  <simpara>
+   &lt;properties&gt; ::= query_timeout=&lt;milli_sec&gt;
+  </simpara>
+  <simpara>
+   &lt;properties&gt; ::= disconnect_on_query_timeout=true|false
+  </simpara>
+  <simpara>
+   &lt;alternative_hosts&gt; ::= &lt;standby_broker1_host&gt;:&lt;port&gt; [,&lt;standby_broker2_host&gt;:&lt;port&gt;]
+  </simpara>
+  <simpara>
+   &lt;host&gt; := HOSTNAME | IP_ADDR
+  </simpara>
+  <simpara>
+   &lt;time&gt; := SECOND
+  </simpara>
+  <simpara>
+   &lt;milli_sec&gt; := MILLI SECOND
+  </simpara>
+  <simplelist>
+   <member>host : Ein Hostname oder eine IP-Adresse der Master-Datenbank</member>
+   <member>db_name : Ein Name der Datenbank</member>
+   <member>db_user : Ein Name des Datenbankbenutzers</member>
+   <member>db_password : Ein Passwort des Datenbankbenutzers</member>
+   <member>
+    alhosts : Gibt die Broker-Informationen des Standby-Servers an, der für das
+    Failover verwendet wird, wenn keine Verbindung zum aktiven Server möglich
+    ist. Sie können mehrere Broker für das Failover angeben, und die Verbindung
+    zu den Brokern wird in der in alhosts aufgeführten Reihenfolge
+    versucht</member>
+   <member>
+    rctime : Ein Intervall zwischen den Versuchen, eine Verbindung zu dem
+    aktiven Broker herzustellen, bei dem der Ausfall aufgetreten ist. Nach
+    einem Ausfall verbindet sich das System mit dem durch althosts angegebenen
+    Broker (Failover), beendet die Transaktion und versucht dann bei jedem
+    rctime, sich mit dem aktiven Broker der Master-Datenbank zu verbinden. Der
+    Standardwert beträgt 600 Sekunden.</member>
+   <member>
+    login_timeout : Timeout-Wert (Einheit: Millisekunden) für die
+    Datenbankanmeldung. Der Standardwert ist 0, was eine unendliche
+    Verzögerung bedeutet.
+   </member>
+   <member>
+    query_timeout : Timeout-Wert (Einheit: Millisekunden) für eine
+    Abfrageanforderung. Bei Zeitüberschreitung wird eine Nachricht zum
+    Abbrechen der angeforderten Abfrage an den Server gesendet. Der
+    Rückgabewert kann von der Konfiguration disconnect_on_query_timeout
+    abhängen; auch wenn die Nachricht zum Abbrechen einer Anforderung an den
+    Server gesendet wird, kann diese Anforderung erfolgreich sein.
+   </member>
+   <member>
+    disconnect_on_query_timeout : Konfiguriert einen Wert, der angibt, ob bei
+    einer Zeitüberschreitung sofort ein Fehler der ausgeführten Funktion
+    zurückgegeben werden soll. Der Standardwert ist false.
+   </member>
+  </simplelist>
+  <note>
+   <simpara>
+    <literal>?</literal> und <literal>:</literal>, die in der
+    PHP-Verbindungs-URL als Bezeichner verwendet werden, dürfen nicht im
+    Passwort enthalten sein. Das Folgende ist ein Beispiel für ein Passwort,
+    das nicht als Verbindungs-URL verwendet werden kann, da es
+    "<literal>?:</literal>" enthält.
+   </simpara>
+   <simpara>
+    $url = "CUBRID:localhost:33000:tdb:dba:12?:?login_timeout=100";
+   </simpara>
+   <simpara>
+    Passwörter, die <literal>?</literal> oder <literal>:</literal> enthalten,
+    können als separater Parameter übergeben werden.
+   </simpara>
+   <simpara>
+    $url = "CUBRID:localhost:33000:tbd:::?login_timeout=100";
+   </simpara>
+   <simpara>
+    $conn = cubrid_connect_with_url($url, "dba", "12?");
+   </simpara>
+   <simpara>
+    Wenn der Benutzer oder das Passwort leer ist, dürfen Sie
+    "<literal>:</literal>" nicht entfernen; das Folgende ist ein Beispiel.
+   </simpara>
+   <simpara>
+    $url = "CUBRID:localhost:33000:demodb:::";
+   </simpara>
+  </note>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>conn_url</parameter></term>
+    <listitem><simpara>Eine Zeichenkette, die die Verbindungsinformationen des Servers enthält.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>userid</parameter></term>
+    <listitem><simpara>Benutzername für die Datenbank.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>passwd</parameter></term>
+    <listitem><simpara>Benutzerpasswort.</simpara></listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>new_link</parameter></term>
+    <listitem><simpara>Wenn ein zweiter Aufruf von
+      <function>cubrid_connect_with_url</function> mit denselben Argumenten
+      erfolgt, wird keine neue Verbindung hergestellt, sondern stattdessen die
+      Verbindungskennung der bereits geöffneten Verbindung zurückgegeben. Der
+      Parameter <parameter>new_link</parameter> ändert dieses Verhalten und
+      bewirkt, dass <function>cubrid_connect_with_url</function> immer eine neue
+      Verbindung öffnet, selbst wenn
+      <function>cubrid_connect_with_url</function> zuvor mit denselben
+      Parametern aufgerufen wurde.</simpara></listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Die Verbindungskennung, wenn der Vorgang erfolgreich ist,&return.falseforfailure;.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>cubrid_connect_with_url</function> mit einer URL ohne Eigenschaften</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$conn_url = "CUBRID:localhost:33000:demodb:dba::";
+$con = cubrid_connect_with_url($conn_url);
+
+if ($con) {
+   echo "connected successfully";
+   cubrid_execute($con, "create table person(id int,name char(16))");
+   $req =cubrid_execute($con, "insert into person values(1,'James')");
+
+   if ($req) {
+      cubrid_close_request($req);
+      cubrid_commit($con);
+   } else {
+      cubrid_rollback($con);
+   }
+   cubrid_disconnect($con);
+}
+?>
+]]>
+   </programlisting>
+  </example>
+
+  <example>
+   <title>Beispiel für <function>cubrid_connect_with_url</function> mit einer URL mit Eigenschaften</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$conn_url = "CUBRID:127.0.0.1:33000:demodb:dba::?login_timeout=100";
+$con = cubrid_connect_with_url ($conn_url);
+
+if ($con) {
+   echo "connected successfully";
+   cubrid_execute($con, "create table person(id int,name char(16))");
+   $req =cubrid_execute($con, "insert into person values(1,'James')");
+
+   if ($req) {
+      cubrid_close_request($req);
+      cubrid_commit($con);
+   } else {
+      cubrid_rollback($con);
+   }
+   cubrid_disconnect($con);
+}
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>cubrid_connect</function></member>
+   <member><function>cubrid_pconnect</function></member>
+   <member><function>cubrid_pconnect_with_url</function></member>
+   <member><function>cubrid_disconnect</function></member>
+   <member><function>cubrid_close</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cubrid/setup.xml
+++ b/reference/cubrid/setup.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="cubrid.setup">
+ &reftitle.setup;
+
+ <section xmlns="http://docbook.org/ns/docbook" xml:id="cubrid.requirements">
+ &reftitle.required;
+  <simpara>
+    Damit diese Funktionen verfügbar sind, müssen Sie CUBRID installieren und die CUBRID-PHP-Bibliothek mit CUBRID-Unterstützung kompilieren.
+  </simpara>
+</section>
+
+ &reference.cubrid.configure;
+
+ <section xml:id="cubrid.configuration">
+  &reftitle.runtime;
+  <simpara>
+    Es gibt derzeit keine Laufzeitkonfiguration.
+  </simpara>
+ </section>
+
+ <section xml:id="cubrid.resources">
+  &reftitle.resources;
+  <simpara>
+   In CUBRID werden vier Ressourcentypen verwendet. Der erste ist die
+   Verbindungskennung für eine Datenbankverbindung, der zweite ist die
+   Ressource, die das Ergebnis einer Abfrage enthält, und die letzten beiden
+   sind Ressourcen, die die Abfrageergebnisse der Datentypen BLOB/CLOB
+   enthalten.
+  </simpara>
+  <section xml:id="cubrid.resources.connection-identifier">
+  <title>Verbindungskennung</title>
+   <simpara>
+    Eine Verbindungskennung, die von <function>cubrid_connect</function>,
+    <function>cubrid_connect_with_url</function>,
+    <function>cubrid_pconnect</function> und
+    <function>cubrid_pconnect_with_url</function> zurückgegeben wird.
+   </simpara>
+  </section>
+  <section xml:id="cubrid.resources.request-identifier">
+  <title>Anfragekennung</title>
+   <simpara>
+    Eine Anfragekennung, die von <function>cubrid_prepare</function> und <function>cubrid_execute</function> zurückgegeben wird.
+   </simpara>
+  </section>
+  <section xml:id="cubrid.resources.lob-identifier">
+  <title>LOB-Kennung</title>
+   <simpara>
+    Eine LOB-Kennung, die von <function>cubrid_lob_get</function> zurückgegeben wird.
+   </simpara>
+  </section>
+  <section xml:id="cubrid.resources.lob2-identifier">
+  <title>LOB2-Kennung</title>
+   <simpara>
+    Eine LOB-Kennung, die von <function>cubrid_lob2_new</function> zurückgegeben
+    oder aus der Ergebnismenge ermittelt wird.
+   </simpara>
+  </section>
+
+ </section>
+
+</chapter>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt neue (zuvor nicht übersetzte) Dateien (cubrid) ins Deutsche, auf dem Stand des aktuellen EN-Texts (3 Datei(en)). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #236 und #242 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").