### PR TITLE
[Sync EN] unserialization: Documented allowed-classes option with enums (#5585)

### DIFF
--- a/language/enumerations.xml
+++ b/language/enumerations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1eb67bea30f61f7d9cdfd371146911a0ba07bbd2 Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
  <chapter xml:id="language.enumerations" xmlns="http://docbook.org/ns/docbook" annotations="interactive">
   <title>Aufzählungen (Enum)</title>
@@ -897,6 +897,12 @@ print serialize(Suit::Hearts);
    mit einem serialisierten Wert übereinstimmt, wird eine Warnung ausgegeben
    und &false; zurückgegeben.
   </para>
+
+  <simpara>
+   Die Option <literal>allowed_classes</literal> von
+   <function>unserialize</function> wirkt sich nicht auf
+   <link linkend="language.enumerations">Enumerations</link> aus.
+  </simpara>
 
   <para>
    Wenn eine Pure Enum in JSON serialisiert wird, wird ein Fehler ausgelöst.

--- a/reference/var/functions/unserialize.xml
+++ b/reference/var/functions/unserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a9e47cecca7d5834de43b7641baf5d86828bb153 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 8af3521cb43f54c652baaf8dbbcb786b79a5d04e Maintainer: sammywg Status: ready -->
 <!-- Reviewed: no -->
 <refentry xml:id="function.unserialize" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
@@ -104,6 +104,9 @@
             Das Auslassen dieser Option hat die gleiche Wirkung wie sie als
             &true; anzugeben: PHP wird versuchen Objekte beliebiger Klassen zu
             instanziieren.
+           </simpara>
+           <simpara>
+            Diese Option wirkt sich nicht auf <link linkend="language.enumerations">Enumerations</link> aus.
            </simpara>
           </entry>
          </row>


### PR DESCRIPTION
Synchronisiert die englische Änderung: Die Option `allowed_classes` von `unserialize` wirkt sich nicht auf Enumerations aus. Der Hinweis wurde in language/enumerations.xml und reference/var/functions/unserialize.xml ergänzt.

Fixes #321