### PR TITLE
[Sync EN] book.xml Add `StreamBucket` (#5598)

### DIFF
--- a/reference/stream/book.xml
+++ b/reference/stream/book.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: lacatoire Status: ready -->
+
+<book xml:id="book.stream" xmlns="http://docbook.org/ns/docbook">
+ <?phpdoc extension-membership="core" ?>
+ <title>Streams</title>
+
+  <preface xml:id="intro.stream">
+   &reftitle.intro;
+   <simpara>
+    Streams sind die Möglichkeit, Datei-, Netzwerk-, Datenkompressions- und
+    andere Operationen zu verallgemeinern, die einen gemeinsamen Satz von
+    Funktionen und Verwendungszwecken teilen. In seiner einfachsten Definition
+    ist ein <literal>Stream</literal> ein
+    <type>resource</type>-Objekt, das ein streambares Verhalten zeigt. Das
+    heißt, es kann auf lineare Weise gelesen oder beschrieben werden und kann
+    mittels <function>fseek</function> an eine beliebige Position innerhalb des
+    Streams springen.
+   </simpara>
+   <simpara>
+    Ein <literal>Wrapper</literal> ist zusätzlicher Code, der dem Stream
+    mitteilt, wie er bestimmte Protokolle/Kodierungen zu behandeln hat. So weiß
+    zum Beispiel der <literal>http</literal>-Wrapper, wie eine URL in eine
+    <literal>HTTP/1.0</literal>-Anfrage für eine Datei auf einem entfernten
+    Server zu übersetzen ist. PHP enthält standardmäßig viele Wrapper (siehe
+    <xref linkend="wrappers"/>), und es können entweder innerhalb eines
+    PHP-Skripts mittels <function>stream_wrapper_register</function> oder direkt
+    aus einer Erweiterung weitere, benutzerdefinierte Wrapper hinzugefügt
+    werden. Da PHP jede beliebige Art von Wrapper hinzugefügt werden kann, gibt
+    es keine feste Grenze für das, was mit ihnen getan werden kann. Um auf die
+    Liste der aktuell registrierten Wrapper zuzugreifen, ist
+    <function>stream_get_wrappers</function> zu verwenden.
+   </simpara>
+   <para>
+    Ein Stream wird referenziert als: <parameter>scheme</parameter>://<parameter>target</parameter>
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       <parameter>scheme</parameter> (string) -
+       Der Name des zu verwendenden Wrappers. Beispiele sind: file, http,
+       https, ftp, ftps, compress.zlib, compress.bz2 und php. Siehe
+       <xref linkend="wrappers"/> für eine Liste der in PHP integrierten
+       Wrapper. Wird kein Wrapper angegeben, wird der Standardwert der Funktion
+       verwendet (typischerweise <literal>file</literal>://).
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       <parameter>target</parameter> -
+       Hängt vom verwendeten Wrapper ab. Bei dateisystembezogenen Streams ist
+       dies typischerweise ein Pfad und der Dateiname der gewünschten Datei.
+       Bei netzwerkbezogenen Streams ist dies typischerweise ein Hostname, oft
+       mit einem angehängten Pfad. Siehe auch hier <xref linkend="wrappers"/>
+       für eine Beschreibung der Ziele integrierter Streams.
+      </simpara>
+     </listitem>
+    </itemizedlist>
+   </para>
+  </preface>
+
+ &reference.stream.setup;
+ &reference.stream.constants;
+ &reference.stream.filters;
+ &reference.stream.contexts;
+ &reference.stream.errors;
+ &reference.stream.examples;
+ &reference.stream.php-user-filter;
+ &reference.stream.streamwrapper;
+ &reference.stream.streambucket;
+ &reference.stream.reference;
+
+</book>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/stream/streambucket.xml
+++ b/reference/stream/streambucket.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 564bdc2db8f4c01ba36f64e24356756442b74bc5 Maintainer: lacatoire Status: ready -->
+<reference xml:id="class.streambucket" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>Die Klasse StreamBucket</title>
+ <titleabbrev>StreamBucket</titleabbrev>
+
+ <partintro>
+
+  <section xml:id="streambucket.intro">
+   &reftitle.intro;
+   <simpara>
+    Ein Stream-Bucket ist ein Teilstück eines Streams, das aus Bucket-Brigaden
+    extrahiert werden kann.
+   </simpara>
+  </section>
+
+  <section xml:id="streambucket.synopsis">
+   &reftitle.classsynopsis;
+
+   <classsynopsis class="class">
+    <ooclass>
+     <modifier>final</modifier>
+     <classname>StreamBucket</classname>
+    </ooclass>
+
+    <classsynopsisinfo role="comment">&Properties;</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>resource</type>
+     <varname linkend="streambucket.props.bucket">bucket</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>string</type>
+     <varname linkend="streambucket.props.data">data</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="streambucket.props.datalen">datalen</varname>
+    </fieldsynopsis>
+    <fieldsynopsis>
+     <modifier>public</modifier>
+     <modifier>readonly</modifier>
+     <type>int</type>
+     <varname linkend="streambucket.props.datalength">dataLength</varname>
+    </fieldsynopsis>
+   </classsynopsis>
+  </section>
+
+  <section xml:id="streambucket.props">
+   &reftitle.properties;
+   <variablelist>
+    <varlistentry xml:id="streambucket.props.bucket">
+     <term>resource <varname>bucket</varname></term>
+     <listitem>
+      <simpara>Eine <literal>userfilter.bucket</literal>-Ressource.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="streambucket.props.data">
+     <term>string <varname>data</varname></term>
+     <listitem>
+      <simpara>Die aktuelle Zeichenkette im Bucket.</simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="streambucket.props.datalen">
+     <term>int <varname>datalen</varname></term>
+     <listitem>
+      <simpara>
+       Die Länge der Zeichenkette im Bucket.
+       Seit PHP 8.4 zugunsten von <literal>StreamBucket::$dataLength</literal>
+       veraltet.
+      </simpara>
+     </listitem>
+    </varlistentry>
+    <varlistentry xml:id="streambucket.props.datalength">
+     <term>int <varname>dataLength</varname></term>
+     <listitem>
+      <simpara>Die Länge der Zeichenkette im Bucket.</simpara>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </section>
+
+  <section role="seealso">
+   &reftitle.seealso;
+   <simplelist>
+    <member><function>stream_bucket_new</function></member>
+    <member><function>stream_bucket_append</function></member>
+    <member><function>stream_bucket_prepend</function></member>
+    <member><function>stream_bucket_make_writeable</function></member>
+   </simplelist>
+  </section>
+
+ </partintro>
+
+</reference>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt zwei bislang fehlende Dateien der Stream-Erweiterung ins Deutsche.

Neu: die Klasse StreamBucket (streambucket.xml) sowie die Einbindung des
zugehörigen Eintrags in book.xml.

Fixes #332