### PR TITLE
[Sync EN] Add PHP 8.4.0 changelog entries for SPL, Standard, and Filesystem pages

### DIFF
--- a/reference/filesystem/functions/tempnam.xml
+++ b/reference/filesystem/functions/tempnam.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
-<!-- EN-Revision: d1cacac75c04a115ee9b464015ce8e7782bd1517 Maintainer: wiesemann Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: wiesemann Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 2f07d53d999169b7446669a51dfd6ce9b3c20435 Reviewer: samesch -->
 <refentry xml:id="function.tempnam" xmlns="http://docbook.org/ns/docbook">
@@ -75,6 +75,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Der Name der von <function>tempnam</function> erstellten Dateien ist
+       nun 13 Bytes länger. Die Gesamtlänge ist weiterhin plattformabhängig.
+      </entry>
+     </row>
      <row>
       <entry>7.1.0</entry>
       <entry>

--- a/reference/spl/splfixedarray.xml
+++ b/reference/spl/splfixedarray.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.splfixedarray" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+ <title>Die Klasse SplFixedArray</title>
+ <titleabbrev>SplFixedArray</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ splfixedarray intro -->
+  <section xml:id="splfixedarray.intro">
+   &reftitle.intro;
+   <para>
+    Die Klasse SplFixedArray stellt die wesentlichen Funktionen eines Arrays
+    bereit. Der Hauptunterschied zwischen einem SplFixedArray und einem
+    normalen PHP-Array besteht darin, dass die Größe eines SplFixedArray
+    manuell geändert werden muss und nur Ganzzahlen innerhalb des Bereichs
+    als Indizes zulässig sind. Der Vorteil ist, dass es weniger Speicher als
+    ein normales <type>array</type> verbraucht.
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="splfixedarray.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis class="class">
+    <ooclass>
+     <classname>SplFixedArray</classname>
+    </ooclass>
+
+    <oointerface>
+     <modifier>implements</modifier>
+     <interfacename>IteratorAggregate</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>ArrayAccess</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>Countable</interfacename>
+    </oointerface>
+
+    <oointerface>
+     <interfacename>JsonSerializable</interfacename>
+    </oointerface>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='SplFixedArray'])">
+     <xi:fallback/>
+    </xi:include>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.splfixedarray')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='SplFixedArray'])">
+     <xi:fallback/>
+    </xi:include>
+   </classsynopsis>
+
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Zugriffe außerhalb des gültigen Bereichs in
+        <classname>SplFixedArray</classname> werfen nun Exceptions vom Typ
+        <exceptionname>OutOfBoundsException</exceptionname> anstelle von
+        <exceptionname>RuntimeException</exceptionname>. Da
+        <exceptionname>OutOfBoundsException</exceptionname> eine Unterklasse
+        von <exceptionname>RuntimeException</exceptionname> ist, ergeben sich
+        beim Abfangen dieser Exceptions keine Verhaltensänderungen.
+       </entry>
+      </row>
+      <row>
+       <entry>8.2.0</entry>
+       <entry>
+        Die magischen Methoden
+        <methodname>SplFixedArray::__serialize</methodname> und
+        <methodname>SplFixedArray::__unserialize</methodname>
+        wurden zu <classname>SplFixedArray</classname> hinzugefügt.
+       </entry>
+      </row>
+      <row>
+       <entry>8.1.0</entry>
+       <entry>
+        <classname>SplFixedArray</classname> implementiert nun
+        <interfacename>JsonSerializable</interfacename>.
+       </entry>
+      </row>
+      <row>
+       <entry>8.0.0</entry>
+       <entry>
+        <classname>SplFixedArray</classname> implementiert nun
+        <interfacename>IteratorAggregate</interfacename>.
+        Zuvor wurde stattdessen <interfacename>Iterator</interfacename>
+        implementiert.
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+  </section>
+
+<!-- {{{ splfixedarray examples -->
+  <section xml:id="splfixedarray.examples">
+   &reftitle.examples;
+   <para>
+    <example>
+     <title><classname>SplFixedArray</classname>-Anwendungsbeispiel</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+// Das Array mit fester Länge initialisieren
+$array = new SplFixedArray(5);
+
+$array[1] = 2;
+$array[4] = "foo";
+
+var_dump($array[0]); // NULL
+var_dump($array[1]); // int(2)
+
+var_dump($array["4"]); // string(3) "foo"
+
+// Die Größe des Arrays auf 10 erhöhen
+$array->setSize(10);
+
+$array[9] = "asdf";
+
+// Das Array auf eine Größe von 2 verkleinern
+$array->setSize(2);
+
+// Die folgenden Zeilen werfen eine RuntimeException: Index invalid or out of range
+try {
+    var_dump($array["non-numeric"]);
+} catch(RuntimeException $re) {
+    echo "RuntimeException: ".$re->getMessage()."\n";
+}
+
+try {
+    var_dump($array[-1]);
+} catch(RuntimeException $re) {
+    echo "RuntimeException: ".$re->getMessage()."\n";
+}
+
+try {
+    var_dump($array[5]);
+} catch(RuntimeException $re) {
+    echo "RuntimeException: ".$re->getMessage()."\n";
+}
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+NULL
+int(2)
+string(3) "foo"
+RuntimeException: Index invalid or out of range
+RuntimeException: Index invalid or out of range
+RuntimeException: Index invalid or out of range
+]]>
+     </screen>
+    </example>
+   </para>
+  </section>
+<!-- }}} -->
+
+<!-- {{{ splfixedarray properties
+  <section xml:id="splfixedarray.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="splfixedarray.props.name">
+     <term><varname>name</varname></term>
+     <listitem>
+      <para>Prop description</para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+}}} -->
+
+ </partintro>
+
+ &reference.spl.entities.splfixedarray;
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/var/functions/debug-zval-dump.xml
+++ b/reference/var/functions/debug-zval-dump.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.debug-zval-dump" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>debug_zval_dump</refname>
+  <refpurpose>Gibt eine Zeichenkettendarstellung einer internen zval-Struktur aus</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>void</type><methodname>debug_zval_dump</methodname>
+   <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
+   <methodparam rep="repeat"><type>mixed</type><parameter>values</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Gibt eine Zeichenkettendarstellung einer internen zval-Struktur (Zend
+   value) aus. Das ist vor allem nützlich, um Implementierungsdetails der Zend
+   Engine oder von PHP-Erweiterungen zu verstehen oder zu debuggen.
+  </para>
+ </refsect1>
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>value</parameter></term>
+     <listitem>
+      <para>
+       Die auszugebende Variable oder der auszugebende Wert.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><parameter>values</parameter></term>
+     <listitem>
+      <para>
+       Weitere auszugebende Variablen oder Werte.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.void;
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       <function>debug_zval_dump</function> gibt nun an, ob ein Array gepackt
+       ist.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><function>debug_zval_dump</function>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$var1 = 'Hello';
+$var1 .= ' World';
+$var2 = $var1;
+
+debug_zval_dump($var1);
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(11) "Hello World" refcount(3)
+]]>
+    </screen>
+   </example>
+  </para>
+  <note>
+   <title>Den <literal>refcount</literal> verstehen</title>
+   <para>
+    Der von dieser Funktion angezeigte <literal>refcount</literal>-Wert kann
+    ohne ein detailliertes Verständnis der Implementierung der Engine
+    überraschend sein.
+   </para>
+   <para>
+    Die Zend Engine verwendet Referenzzählung für zwei verschiedene Zwecke:
+   </para>
+   <para>
+    <simplelist>
+     <member>
+      Optimierung des Speicherverbrauchs mit einer Technik namens "Copy on
+      Write", bei der mehrere Variablen, die denselben Wert enthalten, auf
+      dieselbe Kopie im Speicher verweisen. Wird eine der Variablen geändert,
+      wird sie auf eine neue Kopie im Speicher verwiesen, und der
+      Referenzzähler des Originals wird um 1 verringert.
+     </member>
+     <member>
+      Verfolgung von Variablen, die per Referenz zugewiesen oder übergeben
+      wurden (siehe <link linkend="language.references">Referenzen
+      erklärt</link>). Dieser refcount wird in einem separaten Referenz-zval
+      gespeichert, der auf das zval für den aktuellen Wert verweist. Dieses
+      zusätzliche zval wird derzeit nicht von
+      <function>debug_zval_dump</function> angezeigt.
+     </member>
+    </simplelist>
+   </para>
+   <para>
+    Da <function>debug_zval_dump</function> seine Eingabe als normale, per
+    Wert übergebene Parameter entgegennimmt, wird zu ihrer Übergabe die
+    Copy-on-Write-Technik verwendet: Anstatt die Daten zu kopieren, wird der
+    refcount für die Dauer des Funktionsaufrufs um eins erhöht. Würde die
+    Funktion den Parameter nach dem Empfang ändern, würde eine Kopie
+    erstellt; da sie das nicht tut, zeigt sie einen um eins höheren refcount
+    als im aufrufenden Geltungsbereich an.
+   </para>
+   <para>
+    Die Parameterübergabe verhindert außerdem, dass
+    <function>debug_zval_dump</function> Variablen anzeigt, die per Referenz
+    zugewiesen wurden. Zur Veranschaulichung soll eine leicht abgewandelte
+    Version des obigen Beispiels betrachtet werden:
+
+    <informalexample>
+     <programlisting role="php">
+<![CDATA[
+<?php
+$var1 = 'Hello';
+$var1 .= ' World';
+// Drei Variablen als Referenzen auf denselben Wert setzen
+$var2 =& $var1;
+$var3 =& $var1;
+
+debug_zval_dump($var1);
+?>
+]]>
+     </programlisting>
+     &example.outputs;
+     <screen>
+<![CDATA[
+string(11) "Hello World" refcount(2)
+]]>
+     </screen>
+    </informalexample>
+   </para>
+   <para>
+    Obwohl <varname>$var1</varname>, <varname>$var2</varname> und
+    <varname>$var3</varname> als Referenzen verknüpft sind, wird nur der
+    <emphasis>Wert</emphasis> an <function>debug_zval_dump</function>
+    übergeben. Dieser Wert wird einmal von der Gruppe der Referenzen und
+    einmal innerhalb von <function>debug_zval_dump</function> verwendet und
+    zeigt daher einen refcount von 2.
+   </para>
+   <para>
+    Weitere Komplikationen ergeben sich durch Optimierungen, die in der Engine
+    für verschiedene Datentypen vorgenommen werden. Einige Typen wie
+    Ganzzahlen verwenden kein "Copy on Write" und zeigen daher überhaupt
+    keinen refcount. In anderen Fällen zeigt der refcount zusätzliche, intern
+    verwendete Kopien, etwa wenn eine literale Zeichenkette oder ein Array als
+    Teil einer Code-Anweisung gespeichert wird.
+   </para>
+  </note>
+ </refsect1>
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>var_dump</function></member>
+    <member><function>debug_backtrace</function></member>
+    <member><link linkend="language.references">Referenzen erklärt</link></member>
+    <member><link xlink:href="&url.derick.references;">Referenzen erklärt (von Derick Rethans)</link></member>
+   </simplelist>
+  </para>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9e47cecca7d5834de43b7641baf5d86828bb153 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 17ebcd2ea14b405b781bd93aea6fa7219b6e29ae Maintainer: sammywg Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -176,6 +176,14 @@
         <exceptionname>ValueError</exceptionname>s aus, wenn das Element
         <literal>allowed_classes</literal> von <parameter>options</parameter>
         kein <type>array</type> von Klassennamen ist.
+       </entry>
+      </row>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Das Deserialisieren von Zeichenketten mit dem großgeschriebenen
+        <literal>"S"</literal>-Tag ist nun veraltet; stattdessen sollte das
+        kleingeschriebene <literal>"s"</literal>-Tag verwendet werden.
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Synchronisiert die PHP-8.4.0-Changelog-Einträge: ergänzt `tempnam` und `unserialize` (vorhandene Maintainer beibehalten) und übersetzt die bisher fehlenden Seiten `SplFixedArray` und `debug_zval_dump` ins Deutsche. Spiegelt den EN-Aufbau Tag für Tag.

Fixes #313