### PR TITLE
[Sync EN] Various small extensions (part B): German translation of new files

### DIFF
--- a/appendices/examples.xml
+++ b/appendices/examples.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<appendix xml:id="examples" xmlns="http://docbook.org/ns/docbook">
+ <title>Über die Beispiele im Handbuch</title>
+ <simpara>
+  Es ist zu beachten, dass viele Beispiele in der PHP-Dokumentation der Klarheit und Kürze halber
+  auf die Behandlung von Fehlern und Ausnahmen verzichten.
+ </simpara>
+ <simpara>
+  Das bedeutet nicht, dass die Fehlerbehandlung in Produktivcode weggelassen werden sollte,
+  da dies dazu führen kann, dass <exceptionname>TypeError</exceptionname>s ausgelöst werden,
+  Fehlschlagwerte umgewandelt werden, etwa &false; in eine leere Zeichenkette,
+  oder Annahmen verletzt werden, was schwer auffindbare Fehler verursachen kann.
+  Einige Erweiterungen stellen vollständige Beispiele bereit, in denen die Fehlerbehandlung enthalten ist,
+  um die korrekte Verwendung der verschiedenen von der Erweiterung bereitgestellten Funktionen und Methoden
+  zu demonstrieren.
+ </simpara>
+</appendix>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/chmonly/integration.xml
+++ b/chmonly/integration.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+ <chapter xml:id="chm.integration" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Integration des PHP-Handbuchs</title>
+
+  <para>
+   <note>
+    <para>
+     Die hier bereitgestellten Informationen richten sich hauptsächlich an IDE-Autoren oder
+     fortgeschrittene Benutzer, die diese CHM-Datei in ihre
+     bevorzugten IDEs oder andere Komponenten ihrer Produktivumgebung integrieren möchten.
+    </para>
+   </note>
+  </para>
+  <para>
+   Es gibt mehrere Editoren mit Unterstützung für die CHM-Integration,
+   aber möglicherweise müssen einige Dinge über den Inhalt der CHM-Datei bekannt sein,
+   um das Handbuch erfolgreich in die eigene Umgebung zu integrieren.
+  </para>
+  <para>
+   Die CHM-Datei wird mithilfe von XSL-Stylesheets aus XML-Quellen erstellt. Dies ist
+   derzeit innerhalb der PHP-Handbuch-Familie einzigartig, da alle anderen Versionen
+   mithilfe von DSSSL-Stylesheets erzeugt werden. Das bedeutet auch, dass
+   unbeabsichtigte Unterschiede in der Darstellung auftreten können. Auf die Ausgabe der XSLT
+   wird ein spezielles Konvertierungsskript angewendet, das mehrere praktische
+   Funktionen hinzufügt und das Handbuch zusammen mit den Einstellungsdateien
+   und Skin-Beispielen verpackt.
+  </para>
+  <para>
+   Wer noch nie mit CHM-Dateien gearbeitet hat, kann sich diese als komprimierte
+   Dateien mit vom Betriebssystem unterstütztem Zugriff auf die enthaltenen Dateien sowie zusätzlicher Such-
+   und Indexunterstützung vorstellen. CHM-Dateien können jedoch nur mit dem HTML-Help-
+   Viewer angezeigt werden; auf die enthaltenen Dateien kann direkt über ein spezielles URL-
+   Präfix, den CHM-Dateinamen und die angeforderte enthaltene Datei zugegriffen werden. Da der gesamte
+   Hilfeinhalt in HTML-Dateien gespeichert ist, können Seiten der CHM-Datei
+   im Internet Explorer angezeigt werden.
+  </para>
+  <simpara>
+   Angenommen, die Datei <filename>php_manual_en.chm</filename> wurde unter
+   <filename>c:\phpmanual</filename> abgelegt, dann kann auf die Indexdatei des Handbuchs (die
+   beim ersten Mal angezeigt wird) über die folgende URL zugegriffen werden:
+   <literal>mk:@MSITStore:C:\phpmanual\php_manual_en.chm::/_index.html</literal>.
+   Hierbei ist <literal>mk:@MSITStore:</literal> das spezielle "Protokoll",
+   <filename>C:\phpmanual\php_manual_en.chm</filename> ist die CHM-Datei mit ihrem
+   vollständigen Pfad. Der Teil <filename>/_index.html</filename> ist der Pfad zur
+   Indexdatei innerhalb der CHM, und <literal>::</literal> ist genau das, was zwischen
+   dem CHM-Pfad und diesem Dateipfad eingefügt werden muss.
+  </simpara>
+  <para>
+   <note>
+    <para>
+     Alle Dateien befinden sich im Stammverzeichnis der CHM, anders als bei den vorherigen
+     CHM-Versionen, die ein Sprachverzeichnis enthielten. Bilder, Stylesheets
+     und andere ergänzende Dateien haben Namen, die mit einem Unterstrich beginnen
+     (wie der oben gezeigte Hauptindex), um Namenskollisionen zu vermeiden.
+    </para>
+   </note>
+  </para>
+  <para>
+   Die Namen der erzeugten Dateien folgen denselben Regeln wie das Online-
+   Handbuch, mit der Ausnahme, dass die Erweiterung <literal>.html</literal> und
+   nicht <literal>.php</literal> lautet. Am wichtigsten ist, dass die Dateien der Funktions-
+   dokumentation <filename>function.FUNCNAME.html</filename> heißen,
+   wobei <literal>FUNCNAME</literal> der Funktionsname ist, mit allen
+   Unterstrichen, die in Bindestriche umgewandelt wurden. Einige Beispiele sind
+   <filename>function.echo.html</filename>,
+   <filename>function.mysql-close.html</filename>,
+   <filename>function.imagecopy.html</filename>.
+  </para>
+  <para>
+   Mithilfe all dieser Informationen kann eine Handbuchseite für eine von einem Benutzer
+   angeforderte Funktion angezeigt werden. In der Distribution ist ein einfaches Beispiel enthalten,
+   das <filename>php_quickref.hta</filename> heißt. Dabei handelt es sich um eine
+   <link xlink:href="&url.chm.hta;">HTML-Anwendung</link>, die den
+   einfachen Vorgang der Anzeige einer Handbuchseite für eine Funktion demonstriert. Die
+   darin definierte Funktion <literal>quickRef()</literal> erledigt diese Aufgabe.
+  </para>
+  <para>
+   Um das Handbuch in eine IDE ohne direkte
+   Unterstützung für das PHP-Handbuch (genauer gesagt für die Umwandlung von Unterstrichen in Bindestriche) zu integrieren,
+   kann die mitgelieferte Datei <filename>_function.html</filename> verwendet werden, um auf
+   eine Funktionsseite zuzugreifen. Diese Datei ist einfach eine Weiterleitung und kann über
+   die URL parametrisiert werden, etwa als <filename>_function.html#mysql_close</filename>. Diese Seite
+   leitet automatisch zur Seite der Funktion mysql_close
+   (<filename>function.mysql-close.html</filename>) weiter. Es kann der vollständige
+   Pfad dieser Datei angegeben werden, falls die IDE kontextsensitive
+   Hilfe unterstützt, und die von der IDE angegebene Zeichenkette als Parameter übergeben werden. Ein Beispiel
+   hierfür ist die Integration in UltraEdit 9 (siehe die Website dieser Edition).
+  </para>
+  <para>
+   Der Index des Handbuchs (zugänglich über die Registerkarte Index im Navigations-
+   bereich) kann ebenfalls zu Integrationszwecken verwendet werden. Alle HTML-Seiten
+   sind im Index mit ihren Titeln als Indexbegriffe enthalten (einschließlich der
+   Funktionsbeschreibungsseiten).
+  </para>
+  <para>
+   Wer als Entwickler von Desktop-Anwendungen die CHM-Datei eng
+   in das eigene Programm integrieren möchte (etwa um den Inhaltsverzeichnisbaum
+   in der Hilfebox der IDE anzuzeigen), findet weitere Informationen unter
+   <link xlink:href="&url.chm.helpware;">&url.chm.helpware;</link> sowie
+   Links zu weiteren nützlichen Ressourcen. Die offizielle Website für HTML Help befindet sich
+   unter <link xlink:href="&url.chm;">&url.chm;</link>.
+  </para>
+ </chapter>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/cmark/commonmark.cql.xml
+++ b/reference/cmark/commonmark.cql.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<reference xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.commonmark-cql" role="class">
+
+ <title>Die Klasse CommonMark\CQL</title>
+ <titleabbrev>CommonMark\CQL</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ CommonMark\Parser intro -->
+  <section xml:id="commonmark-cql.intro">
+   &reftitle.intro;
+   <simpara>
+    Die CommonMark Query Language ist eine DSL zur Beschreibung der Navigation durch einen CommonMark-Knotenbaum, implementiert als Parser und Compiler für einen kleinen Satz von Anweisungen sowie eine virtuelle Maschine zur Ausführung dieser Anweisungen.
+   </simpara>
+   <formalpara>
+    <title>Pfade:</title>
+     <para>
+      In ihrer einfachsten Form kombiniert eine CQL-Abfrage die folgenden Pfade und <literal>/</literal>, um die Navigation durch einen Baum zu beschreiben:
+      <simplelist>
+       <member>firstChild</member>
+       <member>lastChild</member>
+       <member>previous</member>
+       <member>next</member>
+       <member>parent</member>
+      </simplelist>
+      Beispielsweise würde <literal>/firstChild/lastChild</literal> zum letzten Kindknoten des ersten Kindknotens navigieren.
+     </para>
+   </formalpara>
+   <formalpara>
+   <title>Schleifen</title>
+   <para>
+    CQL kann angewiesen werden, eine Schleife auszuführen, beispielsweise über die Kinder eines bestimmten Knotens oder seine Geschwister, indem der Pfad <literal>children</literal> oder <literal>siblings</literal> verwendet wird. Beispielsweise navigiert <literal>/firstChild/children</literal> zu allen Kindern des ersten Kindknotens.
+   </para>
+   </formalpara>
+   <formalpara>
+    <title>Teilabfragen</title>
+     <para>
+      CQL kann mithilfe einer Teilabfrage wie <literal>[/firstChild]</literal> angewiesen werden, wie navigiert werden soll. Beispielsweise navigiert <literal>/firstChild/children[/firstChild]</literal> zum ersten Kindknoten aller Kinder des ersten Kindknotens.
+     </para>
+   </formalpara>
+   <formalpara>
+    <title>Schleifeneinschränkungen</title>
+     <para>
+      Während einer Schleife kann CQL angewiesen werden, den navigierten Pfad auf Knoten eines bestimmten Typs zu beschränken. Beispielsweise navigiert <literal>/children(BlockQuote)</literal> zu den Kindern eines Knotens, dessen Typ <literal>BlockQuote</literal> ist. Die folgenden Typen werden (ohne Beachtung der Groß-/Kleinschreibung) erkannt:
+      <simplelist>
+       <member>BlockQuote</member>
+       <member>List</member>
+       <member>Item</member>
+       <member>CodeBlock</member>
+       <member>HtmlBlock</member>
+       <member>CustomBlock</member>
+       <member>Paragraph</member>
+       <member>Heading</member>
+       <member>ThematicBreak</member>
+       <member>Text</member>
+       <member>SoftBreak</member>
+       <member>LineBreak</member>
+       <member>Code</member>
+       <member>HtmlInline</member>
+       <member>CustomInline</member>
+       <member>Emphasis</member>
+       <member>Strong</member>
+       <member>Link</member>
+       <member>Image</member>
+      </simplelist>
+      Typen können als Vereinigung verwendet werden, beispielsweise navigiert <literal>/children(BlockQuote|List)</literal> zu den Kindern eines Knotens, dessen Typ <literal>BlockQuote</literal> oder <literal>List</literal> ist. Typen oder Vereinigungen von Typen können auch negiert werden. Beispielsweise navigiert <literal>/children(~BlockQuote)</literal> zu den Kindern eines Knotens, dessen Typ nicht <literal>BlockQuote</literal> ist, und <literal>/children(~BlockQuote|Paragraph)</literal> navigiert zu den Kindern eines Knotens, dessen Typ nicht <literal>BlockQuote</literal> oder <literal>Paragraph</literal> ist
+     </para>
+   </formalpara>
+   <formalpara>
+    <title>Pfadeinschränkungen</title>
+     <para>
+      CQL kann angewiesen werden, eine Schleife zu erstellen, um zu einem Knoten eines bestimmten Typs an einem bestimmten Pfad zu navigieren. Beispielsweise navigiert <literal>/firstChild(BlockQuote)</literal> zum ersten Kindknoten, dessen Typ <literal>BlockQuote</literal> ist. Beachten Sie, dass auf diese Art von Pfad, ebenso wie bei anderen Schleifen für <literal>children</literal> und <literal>siblings</literal>, nur eine Teilabfrage folgen kann.
+     </para>
+   </formalpara>
+   <formalpara>
+    <title>Hinweise zur Implementierung</title>
+    <para>
+    Obwohl CQL als Teil der PHP-Erweiterung CommonMark implementiert wurde, steht es unabhängig von PHP und verwendet weder die virtuelle Maschine noch die interne Repräsentation von Werten von PHP.
+   </para>
+   </formalpara>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="commonmark-cql.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>CommonMark\CQL</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>CommonMark\CQL</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Constructor;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('commonmark-cql.construct')/db:refsect1[@role='description']/descendant::db:constructorsynopsis[not(@role='procedural')])"/>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.commonmark-cql')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])"/>
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+  &reference.cmark.commonmark.cql.construct;
+  &reference.cmark.commonmark.cql.invoke;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fdf/functions/fdf-get-attachment.xml
+++ b/reference/fdf/functions/fdf-get-attachment.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.fdf-get-attachment">
+ <refnamediv>
+  <refname>fdf_get_attachment</refname>
+  <refpurpose>Extrahiert eine in der FDF eingebettete hochgeladene Datei</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>fdf_get_attachment</methodname>
+   <methodparam><type>resource</type><parameter>fdf_document</parameter></methodparam>
+   <methodparam><type>string</type><parameter>fieldname</parameter></methodparam>
+   <methodparam><type>string</type><parameter>savepath</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Extrahiert eine über das Feld "file selection"
+   <parameter>fieldname</parameter> hochgeladene Datei und speichert sie unter
+   <parameter>savepath</parameter>.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>fdf_document</parameter></term>
+    <listitem>
+     <simpara>
+      Das FDF-Dokument-Handle, das von <function>fdf_create</function>,
+      <function>fdf_open</function> oder <function>fdf_open_string</function> zurückgegeben wird.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>fieldname</parameter></term>
+    <listitem>
+     <simpara>
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>savepath</parameter></term>
+    <listitem>
+     <simpara>
+      Kann der Name einer einfachen Datei oder eines vorhandenen Verzeichnisses sein, in dem die
+      Datei unter ihrem ursprünglichen Namen erstellt werden soll. Jede vorhandene Datei mit
+      demselben Namen wird überschrieben.
+     </simpara>
+     <note>
+      <simpara>
+       Es scheint keine andere Möglichkeit zu geben, den ursprünglichen Dateinamen herauszufinden, als
+       die Datei unter Verwendung eines Verzeichnisses als
+       <parameter>savepath</parameter> zu speichern und den Basisnamen zu prüfen, unter dem sie
+       gespeichert wurde.
+      </simpara>
+     </note>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Das zurückgegebene Array enthält die folgenden Felder:
+   <itemizedlist>
+    <listitem>
+     <simpara><parameter>path</parameter> - Pfad, unter dem die Datei gespeichert wurde</simpara>
+    </listitem>
+    <listitem>
+     <simpara><parameter>size</parameter> - Größe der gespeicherten Datei in Byte</simpara>
+    </listitem>
+    <listitem>
+     <simpara><parameter>type</parameter> - MIME-Typ, sofern in der FDF angegeben</simpara>
+    </listitem>
+   </itemizedlist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Speichern einer hochgeladenen Datei</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+  $fdf = fdf_open_string($HTTP_FDF_DATA);
+  $data = fdf_get_attachment($fdf, "filename", "/tmpdir");
+  echo "The uploaded file is stored in $data[path]";
+?>
+]]>
+   </programlisting>
+  </example>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/fpm/status.xml
+++ b/reference/fpm/status.xml
@@ -1,0 +1,320 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="fpm.status">
+ <title>Statusseite</title>
+
+ <simpara>
+  Diese Seite liefert Informationen zur Einrichtung und zum Inhalt der FPM-Statusseite. Siehe auch
+  <function>fpm_get_status</function>.
+ </simpara>
+
+ <sect2 xml:id="fpm.status.configuration">
+  <title>Konfiguration</title>
+
+  <simpara>
+   Die FPM-Statusseite kann aktiviert werden, indem der Konfigurationsparameter
+   <link linkend="pm.status-path">pm.status_path</link> in der FPM-Pool-Konfiguration
+   gesetzt wird.
+  </simpara>
+
+  <caution>
+   <simpara>
+    Aus Sicherheitsgründen sollte die FPM-Statusseite ausschließlich auf interne Anfragen oder bekannte Client-IPs
+    beschränkt werden, da die Seite Anfrage-URLs und Informationen über verfügbare Ressourcen preisgibt.
+   </simpara>
+  </caution>
+
+  <simpara>
+   Je nach Webserver-Konfiguration kann es erforderlich sein, den Webserver so zu konfigurieren, dass er
+   Anfragen direkt an diesen Pfad zulässt und dabei alle PHP-Skripte umgeht. Ein Beispiel für eine Konfiguration
+   für Apache mit FPM, das auf UDS lauscht und bei dem <literal>pm.status_path</literal> auf
+   <literal>/fpm-status</literal> gesetzt ist, würde so aussehen:
+  </simpara>
+
+  <informalexample>
+   <programlisting role="apache-conf">
+    <![CDATA[
+<LocationMatch "/fpm-status">
+ Require local
+ ProxyPass "unix:/var/run/php-fpm.sock|fcgi://localhost/"
+</LocationMatch>
+]]>
+   </programlisting>
+  </informalexample>
+
+  <simpara>
+   Nach dem Neuladen oder Neustarten von FPM und dem Webserver ist die Statusseite vom
+   Browser aus erreichbar (sofern die Anfrage von einer zulässigen IP-Adresse stammt, falls die IP-Beschränkung
+   konfiguriert wurde).
+  </simpara>
+ </sect2>
+
+ <sect2 xml:id="fpm.status.parameters">
+  <title>Abfrageparameter</title>
+
+  <simpara>
+   Das Format der Ausgabe der Statusseite kann durch Angabe eines der folgenden Abfrageparameter
+   geändert werden:
+  </simpara>
+
+  <simplelist>
+   <member><literal>html</literal></member>
+   <member><literal>json</literal></member>
+   <member><literal>openmetrics</literal></member>
+   <member><literal>xml</literal></member>
+  </simplelist>
+
+  <simpara>
+   Mithilfe des Abfrageparameters <literal>full</literal> können zudem zusätzliche Informationen zurückgegeben werden.
+  </simpara>
+
+  <simpara>
+   Beispiel-URLs für die Statusseite:
+  </simpara>
+
+  <simplelist>
+   <member>
+    <literal>https://localhost/fpm-status</literal>
+    - Kurze Ausgabe im Standard-Textformat
+   </member>
+   <member>
+    <literal>https://localhost/fpm-status?full</literal>
+    - Vollständige Ausgabe im Standard-Textformat
+   </member>
+   <member>
+    <literal>https://localhost/fpm-status?json</literal>
+    - Kurze Ausgabe im JSON-Format
+   </member>
+   <member>
+    <literal>https://localhost/fpm-status?html&amp;full</literal>
+    - Vollständige Ausgabe im HTML-Format
+   </member>
+  </simplelist>
+ </sect2>
+
+ <sect2 xml:id="fpm.status.contents">
+  <title>Angezeigte Informationen</title>
+
+  <simpara>
+   Datums-/Zeitwerte verwenden in der JSON- und XML-Ausgabe das Unix-Timestamp-Format, andernfalls verwenden sie
+   das Format, das zu folgendem Beispieldatum führt:
+   <literal>"03/Jun/2021:07:21:46 +0100"</literal>.
+  </simpara>
+
+  <table>
+   <title>Grundlegende Informationen - werden immer auf der Statusseite angezeigt</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>Parameter</entry>
+      <entry>Beschreibung</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>pool</entry>
+      <entry>Der Name des FPM-Prozess-Pools.</entry>
+     </row>
+     <row>
+      <entry>process manager</entry>
+      <entry>Der Typ des Prozessmanagers - static, dynamic oder ondemand.</entry>
+     </row>
+     <row>
+      <entry>start time</entry>
+      <entry>Datum/Uhrzeit, zu dem der Prozess-Pool zuletzt gestartet wurde.</entry>
+     </row>
+     <row>
+      <entry>start since</entry>
+      <entry>Die Zeit in Sekunden seit dem letzten Start des Prozess-Pools.</entry>
+     </row>
+     <row>
+      <entry>accepted conn</entry>
+      <entry>Die Gesamtzahl der angenommenen Verbindungen.</entry>
+     </row>
+     <row>
+      <entry>listen queue</entry>
+      <entry>Die Anzahl der Anfragen (Backlog), die derzeit auf einen freien Prozess warten.</entry>
+     </row>
+     <row>
+      <entry>max listen queue</entry>
+      <entry>Die maximale Anzahl an Anfragen, die jemals gleichzeitig in der Listen-Queue beobachtet wurde.</entry>
+     </row>
+     <row>
+      <entry>listen queue len</entry>
+      <entry>Die maximal zulässige Größe der Listen-Queue.</entry>
+     </row>
+     <row>
+      <entry>idle processes</entry>
+      <entry>Die Anzahl der Prozesse, die derzeit untätig sind (auf Anfragen warten).</entry>
+     </row>
+     <row>
+      <entry>active processes</entry>
+      <entry>Die Anzahl der Prozesse, die derzeit Anfragen verarbeiten.</entry>
+     </row>
+     <row>
+      <entry>total processes</entry>
+      <entry>Die aktuelle Gesamtzahl der Prozesse.</entry>
+     </row>
+     <row>
+      <entry>max active processes</entry>
+      <entry>Die maximale Anzahl gleichzeitig aktiver Prozesse.</entry>
+     </row>
+     <row>
+      <entry>max children reached</entry>
+      <entry>
+       Wurde die maximale Anzahl an Prozessen jemals erreicht? Falls ja, ist der angezeigte Wert größer als oder gleich
+       <literal>1</literal>, andernfalls ist der Wert <literal>0</literal>.
+      </entry>
+     </row>
+     <row>
+      <entry>slow requests</entry>
+      <entry>
+       Die Gesamtzahl der Anfragen, die das konfigurierte
+       <literal>request_slowlog_timeout</literal> erreicht haben.
+      </entry>
+     </row>
+     <row>
+      <entry>memory peak</entry>
+      <entry>
+       Der Spitzenwert der Speichernutzung seit dem Start von FPM.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <table>
+   <title>Informationen pro Prozess - werden nur im Ausgabemodus <literal>full</literal> angezeigt</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>Parameter</entry>
+      <entry>Beschreibung</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>pid</entry>
+      <entry>Die System-PID des Prozesses.</entry>
+     </row>
+     <row>
+      <entry>state</entry>
+      <entry>Der Zustand des Prozesses - Idle, Running, ...</entry>
+     </row>
+     <row>
+      <entry>start time</entry>
+      <entry>Datum/Uhrzeit, zu dem der Prozess gestartet wurde.</entry>
+     </row>
+     <row>
+      <entry>start since</entry>
+      <entry>Die Anzahl der Sekunden seit dem Start des Prozesses.</entry>
+     </row>
+     <row>
+      <entry>requests</entry>
+      <entry>Die Gesamtzahl der bedienten Anfragen.</entry>
+     </row>
+     <row>
+      <entry>request duration</entry>
+      <entry>Die Gesamtzeit in Mikrosekunden, die für die Bearbeitung der letzten Anfrage aufgewendet wurde.</entry>
+     </row>
+     <row>
+      <entry>request method</entry>
+      <entry>Die HTTP-Methode der zuletzt bedienten Anfrage.</entry>
+     </row>
+     <row>
+      <entry>request uri</entry>
+      <entry>
+       Die URI der zuletzt bedienten Anfrage (nach der Verarbeitung durch den Webserver kann sie immer
+       <literal>/index.php</literal> sein, wenn ein Front-Controller-Pattern-Redirect verwendet wird).
+      </entry>
+     </row>
+     <row>
+      <entry>content length</entry>
+      <entry>Die Länge des Anfragerumpfs der letzten Anfrage in Byte.</entry>
+     </row>
+     <row>
+      <entry>user</entry>
+      <entry>Der HTTP-Benutzer (<literal>PHP_AUTH_USER</literal>) der letzten Anfrage.</entry>
+     </row>
+     <row>
+      <entry>script</entry>
+      <entry>
+       Der vollständige Pfad des von der letzten Anfrage ausgeführten Skripts. Dies ist
+       <literal>'-'</literal>, falls nicht zutreffend (z. B. bei Anfragen an die Statusseite).
+      </entry>
+     </row>
+     <row>
+      <entry>last request cpu</entry>
+      <entry>
+       Die CPU-Auslastung (%cpu) der letzten Anfrage. Dieser Wert ist 0, wenn der Prozess nicht untätig (Idle) ist, da die
+       Berechnung erfolgt, sobald die Verarbeitung der Anfrage abgeschlossen ist.
+       Der Wert kann 100 % überschreiten, da die Metrik angibt, welcher Prozentsatz der gesamten CPU-Zeit in der letzten Anfrage verwendet wurde -
+       sie berücksichtigt Prozesse auf allen Kernen, während sich die 100 % nur auf einen einzelnen Kern beziehen.
+      </entry>
+     </row>
+     <row>
+      <entry>last request memory</entry>
+      <entry>
+       Die maximale Menge an Speicher, die von der letzten Anfrage verbraucht wurde. Dieser Wert ist 0, wenn der Prozess
+       nicht untätig (Idle) ist, da die Berechnung erfolgt, sobald die Verarbeitung der Anfrage abgeschlossen ist.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+
+  <note>
+   <simpara>
+    Alle Werte sind spezifisch für den Pool und werden beim Neustart von FPM zurückgesetzt.
+   </simpara>
+  </note>
+
+  <note>
+   <simpara>
+    Die Ausgabe im OpenMetrics-Format verwendet andere Parametertypen, um besser zum OpenMetrics-Format zu passen.
+    Die Parameter und die Beschreibungen ihrer Werte sind in der Ausgabe im OpenMetrics-Format enthalten.
+   </simpara>
+  </note>
+ </sect2>
+
+ <sect2 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.1.0</entry>
+      <entry>Das Format openmetrics wurde hinzugefügt.</entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </sect2>
+</sect1>
+<!-- Keep this comment at the end of the file
+ Local variables:
+ mode: sgml
+ sgml-omittag:t
+ sgml-shorttag:t
+ sgml-minimize-attributes:nil
+ sgml-always-quote-attributes:t
+ sgml-indent-step:1
+ sgml-indent-data:t
+ indent-tabs-mode:nil
+ sgml-parent-document:nil
+ sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+ sgml-exposed-tags:nil
+ sgml-local-catalogs:nil
+ sgml-local-ecat-files:nil
+ End:
+ vim600: syn=xml fen fdm=syntax fdl=2 si
+ vim: et tw=78 syn=sgml
+ vi: ts=1 sw=1
+ -->

--- a/reference/ibm_db2/functions/db2-fetch-row.xml
+++ b/reference/ibm_db2/functions/db2-fetch-row.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.db2-fetch-row">
+ <refnamediv>
+  <refname>db2_fetch_row</refname>
+  <refpurpose>
+   Setzt den Zeiger der Ergebnismenge auf die nächste oder die angeforderte Zeile
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>db2_fetch_row</methodname>
+   <methodparam><type>resource</type><parameter>stmt</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>row_number</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+
+
+  <simpara>
+   <function>db2_fetch_row</function> wird verwendet, um über eine Ergebnismenge zu iterieren oder
+   um auf eine bestimmte Zeile in einer Ergebnismenge zu zeigen, falls ein scrollbarer
+   Cursor angefordert wurde.
+  </simpara>
+  <simpara>
+   Um einzelne Felder aus der Ergebnismenge abzurufen, ist die Funktion
+   <function>db2_result</function> aufzurufen.
+  </simpara>
+  <simpara>
+   Anstatt <function>db2_fetch_row</function> und
+   <function>db2_result</function> aufzurufen, rufen die meisten Anwendungen eine der Funktionen
+   <function>db2_fetch_assoc</function>, <function>db2_fetch_both</function>
+   oder <function>db2_fetch_array</function> auf, um den Zeiger der Ergebnismenge weiterzubewegen
+   und eine vollständige Zeile als Array zurückzugeben.
+  </simpara>
+
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>stmt</parameter></term>
+    <listitem>
+     <simpara>
+      Eine gültige <literal>stmt</literal>-Ressource.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>row_number</parameter></term>
+    <listitem>
+     <simpara>
+      Bei scrollbaren Cursorn kann eine bestimmte Zeilennummer in der
+      Ergebnismenge angefordert werden. Die Zeilennummerierung beginnt bei 1.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt &true; zurück, wenn die angeforderte Zeile in der Ergebnismenge existiert. Gibt
+   &false; zurück, wenn die angeforderte Zeile nicht in der Ergebnismenge existiert.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Über eine Ergebnismenge iterieren</title>
+    <simpara>
+     Das folgende Beispiel zeigt, wie über eine Ergebnismenge
+     mit <function>db2_fetch_row</function> iteriert und Spalten aus der
+     Ergebnismenge mit <function>db2_result</function> abgerufen werden.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$sql = 'SELECT name, breed FROM animals WHERE weight < ?';
+$stmt = db2_prepare($conn, $sql);
+db2_execute($stmt, array(10));
+while (db2_fetch_row($stmt)) {
+    $name = db2_result($stmt, 0);
+    $breed = db2_result($stmt, 1);
+    print "$name $breed";
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+cat Pook
+gold fish Bubbles
+budgerigar Gizmo
+goat Rickety Ride
+]]>
+    </screen>
+   </example>
+   <example>
+    <title>Unter i5/OS empfohlene Alternativen zu db2_fetch_row/db2_result</title>
+    <simpara>
+     Unter i5/OS wird empfohlen, <function>db2_fetch_both</function>,
+     <function>db2_fetch_array</function> oder <function>db2_fetch_object</function>
+     anstelle von <function>db2_fetch_row</function>/<function>db2_result</function> zu verwenden. Im Allgemeinen
+     haben <function>db2_fetch_row</function>/<function>db2_result</function> mehr Probleme
+     mit verschiedenen Spaltentypen bei der Umwandlung von <literal>EBCDIC</literal> nach <literal>ASCII</literal>,
+     einschließlich möglicher Abschneidung in <literal>DBCS</literal>-Anwendungen.
+     Außerdem kann sich die Leistung von <function>db2_fetch_both</function>,
+     <function>db2_fetch_array</function> und <function>db2_fetch_object</function> als
+     überlegen gegenüber <function>db2_fetch_row</function>/<function>db2_result</function> erweisen.
+    </simpara>
+    <programlisting role="php">
+<![CDATA[
+<?php
+  $conn = db2_connect("","","");
+  $sql = 'SELECT SPECIFIC_SCHEMA, SPECIFIC_NAME, ROUTINE_SCHEMA, ROUTINE_NAME, ROUTINE_TYPE, ROUTINE_CREATED, ROUTINE_BODY, IN_PARMS, OUT_PARMS, INOUT_PARMS, PARAMETER_STYLE, EXTERNAL_NAME, EXTERNAL_LANGUAGE FROM QSYS2.SYSROUTINES FETCH FIRST 2 ROWS ONLY';
+  $stmt = db2_exec($conn, $sql, array('cursor' => DB2_SCROLLABLE));
+  while ($row = db2_fetch_both($stmt)){
+    echo "<br>db2_fetch_both {$row['SPECIFIC_NAME']} {$row['ROUTINE_CREATED']} {$row[5]}";
+  }
+  $stmt = db2_exec($conn, $sql, array('cursor' => DB2_SCROLLABLE));
+  while ($row = db2_fetch_array($stmt)){
+    echo "<br>db2_fetch_array {$row[1]}  {$row[5]}";
+  }
+  $stmt = db2_exec($conn, $sql, array('cursor' => DB2_SCROLLABLE));
+  while ($row = db2_fetch_object($stmt)){
+    echo "<br>db2_fetch_object {$row->SPECIFIC_NAME} {$row->ROUTINE_CREATED}";
+  }
+  db2_close($conn);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+db2_fetch_both MATCH_ANIMAL 2006-08-25-17.10.23.775000 2006-08-25-17.10.23.775000
+db2_fetch_both MULTIRESULTS 2006-10-17-10.11.05.308000 2006-10-17-10.11.05.308000
+db2_fetch_array MATCH_ANIMAL 2006-08-25-17.10.23.775000
+db2_fetch_array MULTIRESULTS 2006-10-17-10.11.05.308000
+db2_fetch_object MATCH_ANIMAL 2006-08-25-17.10.23.775000
+db2_fetch_object MULTIRESULTS 2006-10-17-10.11.05.308000
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>db2_fetch_array</function></member>
+   <member><function>db2_fetch_assoc</function></member>
+   <member><function>db2_fetch_both</function></member>
+   <member><function>db2_fetch_object</function></member>
+   <member><function>db2_result</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/imagick/imagick/forwardfouriertransformimage.xml
+++ b/reference/imagick/imagick/forwardfouriertransformimage.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="imagick.forwardfouriertransformimage" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Imagick::forwardFourierTransformImage</refname>
+  <refpurpose>Implementiert die diskrete Fourier-Transformation (DFT)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <type>bool</type><methodname>Imagick::forwardFourierTransformimage</methodname>
+   <methodparam><type>bool</type><parameter>magnitude</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Implementiert die diskrete Fourier-Transformation (DFT) des Bildes, entweder als Betrags-/Phasen- oder als Real-/Imaginärbildpaar.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>magnitude</parameter></term>
+    <listitem>
+     <para>
+      Falls true, wird ein Betrags-/Phasenpaar zurückgegeben, andernfalls ein Real-/Imaginärbildpaar.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &imagick.return.success;
+  </para>
+ </refsect1>
+
+
+
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+    <example>
+      <title> <function>Imagick::forwardFourierTransformImage</function></title>
+      <programlisting role="php">
+      <![CDATA[
+<?php
+//Hilfsfunktion für forwardTransformImage
+function createMask() {
+    $draw = new \ImagickDraw();
+
+    $draw->setStrokeOpacity(0);
+    $draw->setStrokeColor('rgb(255, 255, 255)');
+    $draw->setFillColor('rgb(255, 255, 255)');
+
+    //Einen Kreis auf der y-Achse zeichnen, dessen Mittelpunkt
+    //bei x, y liegt und der den Ursprung berührt
+    $draw->circle(250, 250, 220, 250);
+
+    $imagick = new \Imagick();
+    $imagick->newImage(512, 512, "black");
+    $imagick->drawImage($draw);
+    $imagick->gaussianBlurImage(20, 20);
+    $imagick->autoLevelImage();
+
+    return $imagick;
+}
+
+
+function forwardFourierTransformImage($imagePath) {
+    $imagick = new \Imagick(realpath($imagePath));
+    $imagick->resizeimage(512, 512, \Imagick::FILTER_LANCZOS, 1);
+
+    $mask = createMask();
+    $imagick->forwardFourierTransformImage(true);
+
+    @$imagick->setimageindex(0);
+    $magnitude = $imagick->getimage();
+
+    @$imagick->setimageindex(1);
+    $imagickPhase = $imagick->getimage();
+
+    if (true) {
+        $imagickPhase->compositeImage($mask, \Imagick::COMPOSITE_MULTIPLY, 0, 0);
+    }
+
+    if (false) {
+        $output = clone $imagickPhase;
+        $output->setimageformat('png');
+        header("Content-Type: image/png");
+        echo $output->getImageBlob();
+    }
+
+    $magnitude->inverseFourierTransformImage($imagickPhase, true);
+
+    $magnitude->setimageformat('png');
+    header("Content-Type: image/png");
+    echo $magnitude->getImageBlob();
+}
+
+?>
+]]>
+      </programlisting>
+    </example>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/info/functions/get-defined-constants.xml
+++ b/reference/info/functions/get-defined-constants.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.get-defined-constants" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>get_defined_constants</refname>
+  <refpurpose>Gibt ein assoziatives Array mit den Namen aller Konstanten und ihren Werten zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>get_defined_constants</methodname>
+   <methodparam choice="opt"><type>bool</type><parameter>categorize</parameter><initializer>&false;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Gibt die Namen und Werte aller derzeit definierten Konstanten zurück.
+   Dazu gehören sowohl die von Erweiterungen erstellten als auch die mit
+   der Funktion <function>define</function> erstellten Konstanten.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>categorize</parameter></term>
+     <listitem>
+      <para>
+       Bewirkt, dass diese Funktion ein mehrdimensionales
+       Array zurückgibt, mit Kategorien in den Schlüsseln der ersten Dimension und Konstanten
+       sowie ihren Werten in der zweiten Dimension.
+       <informalexample>
+        <programlisting role="php">
+<![CDATA[
+<?php
+define("MY_CONSTANT", 1);
+print_r(get_defined_constants(true));
+?>
+]]>
+        </programlisting>
+        &example.outputs.similar;
+        <screen>
+<![CDATA[
+Array
+(
+    [Core] => Array
+        (
+            [E_ERROR] => 1
+            [E_WARNING] => 2
+            [E_PARSE] => 4
+            [E_NOTICE] => 8
+            [E_CORE_ERROR] => 16
+            [E_CORE_WARNING] => 32
+            [E_COMPILE_ERROR] => 64
+            [E_COMPILE_WARNING] => 128
+            [E_USER_ERROR] => 256
+            [E_USER_WARNING] => 512
+            [E_USER_NOTICE] => 1024
+            [E_ALL] => 2047
+            [TRUE] => 1
+        )
+
+    [pcre] => Array
+        (
+            [PREG_PATTERN_ORDER] => 1
+            [PREG_SET_ORDER] => 2
+            [PREG_OFFSET_CAPTURE] => 256
+            [PREG_SPLIT_NO_EMPTY] => 1
+            [PREG_SPLIT_DELIM_CAPTURE] => 2
+            [PREG_SPLIT_OFFSET_CAPTURE] => 4
+            [PREG_GREP_INVERT] => 1
+        )
+
+    [user] => Array
+        (
+            [MY_CONSTANT] => 1
+        )
+
+)
+]]>
+        </screen>
+       </informalexample>
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt ein Array der Form Konstantenname => Konstantenwert zurück, das optional
+   nach dem Namen der Erweiterung gruppiert ist, die die Konstante registriert.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>get_defined_constants</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+print_r(get_defined_constants());
+?>
+]]>
+    </programlisting>
+    &example.outputs.similar;
+    <screen>
+<![CDATA[
+Array
+(
+    [E_ERROR] => 1
+    [E_WARNING] => 2
+    [E_PARSE] => 4
+    [E_NOTICE] => 8
+    [E_CORE_ERROR] => 16
+    [E_CORE_WARNING] => 32
+    [E_COMPILE_ERROR] => 64
+    [E_COMPILE_WARNING] => 128
+    [E_USER_ERROR] => 256
+    [E_USER_WARNING] => 512
+    [E_USER_NOTICE] => 1024
+    [E_ALL] => 2047
+    [TRUE] => 1
+)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>defined</function></member>
+    <member><function>constant</function></member>
+    <member><function>get_loaded_extensions</function></member>
+    <member><function>get_defined_functions</function></member>
+    <member><function>get_defined_vars</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/ldap/functions/ldap-exop-passwd.xml
+++ b/reference/ldap/functions/ldap-exop-passwd.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.ldap-exop-passwd" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ldap_exop_passwd</refname>
+  <refpurpose>Hilfsfunktion für die erweiterte Operation PASSWD</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>bool</type></type><methodname>ldap_exop_passwd</methodname>
+   <methodparam><type>LDAP\Connection</type><parameter>ldap</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>user</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>old_password</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>new_password</parameter><initializer>""</initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">controls</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Führt eine erweiterte Operation PASSWD aus.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>ldap</parameter></term>
+    <listitem>
+     <para>
+      &ldap.parameter.ldap;
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user</parameter></term>
+    <listitem>
+     <para>
+       Der DN des Benutzers, dessen Passwort geändert werden soll.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>old_password</parameter></term>
+    <listitem>
+     <simpara>
+       Das alte Passwort dieses Benutzers. Kann je nach Serverkonfiguration weggelassen werden.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>new_password</parameter></term>
+    <listitem>
+     <para>
+       Das neue Passwort für diesen Benutzer. Kann weggelassen oder leer gelassen werden, um ein Passwort generieren zu lassen.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>controls</parameter></term>
+    <listitem>
+     <para>
+       Falls angegeben, wird mit der Anfrage ein Steuerelement für die Passwortrichtlinie gesendet, und dieser Parameter wird
+       mit einem Array von <link linkend="ldap.controls">LDAP-Steuerelementen</link>
+       gefüllt, die mit der Anfrage zurückgegeben werden.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+    Gibt das generierte Passwort zurück, wenn <parameter>new_password</parameter> leer ist oder weggelassen wird.
+    Andernfalls wird bei Erfolg &true; und bei einem Fehler &false; zurückgegeben.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      &ldap.changelog.ldap-object;
+      &ldap.changelog.controls-nullable;
+      <row>
+       <entry>7.3.0</entry>
+       <entry>
+        Unterstützung für <parameter>controls</parameter> hinzugefügt
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Erweiterte Operation PASSWD</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$ds = ldap_connect("localhost");  // unter der Annahme, dass sich der LDAP-Server auf diesem Host befindet
+
+if ($ds) {
+    // mit einem geeigneten DN binden, um Schreibzugriff zu erhalten
+    $bind = ldap_bind($ds, "cn=root, o=My Company, c=US", "secret");
+    if (!$bind) {
+      echo "Unable to bind to LDAP server";
+      exit;
+    }
+
+    // PASSWD EXOP verwenden, um das Benutzerpasswort durch ein generiertes zu ersetzen
+    $genpw = ldap_exop_passwd($ds, "cn=root, o=My Company, c=US", "secret");
+    if ($genpw) {
+      // das generierte Passwort zum Binden verwenden
+      $bind = ldap_bind($ds, "cn=root, o=My Company, c=US", $genpw);
+    }
+
+    // das Passwort wieder auf "secret" zurücksetzen
+    ldap_exop_passwd($ds, "cn=root, o=My Company, c=US", $genpw, "secret");
+
+    ldap_close($ds);
+} else {
+    echo "Unable to connect to LDAP server";
+}
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>ldap_exop</function></member>
+    <member><function>ldap_parse_exop</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/openssl/functions/openssl-pbkdf2.xml
+++ b/reference/openssl/functions/openssl-pbkdf2.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.openssl-pbkdf2" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>openssl_pbkdf2</refname>
+  <refpurpose>Erzeugt eine PKCS5-v2-PBKDF2-Zeichenkette</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>openssl_pbkdf2</methodname>
+   <methodparam><modifier role="attribute">#[\SensitiveParameter]</modifier><type>string</type><parameter>password</parameter></methodparam>
+   <methodparam><type>string</type><parameter>salt</parameter></methodparam>
+   <methodparam><type>int</type><parameter>key_length</parameter></methodparam>
+   <methodparam><type>int</type><parameter>iterations</parameter></methodparam>
+   <methodparam choice="opt"><type>string</type><parameter>digest_algo</parameter><initializer>"sha1"</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>openssl_pbkdf2</function> berechnet PBKDF2 (Password-Based Key Derivation Function 2),
+   eine in PKCS5 v2 definierte Schlüsselableitungsfunktion.
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <para>
+      Das Passwort, aus dem der abgeleitete Schlüssel erzeugt wird.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>salt</parameter></term>
+    <listitem>
+     <simpara>
+      PBKDF2 empfiehlt ein kryptografisches Salt von mindestens 128 Bit (16 Byte).
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>key_length</parameter></term>
+    <listitem>
+     <para>
+      Die Länge des gewünschten Ausgabeschlüssels.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>iterations</parameter></term>
+    <listitem>
+     <para>
+      Die Anzahl der gewünschten Iterationen.
+      <link xlink:href="https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf">NIST
+       empfiehlt mindestens 1.000</link>. Stand 2023 empfiehlt OWASP 600.000 Iterationen für
+      PBKDF2-HMAC-SHA256 und 210.000 für PBKDF2-HMAC-SHA512.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>digest_algo</parameter></term>
+    <listitem>
+     <para>
+      Optionaler Hash- oder Digest-Algorithmus aus <function>openssl_get_md_methods</function>. Standardmäßig
+      wird SHA-1 verwendet. Es wird empfohlen, ihn auf SHA-256 oder SHA-512 zu setzen.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt eine binäre Rohzeichenkette zurück&return.falseforfailure;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>openssl_pbkdf2()-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$password = 'password';
+$salt = openssl_random_pseudo_bytes(16);
+$keyLength = 20;
+$iterations = 600000;
+$generated_key = openssl_pbkdf2($password, $salt, $keyLength, $iterations, 'sha256');
+echo bin2hex($generated_key)."\n";
+echo base64_encode($generated_key)."\n";
+?>
+]]>
+    </programlisting>
+
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>hash_pbkdf2</function></member>
+    <member><function>openssl_get_md_methods</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/outcontrol/user-level-output-buffers.xml
+++ b/reference/outcontrol/user-level-output-buffers.xml
@@ -1,0 +1,637 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 7cecc752c7a19aa6ea422ac7ae82952a21bedd67 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<chapter xml:id="outcontrol.user-level-output-buffers" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Ausgabepuffer auf Benutzerebene</title>
+ <para>
+  Ausgabepuffer auf Benutzerebene können aus PHP-Code heraus gestartet,
+  manipuliert und beendet werden.
+  Jeder dieser Puffer umfasst einen Ausgabepuffer
+  und eine zugehörige Ausgabe-Handler-Funktion.
+ </para>
+
+ <section xml:id="outcontrol.what-output-is-buffered">
+  <title>Welche Ausgabe wird gepuffert?</title>
+  <para>
+   Die Ausgabepuffer auf Benutzerebene von PHP puffern nach ihrem Start
+   die gesamte Ausgabe, bis sie ausgeschaltet werden oder das Skript endet.
+   Ausgabe im Kontext des PHP-Ausgabepuffers auf Benutzerebene
+   ist alles, was PHP anzeigen oder an den Browser zurücksenden würde.
+   In der Praxis ist Ausgabe alles, was nicht aus Daten der Länge null besteht und:
+   <itemizedlist>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('outputcontrol.what-is-output')/*)"><xi:fallback/></xi:include>
+   </itemizedlist>
+  </para>
+  <note>
+   <simpara>
+    Daten, die direkt nach <literal>stdout</literal> geschrieben werden
+    oder an eine SAPI-Funktion mit ähnlicher Funktionalität übergeben werden,
+    werden von Ausgabepuffern auf Benutzerebene nicht erfasst.
+    Dazu gehört das
+    Schreiben von Daten nach <literal>stdout</literal> mit <function>fwrite</function>
+    oder das Senden von Headern mit <function>header</function>
+    oder <function>setcookie</function>.
+   </simpara>
+  </note>
+ </section>
+
+ <section>
+  <title>Ausgabepufferung einschalten</title>
+  <para>
+   Die Ausgabepufferung kann mit der Funktion <function>ob_start</function>
+   oder durch Setzen der &php.ini;-Einstellungen
+   <link linkend="ini.output-buffering">output_buffering</link>
+   und <link linkend="ini.output-handler">output_handler</link>
+   eingeschaltet werden.
+   Obwohl beide Ausgabepuffer erzeugen können, ist
+   <function>ob_start</function> flexibler,
+   da sie benutzerdefinierte Funktionen als Ausgabe-Handler akzeptiert
+   und auch die auf dem Puffer erlaubten Operationen (flush, clean, remove)
+   festgelegt werden können.
+   Mit <function>ob_start</function> gestartete Puffer sind ab der Zeile aktiv,
+   in der die Funktion aufgerufen wurde,
+   während diejenigen, die mit
+   <link linkend="ini.output-buffering">output_buffering</link>
+   gestartet wurden, die Ausgabe ab der ersten Zeile des Skripts puffern.
+  </para>
+  <para>
+   PHP wird außerdem mit einem eingebauten Ausgabe-Handler
+   <literal>"URL-Rewriter"</literal> ausgeliefert, der seinen eigenen
+   Ausgabepuffer startet und zu jedem Zeitpunkt nur bis zu zwei Instanzen
+   davon zulässt
+   (eine für das URL-Rewriting auf Benutzerebene
+   und eine für die transparente Unterstützung der Session-ID).
+   Diese Puffer können durch Aufruf der Funktion
+   <function>output_add_rewrite_var</function> gestartet werden
+   und/oder durch Aktivieren der &php.ini;-Einstellung
+   <link linkend="ini.session.use-trans-sid">session.use_trans_sid</link>.
+  </para>
+  <para>
+   Die mitgelieferte Erweiterung <literal>zlib</literal> hat ihren eigenen
+   Ausgabepuffer, der mit der &php.ini;-Einstellung
+   <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
+   aktiviert werden kann.
+  </para>
+  <note>
+   <simpara>
+    Während <literal>"URL-Rewriter"</literal> insofern besonders ist,
+    als er zu jedem Zeitpunkt nur bis zu zwei Instanzen davon zulässt,
+    verwenden alle Ausgabepuffer auf Benutzerebene dieselben zugrunde liegenden Puffer,
+    die von <function>ob_start</function> verwendet werden,
+    wobei ihre Funktionalität durch eine benutzerdefinierte Ausgabe-Handler-Funktion implementiert wird.
+    Daher kann ihre gesamte Funktionalität durch Userland-Code emuliert werden.
+   </simpara>
+  </note>
+ </section>
+
+ <section xml:id="outcontrol.nesting-output-buffers">
+  <title>Verschachtelung von Ausgabepuffern</title>
+  <para>
+   Wenn beim Start eines neuen Puffers ein Ausgabepuffer aktiv ist,
+   wird der neue Puffer in den zuvor aktiven Puffer verschachtelt.
+   Der innere Puffer verhält sich gleich, unabhängig davon, ob er verschachtelt ist,
+   aber die von ihm gepufferte Ausgabe wird nicht vom äußeren Puffer gepuffert.
+   Nur die vom inneren Puffer geleerte Ausgabe wird vom äußeren Puffer gepuffert.
+  </para>
+  <para>
+   Die meisten <literal>ob_<replaceable>*</replaceable></literal>-Funktionen arbeiten
+   nur mit dem aktiven Ausgabepuffer (dem zuletzt gestarteten),
+   daher kann nur der aktive Puffer geleert, bereinigt und ausgeschaltet werden.
+   Die Funktionen, die mit anderen Puffern arbeiten, sind
+   <function>ob_list_handlers</function>,
+   die die Liste aller in Verwendung befindlichen Ausgabe-Handler zurückgibt,
+   und <function>ob_get_status</function>,
+   die entweder Informationen nur über den aktiven Puffer
+   oder über alle in Verwendung befindlichen Puffer zurückgeben kann.
+  </para>
+  <para>
+   Der Aufruf von <function>ob_get_level</function>
+   oder <function>ob_get_status</function> gibt
+   die Verschachtelungsebene des aktiven Ausgabepuffers zurück.
+  </para>
+  <caution>
+   <simpara>
+    Der Wert für identische Ebenen unterscheidet sich zwischen <function>ob_get_level</function>
+    und <function>ob_get_status</function> um eins.
+    Bei <function>ob_get_level</function>
+    ist die erste Ebene <literal>1</literal>,
+    während bei <function>ob_get_status</function>
+    die erste Ebene <literal>0</literal> ist.
+   </simpara>
+  </caution>
+ </section>
+
+ <section xml:id="outcontrol.buffer-size">
+  <title>Puffergröße</title>
+  <para>
+   Puffergrößen werden durch Integer ausgedrückt
+   und stellen die Anzahl der Bytes dar, die der Puffer ohne Leeren speichern kann.
+   Wenn die Größe der Ausgabe im Puffer die Größe des Puffers überschreitet,
+   wird der Inhalt des Puffers an den Ausgabe-Handler gesendet,
+   dessen Rückgabewert geleert und der Puffer geleert wird.
+  </para>
+  <para>
+   Mit Ausnahme von <literal>"URL-Rewriter"</literal>
+   kann die Größe von Ausgabepuffern beim Start des Puffers festgelegt werden.
+   Wenn sie auf <literal>0</literal> gesetzt ist,
+   ist der Ausgabepuffer nur durch den für PHP verfügbaren Speicher begrenzt.
+   Wenn sie auf <literal>1</literal> gesetzt ist,
+   wird der Puffer nach jedem Codeblock geleert, der
+   eine Ausgabe ungleich der Länge null erzeugt.
+  </para>
+  <para>
+   Die Größe von Ausgabepuffern kann durch Aufruf von
+   <function>ob_get_status</function> abgerufen werden.
+  </para>
+  <para>
+   Bei mit <function>ob_start</function> gestarteten Ausgabepuffern
+   wird die Puffergröße auf den ganzzahligen Wert gesetzt, der dem
+   zweiten Parameter <parameter>chunk_size</parameter> der Funktion übergeben wird.
+   Wird er weggelassen, ist er auf <literal>0</literal> gesetzt.
+  </para>
+  <para>
+   Der Ausgabepuffer, der mit
+   <link linkend="ini.output-buffering">output_buffering</link>
+   auf <literal>"On"</literal> gestartet wurde, hat eine Puffergröße von 0.
+   Wenn er auf einen Integer gesetzt ist, entspricht die Puffergröße dieser Zahl.
+  </para>
+  <para>
+   Die Puffergröße von <literal>"URL-Rewriter"</literal> ist auf <literal>0</literal> gesetzt,
+   daher ist er nur durch den für PHP verfügbaren Speicher begrenzt.
+  </para>
+  <para>
+   Die Größe des Ausgabepuffers von <literal>zlib</literal> wird durch die
+   &php.ini;-Einstellung
+   <link linkend="ini.zlib.output-compression">zlib.output_compression</link>
+   gesteuert.
+   Wenn sie auf <literal>"On"</literal> gesetzt ist, beträgt die Puffergröße
+   <literal>"16K"</literal>/<literal>16384</literal>.
+   Wenn sie auf einen Integer gesetzt ist, entspricht die Puffergröße dieser Zahl in Bytes.
+  </para>
+ </section>
+
+ <section xml:id="outcontrol.operations-on-buffers">
+  <title>Auf Puffern erlaubte Operationen</title>
+  <simpara>
+   Die auf Puffern erlaubten Operationen können gesteuert werden,
+   indem eines der
+   <link linkend="outcontrol.constants.buffer-control-flags">Puffersteuerungs-Flags</link>
+   an den dritten Parameter <parameter>flags</parameter> von
+   <function>ob_start</function> übergeben wird.
+   Wird er weggelassen, sind standardmäßig alle Operationen erlaubt.
+   Wird stattdessen <literal>0</literal> verwendet,
+   kann der Puffer nicht geleert, bereinigt oder entfernt werden,
+   aber sein Inhalt kann weiterhin abgerufen werden.
+  </simpara>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant> erlaubt
+   <function>ob_clean</function>, den Inhalt des Puffers zu bereinigen.
+  </para>
+  <warning>
+   <simpara>
+    Das Fehlen des Flags <constant>PHP_OUTPUT_HANDLER_CLEANABLE</constant>
+    verhindert nicht, dass <function>ob_end_clean</function>
+    oder <function>ob_get_clean</function> den Inhalt des Puffers leeren.
+   </simpara>
+  </warning>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant> erlaubt
+   <function>ob_flush</function>, den Inhalt des Puffers zu leeren.
+  </para>
+  <warning>
+   <simpara>
+    Das Fehlen des Flags <constant>PHP_OUTPUT_HANDLER_FLUSHABLE</constant>
+    verhindert nicht, dass <function>ob_end_flush</function>
+    oder <function>ob_get_flush</function> den Inhalt des Puffers leeren.
+   </simpara>
+  </warning>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> erlaubt
+   <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+   <function>ob_get_clean</function> oder <function>ob_get_flush</function>,
+   den Puffer auszuschalten.
+  </para>
+  <para>
+   <constant>PHP_OUTPUT_HANDLER_STDFLAGS</constant>,
+   die Kombination der drei Flags, erlaubt, dass jede der drei Operationen
+   auf dem Puffer ausgeführt werden kann.
+  </para>
+ </section>
+
+ <section>
+  <title>Leeren, Zugreifen auf und Bereinigen von Pufferinhalten</title>
+  <para>
+   Das Leeren sendet und verwirft den Inhalt des aktiven Puffers.
+   Ausgabepuffer werden geleert, wenn die Größe der Ausgabe
+   die Größe des Puffers überschreitet; das Skript endet oder
+   <function>ob_flush</function>, <function>ob_end_flush</function>
+   oder <function>ob_get_flush</function> aufgerufen wird.
+  </para>
+  <caution>
+   <simpara>
+    Der Aufruf von <function>ob_end_flush</function>
+    oder <function>ob_get_flush</function> schaltet den aktiven Puffer aus.
+   </simpara>
+  </caution>
+  <caution>
+   <simpara>
+    Das Leeren von Puffern leert den Rückgabewert des Ausgabe-Handlers,
+    der sich vom Inhalt des Puffers unterscheiden kann.
+    Zum Beispiel komprimiert die Verwendung von <function>ob_gzhandler</function>
+    die Ausgabe und leert die komprimierte Ausgabe.
+   </simpara>
+  </caution>
+  <para>
+   Der Inhalt des aktiven Puffers kann durch Aufruf von
+   <function>ob_get_contents</function>, <function>ob_get_clean</function>
+   oder <function>ob_get_flush</function> abgerufen werden.
+  </para>
+  <para>
+   Wenn nur die Länge des Pufferinhalts benötigt wird,
+   geben <function>ob_get_length</function> oder <function>ob_get_status</function>
+   die Länge des Inhalts in Bytes zurück.
+  </para>
+  <caution>
+   <simpara>
+    Der Aufruf von <function>ob_get_clean</function>
+    oder <function>ob_get_flush</function> schaltet den aktiven Puffer aus,
+    nachdem dessen Inhalt zurückgegeben wurde.
+   </simpara>
+  </caution>
+  <para>
+   Der Inhalt des aktiven Puffers kann durch Aufruf von
+   <function>ob_clean</function>, <function>ob_end_clean</function>
+   oder <function>ob_get_clean</function> bereinigt werden.
+  </para>
+  <caution>
+   <simpara>
+    Der Aufruf von <function>ob_end_clean</function>
+    oder <function>ob_get_clean</function> schaltet den aktiven Puffer aus.
+   </simpara>
+  </caution>
+ </section>
+
+ <section>
+  <title>Puffer ausschalten</title>
+  <para>
+   Ausgabepuffer können durch Aufruf von
+   <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+   <function>ob_get_flush</function> oder <function>ob_get_clean</function>
+   ausgeschaltet werden.
+  </para>
+  <warning>
+   <simpara>
+    Ausgabepuffer, die ohne das Flag
+    <constant>PHP_OUTPUT_HANDLER_REMOVABLE</constant> gestartet wurden,
+    können nicht ausgeschaltet werden und können ein <constant>E_NOTICE</constant> erzeugen.
+   </simpara>
+  </warning>
+  <para>
+   Jeder Ausgabepuffer, der bis zum Ende des Skripts
+   oder beim Aufruf von <function>exit</function> nicht geschlossen wurde, wird
+   vom Shutdown-Prozess von PHP geleert und ausgeschaltet.
+   Die Puffer werden in umgekehrter Reihenfolge
+   ihres Starts geleert und ausgeschaltet.
+   Der zuletzt gestartete Puffer wird zuerst,
+   der zuerst gestartete Puffer wird zuletzt geleert und ausgeschaltet.
+  </para>
+  <caution>
+   <simpara>
+    Wenn das Leeren des Pufferinhalts nicht erwünscht ist,
+    sollte ein benutzerdefinierter Ausgabe-Handler verwendet werden, um das Leeren während des Shutdowns zu verhindern.
+   </simpara>
+  </caution>
+ </section>
+
+ <section xml:id="outcontrol.output-handlers">
+  <title>Ausgabe-Handler</title>
+  <para>
+   Ausgabe-Handler sind <type>callable</type>s, die mit Ausgabepuffern verknüpft sind
+   und durch Aufruf von <function>ob_clean</function>,
+   <function>ob_flush</function>, <function>ob_end_flush</function>,
+   <function>ob_get_flush</function>, <function>ob_end_clean</function>,
+   <function>ob_get_clean</function> oder während des Shutdown-Prozesses von PHP aufgerufen werden.
+  </para>
+  <note>
+   <simpara>
+    Der Shutdown-Prozess leert den Rückgabewert des Handlers.
+   </simpara>
+  </note>
+  <para>
+   Wird er beim Start des Ausgabepuffers weggelassen oder &null; gesetzt,
+   wird der interne <literal>"default output handler"</literal> verwendet,
+   der beim Aufruf den unveränderten Inhalt des Puffers zurückgibt.
+   Ausgabe-Handler können verwendet werden, um eine veränderte Version
+   des Pufferinhalts zurückzugeben und/oder Nebenwirkungen zu haben (z. B. Header senden).
+  </para>
+  <para>
+   PHP wird mit zwei internen Ausgabe-Handlern ausgeliefert:
+   <literal>"default output handler"</literal>
+   und <literal>"URL-Rewriter"</literal> (der in
+   seinen eigenen Ausgabepuffer integriert ist und von dem nur bis zu zwei Instanzen gestartet werden können).
+  </para>
+  <para>
+   Die mitgelieferten Erweiterungen umfassen vier zusätzliche Ausgabe-Handler:
+   <function>mb_output_handler</function>, <function>ob_gzhandler</function>,
+   <function>ob_iconv_handler</function>, <function>ob_tidyhandler</function>.
+  </para>
+ </section>
+
+ <section xml:id="outcontrol.working-with-output-handlers">
+  <title>Arbeiten mit Ausgabe-Handlern</title>
+  <para>
+   Beim Aufruf werden Ausgabe-Handlern der Inhalt des Puffers
+   und eine Bitmaske übergeben, die den Status der Ausgabepufferung angibt.
+  </para>
+  <para>
+   <methodsynopsis>
+    <type>string</type>
+    <methodname>
+     <replaceable>handler</replaceable>
+    </methodname>
+    <methodparam>
+     <type>string</type>
+     <parameter>buffer</parameter>
+    </methodparam>
+    <methodparam choice="opt">
+     <type>int</type>
+     <parameter>phase</parameter>
+    </methodparam>
+   </methodsynopsis>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>buffer</parameter></term>
+     <listitem>
+      <simpara>
+       Inhalt des Ausgabepuffers.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>phase</parameter></term>
+     <listitem>
+      <simpara>
+       Bitmaske der
+       <link linkend="constant.php-output-handler-start">
+        Konstanten
+        <constant>PHP_OUTPUT_HANDLER_<replaceable>*</replaceable></constant>
+       </link>.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+  <warning>
+   <simpara>
+    Der Aufruf einer der folgenden Funktionen innerhalb eines Ausgabe-Handlers
+    führt zu einem fatalen Fehler:
+    <function>ob_clean</function>, <function>ob_end_clean</function>,
+    <function>ob_end_flush</function>, <function>ob_flush</function>,
+    <function>ob_get_clean</function>, <function>ob_get_flush</function>,
+    <function>ob_start</function>.
+   </simpara>
+  </warning>
+  <note>
+   <simpara>
+    Wenn das <constant>PHP_OUTPUT_HANDLER_DISABLED</constant>-Flag eines Handlers gesetzt ist,
+    wird der Handler beim Aufruf von
+    <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+    <function>ob_get_clean</function>, <function>ob_get_flush</function>,
+    <function>ob_clean</function>,
+    <function>ob_flush</function>
+    oder während des Shutdown-Prozesses von PHP nicht aufgerufen.
+    Vor PHP 8.4.0 hatte dieses Flag beim Aufruf von <function>ob_clean</function>
+    oder <function>ob_flush</function> keine Wirkung.
+   </simpara>
+  </note>
+  <note>
+   <simpara>
+    Das Arbeitsverzeichnis des Skripts kann sich innerhalb der Shutdown-Funktion
+    bei manchen Webservern ändern, z. B. Apache oder dem eingebauten Webserver.
+   </simpara>
+  </note>
+ </section>
+
+ <section xml:id="outcontrol.flags-passed-to-output-handlers">
+  <title>An Ausgabe-Handler übergebene Flags</title>
+  <para>
+   Die an den zweiten Parameter <parameter>phase</parameter>
+   des Ausgabe-Handlers übergebene Bitmaske liefert Informationen über den Aufruf des Handlers.
+  </para>
+  <note>
+   <simpara>
+    Die Bitmaske kann mehr als ein Flag enthalten,
+    und der bitweise Operator <literal>&amp;</literal> sollte verwendet werden,
+    um zu prüfen, ob ein Flag gesetzt ist.
+   </simpara>
+  </note>
+  <warning>
+   <simpara>
+    Der Wert von <constant>PHP_OUTPUT_HANDLER_WRITE</constant> und seinem Alias
+    <constant>PHP_OUTPUT_HANDLER_CONT</constant> ist <literal>0</literal>,
+    daher kann nur durch Verwendung eines
+    <link linkend="language.operators.comparison">Gleichheitsoperators</link>
+    (<literal>==</literal> oder <literal>===</literal>) festgestellt werden, ob es gesetzt ist.
+   </simpara>
+  </warning>
+  <para>
+   Die folgenden Flags werden in einer bestimmten Phase des Lebenszyklus des Handlers gesetzt:
+   <constant>PHP_OUTPUT_HANDLER_START</constant> wird gesetzt,
+   wenn ein Handler zum ersten Mal aufgerufen wird.
+   <constant>PHP_OUTPUT_HANDLER_FINAL</constant>
+   oder sein Alias <constant>PHP_OUTPUT_HANDLER_END</constant>
+   wird gesetzt, wenn ein Handler zum letzten Mal aufgerufen wird,
+   d. h. wenn er ausgeschaltet wird. Dieses Flag wird auch gesetzt,
+   wenn Puffer vom Shutdown-Prozess von PHP ausgeschaltet werden.
+  </para>
+  <para>
+   Die folgenden Flags werden durch einen bestimmten Aufruf des Handlers gesetzt:
+   <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> wird gesetzt,
+   wenn der Handler durch Aufruf von <function>ob_flush</function> aufgerufen wird.
+   <constant>PHP_OUTPUT_HANDLER_WRITE</constant>
+   oder sein Alias <constant>PHP_OUTPUT_HANDLER_CONT</constant>
+   wird gesetzt, wenn die Größe seines Inhalts der Größe des Puffers entspricht oder sie überschreitet
+   und der Handler aufgerufen wird, während der Puffer automatisch geleert wird.
+   <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> wird gesetzt,
+   wenn der Handler durch Aufruf von <function>ob_clean</function>,
+   <function>ob_end_clean</function> oder <function>ob_get_clean</function> aufgerufen wird.
+   Wenn <function>ob_end_clean</function> oder <function>ob_get_clean</function>
+   aufgerufen wird, wird auch <constant>PHP_OUTPUT_HANDLER_FINAL</constant> gesetzt.
+  </para>
+  <note>
+   <simpara>
+    Wenn <function>ob_end_flush</function> oder <function>ob_get_flush</function>
+    aufgerufen wird, wird <constant>PHP_OUTPUT_HANDLER_FINAL</constant> gesetzt,
+    aber <constant>PHP_OUTPUT_HANDLER_FLUSH</constant> nicht.
+   </simpara>
+  </note>
+ </section>
+
+ <section xml:id="outcontrol.output-handler-return-values">
+  <title>Rückgabewerte von Ausgabe-Handlern</title>
+  <para>
+   Der Rückgabewert des Ausgabe-Handlers wird intern gemäß der
+   standardmäßigen PHP-Typsemantik in eine Zeichenkette umgewandelt, mit zwei Ausnahmen:
+   <type>array</type>s und <type>bool</type>eans.
+  </para>
+  <para>
+   Arrays werden in die Zeichenkette <literal>"Array"</literal> umgewandelt,
+   aber die Warnung <literal>Array to string conversion</literal>
+   wird nicht ausgelöst.
+  </para>
+  <para>
+   Wenn der Handler &false; zurückgibt, wird der Inhalt des Puffers zurückgegeben.
+   Wenn der Handler &true; zurückgibt, wird eine leere Zeichenkette zurückgegeben.
+  </para>
+  <note>
+   <simpara>
+    Wenn ein Handler &false; zurückgibt oder eine Exception wirft,
+    wird sein Status-Flag <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> gesetzt.
+   </simpara>
+  </note>
+ </section>
+
+ <section>
+  <title>In Ausgabe-Handlern geworfene Exceptions</title>
+  <para>
+   Wenn in einem Ausgabe-Handler eine nicht abgefangene Exception geworfen wird,
+   wird das Programm beendet und der Handler
+   vom Shutdown-Prozess aufgerufen, woraufhin
+   die Fehlermeldung <literal>"Uncaught Exception"</literal> geleert wird.
+  </para>
+  <para>
+   Wenn die nicht abgefangene Exception in einem Handler geworfen wird,
+   der von <function>ob_flush</function>,
+   <function>ob_end_flush</function> oder <function>ob_get_flush</function> aufgerufen wird,
+   wird der Inhalt des Puffers vor der Fehlermeldung geleert.
+  </para>
+  <para>
+   Wenn in einem Ausgabe-Handler während des Shutdowns eine nicht abgefangene Exception geworfen wird,
+   wird der Handler beendet und weder der Inhalt des Puffers
+   noch die Fehlermeldung geleert.
+  </para>
+  <note>
+   <simpara>
+    Wenn ein Handler eine Exception wirft,
+    wird sein Status-Flag <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> gesetzt.
+   </simpara>
+  </note>
+ </section>
+
+ <section>
+  <title>In Ausgabe-Handlern ausgelöste Fehler</title>
+  <para>
+   Wenn in einem Ausgabe-Handler ein nicht fataler Fehler ausgelöst wird,
+   setzt das Programm seine Ausführung fort.
+  </para>
+  <para>
+   Wenn der nicht fatale Fehler in einem Handler ausgelöst wird, der von
+   <function>ob_flush</function>, <function>ob_end_flush</function>
+   oder <function>ob_get_flush</function> aufgerufen wird,
+   leert der Puffer abhängig vom Rückgabewert des Handlers bestimmte Daten.
+   Wenn der Handler &false; zurückgibt, werden der Puffer und die Fehlermeldung geleert.
+   Wenn er etwas anderes zurückgibt, wird der Rückgabewert des Handlers geleert,
+   aber nicht die Fehlermeldung.
+  </para>
+  <note>
+   <simpara>
+    Wenn ein Handler &false; zurückgibt,
+    wird sein Status-Flag <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> gesetzt.
+   </simpara>
+  </note>
+  <para>
+   Wenn in einem Ausgabe-Handler ein fataler Fehler ausgelöst wird,
+   wird das Programm beendet und der Handler
+   vom Shutdown-Prozess aufgerufen, woraufhin die Fehlermeldung geleert wird.
+  </para>
+  <para>
+   Wenn der fatale Fehler in einem Handler ausgelöst wird,
+   der von <function>ob_flush</function>,
+   <function>ob_end_flush</function> oder <function>ob_get_flush</function> aufgerufen wird,
+   wird der Inhalt der Puffer vor der Fehlermeldung geleert.
+  </para>
+  <para>
+   Wenn während des Shutdowns in einem Ausgabe-Handler ein fataler Fehler ausgelöst wird,
+   wird das Programm beendet, ohne den Puffer oder die Fehlermeldung zu leeren.
+  </para>
+ </section>
+
+ <section>
+  <title>Ausgabe in Ausgabe-Handlern</title>
+  <para>
+   Unter bestimmten Umständen wird die im Handler erzeugte Ausgabe
+   zusammen mit dem Inhalt des Puffers geleert.
+   Diese Ausgabe wird nicht an den Puffer angehängt und ist nicht Teil der Zeichenkette,
+   die von <function>ob_get_flush</function> zurückgegeben wird.
+  </para>
+  <para>
+   Während Leeroperationen (Aufruf von <function>ob_flush</function>,
+   <function>ob_end_flush</function>, <function>ob_get_flush</function>
+   und während des Shutdowns)
+   wird, wenn der Rückgabewert eines Handlers &false; ist,
+   der Inhalt des Puffers gefolgt von der Ausgabe geleert.
+   Wenn der Handler nicht während des Shutdowns aufgerufen wird,
+   führt das Werfen einer Exception durch den Handler oder der Aufruf von <function>exit</function>
+   zum gleichen Verhalten.
+  </para>
+  <note>
+   <simpara>
+    Wenn ein Handler &false; zurückgibt,
+    wird sein Status-Flag <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> gesetzt.
+   </simpara>
+  </note>
+ </section>
+
+ <section>
+  <title>Status-Flags von Ausgabe-Handlern</title>
+  <para>
+   Die
+   <link linkend="outcontrol.constants.flags-returned-by-handler">
+    Handler-Status-Flags
+   </link> der Bitmaske <literal>flags</literal> des Puffers
+   werden jedes Mal gesetzt, wenn der Ausgabe-Handler aufgerufen wird,
+   und sind Teil der von <function>ob_get_status</function> zurückgegebenen
+   <literal>flags</literal>.
+   Wenn der Handler erfolgreich ausgeführt wird und nicht &false; zurückgibt,
+   werden <constant>PHP_OUTPUT_HANDLER_STARTED</constant> und
+   <constant>PHP_OUTPUT_HANDLER_PROCESSED</constant> gesetzt.
+   Wenn der Handler &false; zurückgibt oder während der Ausführung eine Exception wirft,
+   werden <constant>PHP_OUTPUT_HANDLER_STARTED</constant> und
+   <constant>PHP_OUTPUT_HANDLER_DISABLED</constant> gesetzt.
+  </para>
+  <note>
+   <simpara>
+    Wenn das <constant>PHP_OUTPUT_HANDLER_DISABLED</constant>-Flag eines Handlers gesetzt ist,
+    wird der Handler beim Aufruf von
+    <function>ob_end_clean</function>, <function>ob_end_flush</function>,
+    <function>ob_get_clean</function>, <function>ob_get_flush</function>,
+    <function>ob_clean</function>,
+    <function>ob_flush</function>
+    oder während des Shutdown-Prozesses von PHP nicht aufgerufen.
+    Vor PHP 8.4.0 hatte dieses Flag beim Aufruf von <function>ob_clean</function>
+    oder <function>ob_flush</function> keine Wirkung.
+   </simpara>
+  </note>
+ </section>
+
+</chapter>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo/pdo/connect.xml
+++ b/reference/pdo/pdo/connect.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="pdo.connect" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <refnamediv>
+  <refname>PDO::connect</refname>
+  <refpurpose>Stellt eine Verbindung zu einer Datenbank her und gibt für Treiber, die dies unterstützen, eine PDO-Unterklasse zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="PDO">
+   <modifier>public</modifier> <modifier>static</modifier> <type>static</type><methodname>PDO::connect</methodname>
+   <methodparam><type>string</type><parameter>dsn</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>username</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><modifier role="attribute">#[\SensitiveParameter]</modifier><type class="union"><type>string</type><type>null</type></type><parameter>password</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Erzeugt eine Instanz einer <classname>PDO</classname>-Unterklasse für die
+   Datenbank, mit der eine Verbindung hergestellt wird, sofern sie existiert,
+   andernfalls wird eine generische <classname>PDO</classname>-Instanz zurückgegeben.
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='parameters']/.)">
+  <xi:fallback/>
+ </xi:include>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt eine Instanz einer <classname>PDO</classname>-Unterklasse für den
+   entsprechenden PDO-Treiber zurück, sofern sie existiert,
+   andernfalls eine generische <classname>PDO</classname>-Instanz.
+  </simpara>
+ </refsect1>
+
+ <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('pdo.construct')/db:refsect1[@role='errors']/.)">
+  <xi:fallback/>
+ </xi:include>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><classname>Pdo\Dblib</classname></member>
+   <member><classname>Pdo\Firebird</classname></member>
+   <member><classname>Pdo\Mysql</classname></member>
+   <member><classname>Pdo\Odbc</classname></member>
+   <member><classname>Pdo\Pgsql</classname></member>
+   <member><classname>Pdo\Sqlite</classname></member>
+   <member><methodname>PDO::__construct</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo_cubrid/constants.xml
+++ b/reference/pdo_cubrid/constants.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<section xml:id="pdo-cubrid.constants" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.constants;
+ &pdo.driver-constants;
+  <para>
+   Die folgenden Konstanten können beim Setzen des Datenbankattributs verwendet werden.
+   Sie können an <function>PDO::getAttribute</function> oder
+   <function>PDO::setAttribute</function> übergeben werden.
+  <table>
+   <title>PDO::CUBRID-Attribut-Flags</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row xml:id="pdo.constants.cubrid-attr-isolation-level">
+       <entry><constant>PDO::CUBRID_ATTR_ISOLATION_LEVEL</constant></entry>
+       <entry>Transaktionsisolationsebene für die Datenbankverbindung.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-attr-lock-timeout">
+       <entry><constant>PDO::CUBRID_ATTR_LOCK_TIMEOUT</constant></entry>
+       <entry>Transaktions-Timeout in Sekunden.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-attr-max-string-length">
+       <entry><constant>PDO::CUBRID_ATTR_MAX_STRING_LENGTH</constant></entry>
+       <entry>Nur lesbar. Die maximale Zeichenkettenlänge für die Datentypen
+        bit, varbit, char, varchar, nchar und nchar varying bei Verwendung der
+        CUBRID-PDO-API.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Setzen der Transaktionsisolationsebene
+   verwendet werden. Sie können an <function>PDO::getAttribute</function> übergeben oder
+   von <function>PDO::setAttribute</function> zurückgegeben werden.
+  <table>
+   <title>PDO::CUBRID-Isolationsebenen-Flags</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row xml:id="pdo.constants.tran-commit-class-uncommit-instance">
+       <entry><constant>PDO::TRAN_COMMIT_CLASS_UNCOMMIT_INSTANCE</constant></entry>
+       <entry>Die niedrigste Isolationsebene (1). Für das Tupel kann ein
+        Dirty Read, Non-Repeatable Read oder Phantom Read auftreten, und für
+        die Tabelle kann ebenfalls ein Non-Repeatable Read auftreten.</entry>
+      </row>
+      <row xml:id="pdo.constants.tran-commit-class-commit-instance">
+       <entry><constant>PDO::TRAN_COMMIT_CLASS_COMMIT_INSTANCE</constant></entry>
+       <entry>Eine relativ niedrige Isolationsebene (2). Ein Dirty Read tritt
+        nicht auf, aber ein Non-Repeatable Read oder Phantom Read kann auftreten.</entry>
+      </row>
+      <row xml:id="pdo.constants.tran-rep-class-uncommit-instance">
+       <entry><constant>PDO::TRAN_REP_CLASS_UNCOMMIT_INSTANCE</constant></entry>
+       <entry>Die Standardisolation von CUBRID (3). Für das Tupel kann ein
+        Dirty Read, Non-Repeatable Read oder Phantom Read auftreten, aber für
+        die Tabelle ist ein Repeatable Read gewährleistet.</entry>
+      </row>
+      <row xml:id="pdo.constants.tran-rep-class-commit-instance">
+       <entry><constant>PDO::TRAN_REP_CLASS_COMMIT_INSTANCE</constant></entry>
+       <entry>Eine relativ niedrige Isolationsebene (4). Ein Dirty Read tritt
+        nicht auf, aber ein Non-Repeatable Read oder Phantom Read kann.</entry>
+      </row>
+      <row xml:id="pdo.constants.tran-rep-class-rep-instance">
+       <entry><constant>PDO::TRAN_REP_CLASS_REP_INSTANCE</constant></entry>
+       <entry>Eine relativ hohe Isolationsebene (5). Ein Dirty Read oder
+       Non-Repeatable Read tritt nicht auf, aber ein Phantom Read kann.</entry>
+      </row>
+      <row xml:id="pdo.constants.tran-serializable">
+       <entry><constant>PDO::TRAN_SERIALIZABLE</constant></entry>
+       <entry>Die höchste Isolationsebene (6). Probleme im Zusammenhang mit
+       Nebenläufigkeit (z. B. Dirty Read, Non-Repeatable Read, Phantom Read usw.)
+       treten nicht auf.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+
+  <para>
+   Die folgenden Konstanten können beim Abrufen von Schemainformationen verwendet werden.
+   Sie können an <function>PDO::cubrid_schema</function> übergeben werden.
+  <table>
+   <title>PDO::CUBRID-Schema-Flags</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Konstante</entry>
+       <entry>Beschreibung</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row xml:id="pdo.constants.cubrid-sch-table">
+       <entry><constant>PDO::CUBRID_SCH_TABLE</constant></entry>
+       <entry>Ruft Name und Typ einer Tabelle in CUBRID ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-view">
+       <entry><constant>PDO::CUBRID_SCH_VIEW</constant></entry>
+       <entry>Ruft Name und Typ einer View in CUBRID ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-query-spec">
+       <entry><constant>PDO::CUBRID_SCH_QUERY_SPEC</constant></entry>
+       <entry>Ruft die Abfragedefinition einer View ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-attribute">
+       <entry><constant>PDO::CUBRID_SCH_ATTRIBUTE</constant></entry>
+       <entry>Ruft die Attribute einer Tabellenspalte ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-table-attribute">
+       <entry><constant>PDO::CUBRID_SCH_TABLE_ATTRIBUTE</constant></entry>
+       <entry>Ruft die Attribute einer Tabelle ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-method">
+       <entry><constant>PDO::CUBRID_SCH_METHOD</constant></entry>
+       <entry>Ruft die Instanzmethode ab. Die Instanzmethode ist eine Methode,
+       die von einer Klasseninstanz aufgerufen wird. Sie wird häufiger verwendet
+       als die Klassenmethode, da die meisten Operationen in der Instanz
+       ausgeführt werden.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-table-method">
+       <entry><constant>PDO::CUBRID_SCH_TABLE_METHOD</constant></entry>
+       <entry>Ruft die Klassenmethode ab. Die Klassenmethode ist eine Methode,
+        die von einem Klassenobjekt aufgerufen wird. Sie wird üblicherweise
+        verwendet, um eine neue Klasseninstanz zu erstellen oder zu
+        initialisieren. Sie wird auch verwendet, um auf Klassenattribute
+        zuzugreifen oder sie zu aktualisieren.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-method-file">
+       <entry><constant>PDO::CUBRID_SCH_METHOD_FILE</constant></entry>
+       <entry>Ruft die Informationen der Datei ab, in der die Methode der
+        Tabelle definiert ist.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-super-table">
+       <entry><constant>PDO::CUBRID_SCH_SUPER_TABLE</constant></entry>
+       <entry>Ruft Name und Typ der Tabelle ab, von der die Tabelle Attribute
+        erbt.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-sub-table">
+       <entry><constant>PDO::CUBRID_SCH_SUB_TABLE</constant></entry>
+       <entry>Ruft Name und Typ der Tabelle ab, die Attribute von dieser
+        Tabelle erbt.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-constraint">
+       <entry><constant>PDO::CUBRID_SCH_CONSTRAINT</constant></entry>
+       <entry>Ruft die Tabellen-Constraints ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-trigger">
+       <entry><constant>PDO::CUBRID_SCH_TRIGGER</constant></entry>
+       <entry>Ruft die Tabellen-Trigger ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-table-privilege">
+       <entry><constant>PDO::CUBRID_SCH_TABLE_PRIVILEGE</constant></entry>
+       <entry>Ruft die Berechtigungsinformationen einer Tabelle ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-col-privilege">
+       <entry><constant>PDO::CUBRID_SCH_COL_PRIVILEGE</constant></entry>
+       <entry>Ruft die Berechtigungsinformationen einer Spalte ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-direct-super-table">
+       <entry><constant>PDO::CUBRID_SCH_DIRECT_SUPER_TABLE</constant></entry>
+       <entry>Ruft die direkte Supertabelle einer Tabelle ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-primary-key">
+       <entry><constant>PDO::CUBRID_SCH_PRIMARY_KEY</constant></entry>
+       <entry>Ruft den Primärschlüssel einer Tabelle ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-imported-keys">
+       <entry><constant>PDO::CUBRID_SCH_IMPORTED_KEYS</constant></entry>
+       <entry>Ruft die importierten Schlüssel einer Tabelle ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-exported-keys">
+       <entry><constant>PDO::CUBRID_SCH_EXPORTED_KEYS</constant></entry>
+       <entry>Ruft die exportierten Schlüssel einer Tabelle ab.</entry>
+      </row>
+      <row xml:id="pdo.constants.cubrid-sch-cross-reference">
+       <entry><constant>PDO::CUBRID_SCH_CROSS_REFERENCE</constant></entry>
+       <entry>Ruft die Referenzbeziehung zweier Tabellen ab.</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+  </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/phar/ini.xml
+++ b/reference/phar/ini.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 525aa5f198d482c0d03be54ddee5af13b376ab99 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<section xml:id="phar.configuration" xmlns="http://docbook.org/ns/docbook">
+ &reftitle.runtime;
+ &extension.runtime;
+ <para>
+  <table>
+   <title>Konfigurationsoptionen für Dateisystem und Streams</title>
+   <tgroup cols="4">
+    <thead>
+     <row>
+      <entry>&Name;</entry>
+      <entry>&Default;</entry>
+      <entry>&Changeable;</entry>
+      <entry>&Changelog;</entry>
+     </row>
+    </thead>
+    <tbody xml:id="phar.configuration.list">
+     <row>
+      <entry><link linkend="ini.phar.readonly">phar.readonly</link></entry>
+      <entry>"1"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.phar.require-hash">phar.require_hash</link></entry>
+      <entry>"1"</entry>
+      <entry><constant>INI_ALL</constant></entry>
+      <entry></entry>
+     </row>
+     <row>
+      <entry><link linkend="ini.phar.cache-list">phar.cache_list</link></entry>
+      <entry>""</entry>
+      <entry><constant>INI_SYSTEM</constant></entry>
+      <entry></entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+ </para>
+
+ &ini.descriptions.title;
+
+ <para>
+  <variablelist>
+   <varlistentry xml:id="ini.phar.readonly">
+    <term>
+     <parameter>phar.readonly</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <para>
+      Diese Option deaktiviert das Erstellen oder Verändern von Phar-Archiven
+      über den Stream <literal>phar</literal> oder die Schreibunterstützung des
+      <classname>Phar</classname>-Objekts. Diese Einstellung sollte auf
+      Produktionsmaschinen immer aktiviert sein, da die bequeme
+      Schreibunterstützung der Phar-Erweiterung in Kombination mit anderen
+      gängigen Sicherheitslücken die unkomplizierte Erstellung eines
+      PHP-basierten Virus erlauben könnte.
+     </para>
+     <note>
+      <para>
+       Diese Einstellung kann aus Sicherheitsgründen nur in der php.ini
+       deaktiviert werden. Wenn <literal>phar.readonly</literal> in der php.ini
+       deaktiviert ist, darf der Benutzer <literal>phar.readonly</literal> in
+       einem Skript aktivieren oder später deaktivieren. Wenn
+       <literal>phar.readonly</literal> in der php.ini aktiviert ist, darf ein
+       Skript die INI-Variable harmlos &quot;erneut aktivieren&quot;, sie aber
+       nicht deaktivieren.
+      </para>
+     </note>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.phar.require-hash">
+    <term>
+     <parameter>phar.require_hash</parameter>
+     <type>bool</type>
+    </term>
+    <listitem>
+     <para>
+      Diese Option erzwingt, dass alle geöffneten Phar-Archive eine Art
+      Signatur enthalten (derzeit werden MD5, SHA1, SHA256, SHA512 und OpenSSL unterstützt), und
+      verweigert die Verarbeitung jedes Phar-Archivs, das keine Signatur enthält.
+     </para>
+     <note>
+      <para>
+       Diese Einstellung kann nur in der php.ini deaktiviert werden.
+       Wenn <literal>phar.require_hash</literal> in der php.ini deaktiviert ist,
+       darf der Benutzer <literal>phar.require_hash</literal> in einem Skript
+       aktivieren oder später deaktivieren. Wenn
+       <literal>phar.require_hash</literal> in der php.ini aktiviert ist, darf
+       ein Skript die INI-Variable harmlos &quot;erneut aktivieren&quot;, sie
+       aber nicht deaktivieren.
+      </para>
+      <para>
+       Diese Einstellung hat keine Auswirkung auf das Lesen einfacher
+       tar-Dateien mit der Klasse <classname>PharData</classname>.
+      </para>
+     </note>
+     <caution>
+      <simpara>
+       <literal>phar.require_hash</literal> bietet an sich keine Sicherheit,
+       es ist lediglich eine Maßnahme gegen das versehentliche Ausführen
+       beschädigter Phar-Archive, denn jeder, der das Phar manipulieren könnte,
+       könnte die Signatur anschließend leicht korrigieren.
+      </simpara>
+     </caution>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry xml:id="ini.phar.cache-list">
+    <term>
+     <parameter>phar.cache_list</parameter>
+     <type>string</type>
+    </term>
+    <listitem>
+     <para>
+      Erlaubt es, Phar-Archive abzubilden, damit sie beim Start des Webservers
+      vorab geparst werden, was eine Leistungsverbesserung bietet, die das
+      Ausführen von Dateien aus einem Phar-Archiv sehr nahe an die
+      Geschwindigkeit bringt, mit der diese Dateien aus einer herkömmlichen
+      festplattenbasierten Installation ausgeführt werden.
+      <example>
+       <title>Verwendungsbeispiel für phar.cache_list</title>
+       <programlisting>
+<![CDATA[
+in php.ini (windows):
+phar.cache_list =C:\path\to\phar1.phar;C:\path\to\phar2.phar
+in php.ini (unix):
+phar.cache_list =/path/to/phar1.phar:/path/to/phar2.phar
+]]>
+       </programlisting>
+      </example>
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </para>
+</section>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/svn/functions/svn-fs-apply-text.xml
+++ b/reference/svn/functions/svn-fs-apply-text.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.svn-fs-apply-text">
+ <refnamediv>
+  <refname>svn_fs_apply_text</refname>
+  <refpurpose>Erzeugt und gibt einen Stream zurück, der zum Ersetzen des Inhalts einer Datei verwendet wird</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>resource</type><methodname>svn_fs_apply_text</methodname>
+   <methodparam><type>resource</type><parameter>root</parameter></methodparam>
+   <methodparam><type>string</type><parameter>path</parameter></methodparam>
+  </methodsynopsis>
+  &warn.undocumented.func;
+  <simpara>
+   Erzeugt und gibt einen Stream zurück, der zum Ersetzen des Inhalts einer Datei verwendet wird.
+  </simpara>
+ </refsect1>
+<!--
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>root</parameter></term>
+     <listitem>
+      <para>
+       Its description
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>path</parameter></term>
+     <listitem>
+      <para>
+       Its description
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   What the function returns, first on success, then on failure. See
+   also the &amp;return.success; entity
+  </para>
+ </refsect1>
+-->
+ <refsect1 role="notes">
+  &reftitle.notes;
+  &warn.experimental.func;
+ </refsect1>
+
+ <!-- Use when ERRORS exist
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   When does this function throw E_* level errors, or exceptions?
+  </para>
+ </refsect1>
+ -->
+
+ <!-- Use when a CHANGELOG exists
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>Enter the PHP version of change here</entry>
+       <entry>Description of change</entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+ -->
+
+ <!-- Use when examples exist
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>A <function>svn_fs_apply_text</function> example</title>
+    <para>
+     Any text that describes the purpose of the example, or
+     what goes on in the example should go here (inside the
+     <example> tag, not out
+    </para>
+    <programlisting role="php">
+<![CDATA[
+<?php
+if ($anexample === true) {
+    echo 'Use the PEAR Coding Standards';
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+Use the PEAR Coding Standards
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+ -->
+
+ <!-- Use when adding See Also links
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function></function></member>
+    <member>Or <link linkend="somethingelse">something else</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+ -->
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/sync/book.xml
+++ b/reference/sync/book.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<book xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="book.sync">
+ <?phpdoc extension-membership="pecl" ?>
+ <title>Sync</title>
+ <titleabbrev>Sync</titleabbrev>
+
+ <preface xml:id="intro.sync">
+  &reftitle.intro;
+  <simpara>
+   Die Erweiterung <literal>sync</literal> führt plattformübergreifende Synchronisationsobjekte in PHP ein.
+   Benannte und unbenannte Objekte vom Typ Mutex, Semaphore, Event, Reader-Writer und
+   benannte Shared-Memory-Objekte stellen Synchronisation auf Betriebssystemebene sowohl auf
+   POSIX- (z. B. Linux) als auch auf Windows-Plattformen bereit.
+  </simpara>
+  <simpara>
+   Während des Abbaus der Erweiterung erfolgt eine automatische Bereinigung der belegten
+   Synchronisationsobjekte. Das bedeutet, dass Objekte nicht in einem unbekannten Zustand
+   zurückbleiben, wenn PHP ein Skript vorzeitig beendet (z. B. weil die Ausführungszeit des
+   Skripts überschritten wird). Die einzige Ausnahme ist, wenn PHP selbst abstürzt
+   (z. B. durch einen internen Pufferüberlauf).
+  </simpara>
+  <simpara>
+   Unbenannte Synchronisationsobjekte sind außerhalb eines Multithread-Szenarios von
+   wenig Nutzen. Unbenannte Objekte sind in Verbindung mit der PECL-Erweiterung pthreads
+   nützlicher.
+  </simpara>
+  <note>
+   <simpara>
+    Benannte Objekte erfordern auf allen Systemen besondere Sorgfalt bei der Verwendung.
+    Wenn ein Objekt mit einem bestimmten Satz von Parametern instanziiert wird, muss es
+    immer mit diesen Parametern instanziiert werden, andernfalls landet das Objekt
+    wahrscheinlich in einem inkonsistenten Zustand, bis das System neu gestartet wird
+    oder ein Systemadministrator das Chaos beseitigt.
+   </simpara>
+  </note>
+ </preface>
+
+ &reference.sync.setup;
+ &reference.sync.syncmutex;
+ &reference.sync.syncsemaphore;
+ &reference.sync.syncevent;
+ &reference.sync.syncreaderwriter;
+ &reference.sync.syncsharedmemory;
+
+</book>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/xml/functions/xml-parser-set-option.xml
+++ b/reference/xml/functions/xml-parser-set-option.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.xml-parser-set-option" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>xml_parser_set_option</refname>
+  <refpurpose>Setzt Optionen in einem XML-Parser</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>xml_parser_set_option</methodname>
+   <methodparam><type>XMLParser</type><parameter>parser</parameter></methodparam>
+   <methodparam><type>int</type><parameter>option</parameter></methodparam>
+   <methodparam><type class="union"><type>string</type><type>int</type><type>bool</type></type><parameter>value</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Setzt eine Option in einem XML-Parser.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>parser</parameter></term>
+     <listitem>
+      <para>
+       Eine Referenz auf den XML-Parser, in dem eine Option gesetzt werden soll.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>option</parameter></term>
+     <listitem>
+      <para>
+       Welche Option gesetzt werden soll. Siehe unten.
+      </para>
+      <para>
+       Die folgenden Optionen sind verfügbar:
+       <table>
+        <title>XML-Parser-Optionen</title>
+        <tgroup cols="3">
+         <thead>
+          <row>
+           <entry>Optionskonstante</entry>
+           <entry>Datentyp</entry>
+           <entry>Beschreibung</entry>
+          </row>
+         </thead>
+         <tbody>
+          <row>
+           <entry><constant>XML_OPTION_CASE_FOLDING</constant></entry>
+           <entry>bool</entry>
+           <entry>
+            Steuert, ob die <link
+            linkend="xml.case-folding">Groß-/Kleinschreibungsumwandlung</link> für
+            diesen XML-Parser aktiviert ist. Standardmäßig aktiviert.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>XML_OPTION_PARSE_HUGE</constant></entry>
+           <entry>bool</entry>
+           <entry>
+            Erlaubt das Parsen von Dokumenten, die größer als 10 MB sind.
+            Diese Option sollte nur aktiviert werden, wenn die Dokumentgröße
+            begrenzt ist, da sie andernfalls zu einem DoS führen könnte.
+            Diese Option ist nur verfügbar, wenn libxml2 verwendet wird.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>XML_OPTION_SKIP_TAGSTART</constant></entry>
+           <entry>integer</entry>
+           <entry>
+            Gibt an, wie viele Zeichen am Anfang eines Tag-Namens übersprungen
+            werden sollen.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>XML_OPTION_SKIP_WHITE</constant></entry>
+           <entry>bool</entry>
+           <entry>
+            Ob Werte übersprungen werden sollen, die aus Leerraumzeichen bestehen.
+           </entry>
+          </row>
+          <row>
+           <entry><constant>XML_OPTION_TARGET_ENCODING</constant></entry>
+           <entry>string</entry>
+           <entry>
+            Legt fest, welche <link linkend="xml.encoding">Zielkodierung</link> in
+            diesem XML-Parser verwendet werden soll. Standardmäßig ist sie auf
+            dieselbe wie die von <function>xml_parser_create</function> verwendete
+            Quellkodierung gesetzt.
+            Unterstützte Zielkodierungen sind <literal>ISO-8859-1</literal>,
+            <literal>US-ASCII</literal> und <literal>UTF-8</literal>.
+           </entry>
+          </row>
+         </tbody>
+        </tgroup>
+       </table>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       Der neue Wert der Option.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt bei Erfolg &true; zurück. Im Fehlerfall wird &false; zurückgegeben.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Wirft einen <classname>ValueError</classname>, wenn ein ungültiger Wert an
+   <parameter>option</parameter> übergeben wird.
+  </para>
+  <simpara>
+   Vor PHP 8.0.0 erzeugte die Übergabe eines ungültigen Werts an
+   <parameter>option</parameter> ein <constant>E_WARNING</constant>
+   und ließ die Funktion &false; zurückgeben.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Die Option <constant>XML_OPTION_PARSE_HUGE</constant> wurde hinzugefügt.
+      </entry>
+     </row>
+     <row>
+      <entry>8.3.0</entry>
+      <entry>
+       Der Parameter <parameter>value</parameter> akzeptiert nun auch Booleans.
+       Die Optionen <constant>XML_OPTION_CASE_FOLDING</constant> und <constant>XML_OPTION_SKIP_WHITE</constant>
+       sind nun boolesche Optionen.
+      </entry>
+     </row>
+     &xml.changelog.parser-param;
+     <row>
+      <entry>8.0.0</entry>
+      <entry>
+       Es wird nun ein <classname>ValueError</classname> geworfen, wenn
+       <parameter>option</parameter> ungültig ist.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaconf/yaconf.xml
+++ b/reference/yaconf/yaconf.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 330a38c4d45556b49e06ebe6d39e0e311534cd8c Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<reference xml:id="class.yaconf" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Die Yaconf-Klasse</title>
+ <titleabbrev>Yaconf</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ Yaconf intro -->
+  <section xml:id="yaconf.intro">
+   &reftitle.intro;
+   <simpara>
+    Yaconf ist ein Konfigurationscontainer.
+    Er parst INI-Dateien und speichert das Ergebnis in
+    PHP beim Start von PHP, das Ergebnis bleibt
+    während des gesamten PHP-Lebenszyklus erhalten.
+   </simpara>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="yaconf.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>Yaconf</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <ooclass>
+      <classname>Yaconf</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.yaconf')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+ </partintro>
+
+ &reference.yaconf.entities.yaconf;
+
+</reference>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yar/yar_concurrent_client/loop.xml
+++ b/reference/yar/yar_concurrent_client/loop.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+
+<refentry xml:id="yar-concurrent-client.loop" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Yar_Concurrent_Client::loop</refname>
+  <refpurpose>Sendet alle Aufrufe</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>public</modifier> <modifier>static</modifier> <type>bool</type><methodname>Yar_Concurrent_Client::loop</methodname>
+   <methodparam choice="opt"><type>callable</type><parameter>callback</parameter></methodparam>
+   <methodparam choice="opt"><type>callable</type><parameter>error_callback</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+    Sendet alle registrierten entfernten RPC-Aufrufe.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>callback</parameter></term>
+    <listitem>
+     <para>
+      Wenn dieser Callback gesetzt ist, ruft Yar ihn auf, nachdem alle
+      Aufrufe gesendet wurden und bevor eine Antwort zurückkommt, mit einem
+      $callinfo von NULL.
+     </para>
+     <para>
+      Wenn der Benutzer dann beim Registrieren des nebenläufigen Aufrufs
+      keinen Callback angegeben hat, wird dieser Callback zur Verarbeitung
+      der Antwort verwendet, andernfalls wird der beim Registrieren
+      angegebene Callback verwendet.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>error_callback</parameter></term>
+    <listitem>
+     <para>
+      Wenn dieser Callback gesetzt ist, ruft Yar ihn auf, wenn ein Fehler
+      auftritt.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <function>Yar_Concurrent_Client::loop</function></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+function callback($retval, $callinfo) {
+     if ($callinfo == NULL) {
+        echo "Now, all requests are sent, and no response available\n";
+     } else {
+        echo "This is a remote call response, the method name is", $callinfo["method"],
+             ". calling sequence is " , $callinfo["sequence"] , "\n";
+        var_dump($retval);
+     }
+}
+
+function error_callback($type, $error, $callinfo) {
+    error_log($error);
+}
+
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback");
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"));   // wenn der Callback nicht angegeben ist,
+                                                                               // wird der Callback in loop verwendet
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_PACKAGER => "json"));
+                                                                               //dieser Server akzeptiert den json-Packager
+Yar_Concurrent_Client::call("http://host/api/", "some_method", array("parameters"), "callback", NULL, array(YAR_OPT_TIMEOUT=>1));
+                                                                               //benutzerdefiniertes Timeout
+
+Yar_Concurrent_Client::loop("callback", "error_callback"); //sendet die Anfragen,
+                                                           //der error_callback ist optional
+?>
+]]>
+   </programlisting>
+   &example.outputs.similar;
+   <screen>
+<![CDATA[
+Now, all requests are sent, and no response available
+This is a remote call response, the method name issome_method. calling sequence is 4
+string(11) "some_method"
+This is a remote call response, the method name issome_method. calling sequence is 1
+string(11) "some_method"
+This is a remote call response, the method name issome_method. calling sequence is 2
+string(11) "some_method"
+This is a remote call response, the method name issome_method. calling sequence is 3
+string(11) "some_method"
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Yar_Concurrent_Client::call</methodname></member>
+   <member><methodname>Yar_Concurrent_Client::reset</methodname></member>
+   <member><methodname>Yar_Server::__construct</methodname></member>
+   <member><methodname>Yar_Server::handle</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/yaz/functions/yaz-es.xml
+++ b/reference/yaz/functions/yaz-es.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: dfd68fd22aef25658bc9348176b55b504d26ab11 Maintainer: lacatoire Status: ready -->
+<!-- Reviewed: no -->
+<refentry xml:id="function.yaz-es" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>yaz_es</refname>
+  <refpurpose>
+   Bereitet einen Extended-Service-Request vor
+  </refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>yaz_es</methodname>
+   <methodparam>
+    <type>resource</type><parameter>id</parameter>
+   </methodparam>
+   <methodparam>
+    <type>string</type><parameter>type</parameter>
+   </methodparam>
+   <methodparam>
+    <type>array</type><parameter>args</parameter>
+   </methodparam>
+  </methodsynopsis>
+  <simpara>
+   Diese Funktion bereitet einen Extended-Service-Request vor.
+   Extended Services sind eine Familie verschiedener Z39.50-Dienste wie
+   Record Update, Item Order, Datenbankverwaltung usw.
+  </simpara>
+  <note>
+   <para>
+    Viele Z39.50-Server unterstützen keine Extended Services.
+   </para>
+  </note>
+  <para>
+   Die Funktion <function>yaz_es</function> erzeugt ein Paket für einen
+   Extended-Service-Request und stellt es in eine Warteschlange von Operationen.
+   Mit <function>yaz_wait</function> werden die Requests an den Server gesendet.
+   Nach Abschluss von <function>yaz_wait</function> sollte das Ergebnis der
+   Extended-Service-Operation mit einem Aufruf von
+   <function>yaz_es_result</function> abgerufen werden.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>id</parameter></term>
+     <listitem>
+      <para>
+       Die von <function>yaz_connect</function> zurückgegebene Verbindungsressource.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>type</parameter></term>
+     <listitem>
+      <para>
+       Eine Zeichenkette, die den Typ des Extended Service angibt:
+       <literal>itemorder</literal> (Item Order),
+       <literal>create</literal> (Datenbank erstellen),
+       <literal>drop</literal> (Datenbank löschen),
+       <literal>commit</literal> (Commit-Operation),
+       <literal>update</literal> (Datensatz aktualisieren),
+       <literal>xmlupdate</literal> (XML-Aktualisierung).
+       Jeder Typ wird im folgenden Abschnitt beschrieben.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term><parameter>args</parameter></term>
+     <listitem>
+      <para>
+       Ein Array mit Optionen für Extended Services sowie
+       paketspezifischen Optionen. Die Optionen sind identisch mit jenen,
+       die in der C-API von ZOOM C angeboten werden. Siehe die
+       ZOOM <link xlink:href="&url.yaz.zoom.ext;">Extended Services</link>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Datensatz aktualisieren</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$con = yaz_connect("myhost/database");
+$args = array (
+    "record" => "<gils><title>some title</title></gils>",
+    "syntax" => "xml",
+    "action" => "specialUpdate"
+);
+yaz_es($con, "update", $args);
+yaz_wait();
+$result = yaz_es_result($id);
+?>
+]]>
+   </programlisting>
+   </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>yaz_es_result</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die neuen (zuvor nicht übersetzten) Dateien mehrerer kleinerer Erweiterungen ins Deutsche (yaz, yar, yaconf, xml, sync, svn, phar, pdo_cubrid, pdo, outcontrol, openssl, ldap, info, imagick, ibm_db2, fpm, fdf, cmark, chmonly, appendices), auf dem Stand des aktuellen EN-Texts (20 Dateien). Struktur tag-für-tag zur EN-Quelle gespiegelt, Maintainer: lacatoire.

Adressiert teilweise #235, #236, #242 und #243 (Abschnitt „Neue EN-Dateien (noch nicht übersetzt)").