### PR TITLE
[Sync EN] Add PHP 8.4.0 changelog entries for Intl and MBString pages

### DIFF
--- a/reference/intl/idn/idn-to-ascii.xml
+++ b/reference/intl/idn/idn-to-ascii.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.idn-to-ascii" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>idn_to_ascii</refname>
+  <refpurpose>Wandelt einen Domainnamen in die IDNA-ASCII-Form um</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.procedural;</para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>idn_to_ascii</methodname>
+   <methodparam><type>string</type><parameter>domain</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>IDNA_DEFAULT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>variant</parameter><initializer><constant>INTL_IDNA_VARIANT_UTS46</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">idna_info</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Diese Funktion wandelt einen Unicode-Domainnamen in ein
+   IDNA-ASCII-kompatibles Format in Kleinbuchstaben um.
+  </para>
+  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>domain</parameter></term>
+     <listitem>
+      <para>
+       Die umzuwandelnde Domain, die UTF-8-kodiert sein muss.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Umwandlungsoptionen - eine Kombination der IDNA_*-Konstanten
+       (außer den IDNA_ERROR_*-Konstanten).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>variant</parameter></term>
+     <listitem>
+      <para>
+       Entweder <constant>INTL_IDNA_VARIANT_2003</constant> (veraltet seit
+       PHP 7.2.0) für IDNA 2003 oder
+       <constant>INTL_IDNA_VARIANT_UTS46</constant> (erst ab ICU 4.6
+       verfügbar) für UTS #46.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>idna_info</parameter></term>
+     <listitem>
+      <para>
+       Dieser Parameter kann nur verwendet werden, wenn
+       <constant>INTL_IDNA_VARIANT_UTS46</constant> für
+       <parameter>variant</parameter> verwendet wurde. In diesem Fall wird er
+       mit einem Array gefüllt, das die Schlüssel <literal>'result'</literal>
+       (das möglicherweise unzulässige Ergebnis der Umwandlung),
+       <literal>'isTransitionalDifferent'</literal> (ein boolescher Wert, der
+       angibt, ob die Verwendung der Übergangsmechanismen von UTS #46 das
+       Ergebnis verändert hat oder verändert hätte) und
+       <literal>'errors'</literal> (ein <type>int</type>, der einen Bitsatz
+       der Fehlerkonstanten IDNA_ERROR_* darstellt) enthält.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Der in ASCII-kompatibler Form kodierte Domainname, &return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Wirft nun einen <exceptionname>ValueError</exceptionname>, wenn der
+        Parameter <parameter>domain</parameter> leer ist.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Wirft nun einen <exceptionname>ValueError</exceptionname>, wenn der
+        Parameter <parameter>variant</parameter> nicht
+        <constant>INTL_IDNA_VARIANT_UTS46</constant> ist.
+       </entry>
+      </row>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Der Standardwert von <parameter>variant</parameter> ist nun
+        <constant>INTL_IDNA_VARIANT_UTS46</constant> anstelle des veralteten
+        <constant>INTL_IDNA_VARIANT_2003</constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        <constant>INTL_IDNA_VARIANT_2003</constant> wurde als veraltet
+        markiert; <constant>INTL_IDNA_VARIANT_UTS46</constant> sollte
+        stattdessen verwendet werden.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>idn_to_ascii</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+echo idn_to_ascii('täst.de');
+
+?>
+]]>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+xn--tst-qla.de
+]]>
+  </screen>
+  <example>
+   <title>Reine ASCII-Domainnamen werden nur in Kleinbuchstaben umgewandelt</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+var_dump(idn_to_ascii('Example.com'));
+
+?>
+]]>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+string(11) "example.com"
+]]>
+  </screen>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>idn_to_utf8</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/idn/idn-to-utf8.xml
+++ b/reference/intl/idn/idn-to-utf8.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.idn-to-utf8" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>idn_to_utf8</refname>
+  <refpurpose>Wandelt einen Domainnamen von IDNA-ASCII nach Unicode um</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <para>&style.procedural;</para>
+  <methodsynopsis>
+   <type class="union"><type>string</type><type>false</type></type><methodname>idn_to_utf8</methodname>
+   <methodparam><type>string</type><parameter>domain</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>flags</parameter><initializer><constant>IDNA_DEFAULT</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>variant</parameter><initializer><constant>INTL_IDNA_VARIANT_UTS46</constant></initializer></methodparam>
+   <methodparam choice="opt"><type>array</type><parameter role="reference">idna_info</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Diese Funktion wandelt einen Unicode-Domainnamen aus einem
+   IDNA-ASCII-kompatiblen Format in reines Unicode um, kodiert in UTF-8.
+  </para>
+  </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>domain</parameter></term>
+     <listitem>
+      <para>
+       Die umzuwandelnde Domain in einem IDNA-ASCII-kompatiblen Format.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>flags</parameter></term>
+     <listitem>
+      <para>
+       Umwandlungsoptionen - eine Kombination der IDNA_*-Konstanten
+       (außer den IDNA_ERROR_*-Konstanten).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>variant</parameter></term>
+     <listitem>
+      <para>
+       Entweder <constant>INTL_IDNA_VARIANT_2003</constant> (veraltet seit
+       PHP 7.2.0) für IDNA 2003 oder
+       <constant>INTL_IDNA_VARIANT_UTS46</constant> (erst ab ICU 4.6
+       verfügbar) für UTS #46.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>idna_info</parameter></term>
+     <listitem>
+      <para>
+       Dieser Parameter kann nur verwendet werden, wenn
+       <constant>INTL_IDNA_VARIANT_UTS46</constant> für
+       <parameter>variant</parameter> verwendet wurde. In diesem Fall wird er
+       mit einem Array gefüllt, das die Schlüssel <literal>'result'</literal>
+       (das möglicherweise unzulässige Ergebnis der Umwandlung),
+       <literal>'isTransitionalDifferent'</literal> (ein boolescher Wert, der
+       angibt, ob die Verwendung der Übergangsmechanismen von UTS #46 das
+       Ergebnis verändert hat oder verändert hätte) und
+       <literal>'errors'</literal> (ein <type>int</type>, der einen Bitsatz
+       der Fehlerkonstanten IDNA_ERROR_* darstellt) enthält.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Der Domainname in Unicode, kodiert in UTF-8, &return.falseforfailure;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Wirft nun einen <exceptionname>ValueError</exceptionname>, wenn der
+        Parameter <parameter>domain</parameter> leer ist.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Wirft nun einen <exceptionname>ValueError</exceptionname>, wenn der
+        Parameter <parameter>variant</parameter> nicht
+        <constant>INTL_IDNA_VARIANT_UTS46</constant> ist.
+       </entry>
+      </row>
+      <row>
+       <entry>7.4.0</entry>
+       <entry>
+        Der Standardwert von <parameter>variant</parameter> ist nun
+        <constant>INTL_IDNA_VARIANT_UTS46</constant> anstelle des veralteten
+        <constant>INTL_IDNA_VARIANT_2003</constant>.
+       </entry>
+      </row>
+      <row>
+       <entry>7.2.0</entry>
+       <entry>
+        <constant>INTL_IDNA_VARIANT_2003</constant> wurde als veraltet
+        markiert; <constant>INTL_IDNA_VARIANT_UTS46</constant> sollte
+        stattdessen verwendet werden.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title><function>idn_to_utf8</function>-Beispiel</title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+
+echo idn_to_utf8('xn--tst-qla.de');
+
+?>
+]]>
+   </programlisting>
+  </example>
+  &example.outputs;
+  <screen>
+<![CDATA[
+täst.de
+]]>
+  </screen>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>idn_to_ascii</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mbstring/functions/mb-strcut.xml
+++ b/reference/mbstring/functions/mb-strcut.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-strcut" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>mb_strcut</refname>
+  <refpurpose>Gibt einen Teil einer Zeichenkette zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_strcut</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam><type>int</type><parameter>start</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>length</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   <function>mb_strcut</function> extrahiert eine Teilzeichenkette aus einer
+   Zeichenkette, ähnlich wie <function>mb_substr</function>, arbeitet jedoch
+   mit Bytes statt mit Zeichen. Liegt die Schnittposition zwischen zwei Bytes
+   eines Multibyte-Zeichens, wird der Schnitt ab dem ersten Byte dieses
+   Zeichens vorgenommen. Das ist auch der Unterschied zur Funktion
+   <function>substr</function>, die die Zeichenkette einfach zwischen den
+   Bytes schneiden und so eine fehlerhafte Byte-Sequenz erzeugen würde.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string</parameter></term>
+     <listitem>
+      <para>
+       Die zu schneidende Zeichenkette.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>start</parameter></term>
+     <listitem>
+      <para>
+       Ist <parameter>start</parameter> nicht negativ, beginnt die
+       zurückgegebene Zeichenkette an der <parameter>start</parameter>-ten
+       <emphasis>Byte</emphasis>-Position in <parameter>string</parameter>,
+       von null an gezählt. In der Zeichenkette '<literal>abcdef</literal>'
+       ist beispielsweise das Byte an Position <literal>0</literal>
+       '<literal>a</literal>', das Byte an Position <literal>2</literal>
+       '<literal>c</literal>' und so weiter.
+      </para>
+      <para>
+       Ist <parameter>start</parameter> negativ, beginnt die zurückgegebene
+       Zeichenkette am <parameter>start</parameter>-ten Byte, vom Ende von
+       <parameter>string</parameter> aus rückwärts gezählt. Ist der Betrag
+       eines negativen <parameter>start</parameter> jedoch größer als die
+       Länge der Zeichenkette, beginnt der zurückgegebene Teil am Anfang von
+       <parameter>string</parameter>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>length</parameter></term>
+     <listitem>
+      <para>
+       Länge in <emphasis>Bytes</emphasis>. Wird er weggelassen oder
+       <literal>NULL</literal> übergeben, werden alle Bytes bis zum Ende der
+       Zeichenkette extrahiert.
+      </para>
+      <para>
+       Ist <parameter>length</parameter> negativ, endet die zurückgegebene
+       Zeichenkette am <parameter>length</parameter>-ten Byte, vom Ende von
+       <parameter>string</parameter> aus rückwärts gezählt. Ist der Betrag
+       eines negativen <parameter>length</parameter> jedoch größer als die
+       Anzahl der Zeichen nach der <parameter>start</parameter>-Position, wird
+       eine leere Zeichenkette zurückgegeben.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>encoding</parameter></term>
+     <listitem>
+      &mbstring.encoding.parameter;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <function>mb_strcut</function> gibt den durch die Parameter
+   <parameter>start</parameter> und <parameter>length</parameter> angegebenen
+   Teil von <parameter>string</parameter> zurück.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Das Verhalten ist nun bei ungültigen <literal>UTF-8</literal>- und <literal>UTF-16</literal>-Zeichenketten konsistenter.
+      </entry>
+     </row>
+     &mbstring.changelog.encoding-nullable;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mb_substr</function></member>
+    <member><function>mb_internal_encoding</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mbstring/functions/mb-substr.xml
+++ b/reference/mbstring/functions/mb-substr.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 1be57c2d7d7306b6167a4305059fe1abe8911699 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.mb-substr" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>mb_substr</refname>
+  <refpurpose>Gibt einen Teil einer Zeichenkette zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>mb_substr</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam><type>int</type><parameter>start</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>length</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>encoding</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <para>
+   Führt eine Multibyte-sichere <function>substr</function>-Operation auf
+   Basis der Anzahl der Zeichen durch. Die Position wird vom Anfang von
+   <parameter>string</parameter> an gezählt. Die Position des ersten Zeichens
+   ist 0, die des zweiten Zeichens 1 und so weiter.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string</parameter></term>
+     <listitem>
+      <para>
+       Die Zeichenkette, aus der die Teilzeichenkette extrahiert werden soll.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>start</parameter></term>
+     <listitem>
+      <para>
+       Ist <parameter>start</parameter> nicht negativ, beginnt die
+       zurückgegebene Zeichenkette an der <parameter>start</parameter>-ten
+       Position in <parameter>string</parameter>, von null an gezählt. In der
+       Zeichenkette '<literal>abcdef</literal>' ist beispielsweise das Zeichen
+       an Position <literal>0</literal> '<literal>a</literal>', das Zeichen an
+       Position <literal>2</literal> '<literal>c</literal>' und so weiter.
+      </para>
+      <para>
+       Ist <parameter>start</parameter> negativ, beginnt die zurückgegebene
+       Zeichenkette am <parameter>start</parameter>-ten Zeichen vom Ende von
+       <parameter>string</parameter> aus.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>length</parameter></term>
+     <listitem>
+      <para>
+       Maximale Anzahl der aus <parameter>string</parameter> zu verwendenden
+       Zeichen. Wird er weggelassen oder <literal>NULL</literal> übergeben,
+       werden alle Zeichen bis zum Ende der Zeichenkette extrahiert.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>encoding</parameter></term>
+     <listitem>
+      &mbstring.encoding.parameter;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   <function>mb_substr</function> gibt den durch die Parameter
+   <parameter>start</parameter> und <parameter>length</parameter> angegebenen
+   Teil von <parameter>string</parameter> zurück.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Bei ungültigen Zeichenketten (solchen mit Kodierungsfehlern) werden
+       Zeichenindizes nun auf dieselbe Weise interpretiert wie bei den meisten
+       anderen mbstring-Funktionen. Das bedeutet, dass von
+       <function>mb_strpos</function> zurückgegebene Zeichenindizes direkt
+       übergeben werden können.
+      </entry>
+     </row>
+     &mbstring.changelog.encoding-nullable;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>mb_strcut</function></member>
+    <member><function>mb_internal_encoding</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die bisher fehlenden Seiten `idn_to_ascii`, `idn_to_utf8`, `mb_strcut` und `mb_substr` ins Deutsche, inklusive der neuen PHP-8.4.0-Changelog-Einträge. Spiegelt den EN-Aufbau Tag für Tag.

Fixes #312