### PR TITLE
[Sync EN] PDO: update constants type from int to bool for PHP 8.4.0 (#5593)

### DIFF
--- a/reference/pdo/constants.xml
+++ b/reference/pdo/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: a8863b0123dc5348c91e67198b995222878a7e65 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: eae19eb5fe0f5bebcbce382ea7a505cedeb5a883 Reviewer: samesch -->
 <appendix xml:id="pdo.constants" xmlns="http://docbook.org/ns/docbook">
@@ -373,12 +373,16 @@
   <varlistentry xml:id="pdo.constants.attr-autocommit">
    <term>
     <constant>PDO::ATTR_AUTOCOMMIT</constant>
-    (<type>int</type>)
+    (<type>bool</type>)
    </term>
    <listitem>
     <simpara>
      Wenn dieser Wert &false; ist, versucht PDO, Autocommit zu deaktivieren,
      damit die Verbindung eine Transaktion starten kann.
+    </simpara>
+    <simpara>
+     Seit PHP 8.4.0 ist diese Konstante als <type>bool</type> typisiert;
+     zuvor war sie als <type>int</type> typisiert.
     </simpara>
    </listitem>
   </varlistentry>
@@ -638,11 +642,19 @@ if ($db->getAttribute(PDO::ATTR_DRIVER_NAME) == 'mysql') {
   <varlistentry xml:id="pdo.constants.attr-emulate-prepares">
    <term>
     <constant>PDO::ATTR_EMULATE_PREPARES</constant>
-    (<type>int</type>)
+    (<type>bool</type>)
    </term>
    <listitem>
     <simpara>
-
+     Legt fest, ob die Emulation von Prepared Statements aktiviert oder
+     deaktiviert wird. Einige Treiber unterstützen native Prepared Statements
+     entweder gar nicht oder nur eingeschränkt. Bei &true; emuliert PDO
+     Prepared Statements immer; bei &false; werden die nativen Prepared
+     Statements des Treibers verwendet.
+    </simpara>
+    <simpara>
+     Seit PHP 8.4.0 ist diese Konstante als <type>bool</type> typisiert;
+     zuvor war sie als <type>int</type> typisiert.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/pdo_dblib/pdo-dblib.xml
+++ b/reference/pdo_dblib/pdo-dblib.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: lacatoire Status: ready -->
+<reference xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xml:id="class.pdo-dblib" role="class">
+ <title>Die Klasse Pdo\Dblib</title>
+ <titleabbrev>Pdo\Dblib</titleabbrev>
+
+ <partintro>
+
+  <!-- {{{ ClassName intro -->
+  <section xml:id="pdo-dblib.intro">
+   &reftitle.intro;
+   <simpara>
+    Eine Unterklasse von <classname>PDO</classname>, die eine Verbindung über
+    den DBLib-PDO-Treiber darstellt.
+   </simpara>
+  </section>
+  <!-- }}} -->
+
+  <section xml:id="pdo-dblib.synopsis">
+   &reftitle.classsynopsis;
+   <!-- {{{ Synopsis -->
+   <packagesynopsis>
+    <package>Pdo</package>
+
+    <classsynopsis class="class">
+     <ooclass>
+      <classname>Dblib</classname>
+     </ooclass>
+
+     <ooclass>
+      <modifier>extends</modifier>
+      <classname>PDO</classname>
+     </ooclass>
+
+     <classsynopsisinfo role="comment">&InheritedConstants;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:partintro/db:section/db:classsynopsis/db:fieldsynopsis[preceding-sibling::db:classsynopsisinfo[1][@role='comment' and text()='&Constants;']]))">
+      <xi:fallback/>
+     </xi:include>
+
+     <classsynopsisinfo role="comment">&Constants;</classsynopsisinfo>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-connection-timeout">Pdo\Dblib::ATTR_CONNECTION_TIMEOUT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-query-timeout">Pdo\Dblib::ATTR_QUERY_TIMEOUT</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-stringify-uniqueidentifier">Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-version">Pdo\Dblib::ATTR_VERSION</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-tds-version">Pdo\Dblib::ATTR_TDS_VERSION</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-skip-empty-rowsets">Pdo\Dblib::ATTR_SKIP_EMPTY_ROWSETS</varname>
+     </fieldsynopsis>
+     <fieldsynopsis>
+      <modifier>public</modifier>
+      <modifier>const</modifier>
+      <type>int</type>
+      <varname linkend="pdo-dblib.constants.attr-datetime-convert">Pdo\Dblib::ATTR_DATETIME_CONVERT</varname>
+     </fieldsynopsis>
+
+     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:constructorsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.pdo')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[@role='PDO'])">
+      <xi:fallback/>
+     </xi:include>
+    </classsynopsis>
+   </packagesynopsis>
+   <!-- }}} -->
+
+  </section>
+
+  <section xml:id="pdo-dblib.constants">
+   &reftitle.constants;
+   <variablelist>
+    <varlistentry xml:id="pdo-dblib.constants.attr-connection-timeout">
+     <term><constant>Pdo\Dblib::ATTR_CONNECTION_TIMEOUT</constant></term>
+     <listitem>
+      <simpara>
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-dblib.constants.attr-query-timeout">
+     <term><constant>Pdo\Dblib::ATTR_QUERY_TIMEOUT</constant></term>
+     <listitem>
+      <simpara>
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-dblib.constants.attr-stringify-uniqueidentifier">
+     <term><constant>Pdo\Dblib::ATTR_STRINGIFY_UNIQUEIDENTIFIER</constant></term>
+     <listitem>
+      <simpara>
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-dblib.constants.attr-version">
+     <term><constant>Pdo\Dblib::ATTR_VERSION</constant></term>
+     <listitem>
+      <simpara>
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-dblib.constants.attr-tds-version">
+     <term><constant>Pdo\Dblib::ATTR_TDS_VERSION</constant></term>
+     <listitem>
+      <simpara>
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-dblib.constants.attr-skip-empty-rowsets">
+     <term><constant>Pdo\Dblib::ATTR_SKIP_EMPTY_ROWSETS</constant></term>
+     <listitem>
+      <simpara>
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="pdo-dblib.constants.attr-datetime-convert">
+     <term><constant>Pdo\Dblib::ATTR_DATETIME_CONVERT</constant></term>
+     <listitem>
+      <simpara>
+       Dieses Verbindungsattribut steuert das Format von Zeichenketten für
+       Datetime-Typen. Wenn dies &false; ist, gibt PDO_DBLIB einen
+       Datetime-Typ als Zeichenkette in dem Format zurück, in dem ihn der SQL
+       Server zurückgibt (also <literal>"2017-10-27 10:22:44"</literal>). Wenn
+       &true;, wandelt PDO_DBLIB den Datetime-Typ in eine Zeichenkette um und
+       verwendet dabei ein benutzerdefiniertes oder gebietsschemaabhängiges
+       Format, wie es in der FreeTDS-Datei <filename>locales.conf</filename>
+       angegeben ist. Standardmäßig ist dieses Attribut &false;.
+      </simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pdo_mysql/constants.xml
+++ b/reference/pdo_mysql/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: b2a7a5fab7231fa8634096f111ae0fa0dc60bcfe Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 5d8e96f9b174f7471daebce760657eb0f190b0ba Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <section xml:id="ref.pdo-mysql.constants" xmlns="http://docbook.org/ns/docbook">
  &reftitle.constants;
@@ -86,11 +86,15 @@
   <varlistentry xml:id="pdo.constants.mysql-attr-direct-query">
    <term>
     <constant>PDO::MYSQL_ATTR_DIRECT_QUERY</constant>
-    (<type>int</type>)
+    (<type>bool</type>)
    </term>
    <listitem>
     <simpara>
      &Alias; <constant>PDO::ATTR_EMULATE_PREPARES</constant>
+    </simpara>
+    <simpara>
+     Seit PHP 8.4.0 ist diese Konstante als <type>bool</type> typisiert;
+     zuvor war sie als <type>int</type> typisiert.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Aktualisiert den Typ der PDO-Konstanten von int auf bool für PHP 8.4.0 (PDO::ATTR_AUTOCOMMIT, PDO::ATTR_EMULATE_PREPARES und der Alias PDO::MYSQL_ATTR_DIRECT_QUERY). Ergänzt außerdem die neue deutsche Übersetzung der Seite pdo_dblib.

Fixes #318