### PR TITLE
[Sync EN] proc_close: "waits", not "closes". Also grammar fix in Returns.

### DIFF
--- a/reference/exec/functions/proc-close.xml
+++ b/reference/exec/functions/proc-close.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 350d95443aeb0ea8751d71f262aac56d3ad48f83 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 970d3aa7fdf5c714b584cbe67ebf9e32a1e8b0d3 Maintainer: sammywg Status: ready -->
 <refentry xml:id="function.proc-close" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>proc_close</refname>
-  <refpurpose>Schließt einen Prozess, der mit <function>proc_open</function>
-   gestartet wurde und gibt den Exitcode dieses Prozesses zurück</refpurpose>
+  <refpurpose>Schließt die Pipes zu einem mit <function>proc_open</function>
+   gestarteten Prozess, wartet auf dessen Beendigung und gibt dessen Exitcode
+   zurück</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
@@ -44,10 +44,10 @@
 
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
-  <para>
+  <simpara>
    Gibt den Termination-Status des gelaufenen Prozesses zurück. Falls ein
-   Fehler auftritt wird <literal>-1</literal> zurückgegeben.
-  </para>
+   Fehler auftritt, wird <literal>-1</literal> zurückgegeben.
+  </simpara>
   &note.sigchild;
  </refsect1>
 


### PR DESCRIPTION
Aktualisiert refpurpose (schließt die Pipes, wartet auf Beendigung) und korrigiert die Grammatik im Rückgabewert, synchron mit dem Englischen.

Fixes #329