### PR TITLE
[Sync EN] PHP 8.5 changelog entries for readline functions (#5594)

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 69fe083419b7888f6d424595771d54fe2d850d9d Maintainer: simp Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: simp Status: ready -->
 <!-- Reviewed: no -->
 <!-- CREDITS: sammywg, mk, betz -->
 
@@ -869,6 +869,13 @@ Dateinamen gesucht.'>
 
 <!ENTITY return.type.true '<row xmlns="http://docbook.org/ns/docbook">
  <entry>8.2.0</entry>
+ <entry>
+  Der Rückgabewert ist nun &true; vorher war es <type>bool</type>.
+ </entry>
+</row>'>
+
+<!ENTITY return.type.true.85 '<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.5.0</entry>
  <entry>
   Der Rückgabewert ist nun &true; vorher war es <type>bool</type>.
  </entry>

--- a/reference/readline/functions/readline-add-history.xml
+++ b/reference/readline/functions/readline-add-history.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: sammywg Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-add-history">
  <refnamediv>
@@ -38,6 +38,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:

--- a/reference/readline/functions/readline-callback-handler-install.xml
+++ b/reference/readline/functions/readline-callback-handler-install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: sammywg Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-callback-handler-install">
  <refnamediv>
@@ -57,6 +57,23 @@
   <simpara>
    &return.true.always;
   </simpara>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">

--- a/reference/readline/functions/readline-clear-history.xml
+++ b/reference/readline/functions/readline-clear-history.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 53208f9bd0a035a4e1409ba700106540474c9ef1 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: be246a268d0d5ab0b215c429cb031e70c98327ef Maintainer: sammywg Status: ready -->
 <!-- Reviewed: no -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.readline-clear-history">
  <refnamediv>
@@ -29,6 +29,24 @@
    &return.true.always;
   </simpara>
  </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     &return.type.true.85;
+    </tbody>
+   </tgroup>
+  </informaltable>
+ </refsect1>
+
 </refentry>
 <!-- Keep this comment at the end of the file
 Local variables:


### PR DESCRIPTION
Synchronisiert die Änderungsprotokoll-Einträge für PHP 8.5 der readline-Funktionen (Rückgabetyp ist nun `true`). Fügt die Entität `return.type.true.85` in `language-snippets.ent` hinzu und ergänzt die Changelog-Abschnitte in den drei betroffenen Dateien.

Fixes #319