### PR TITLE
[Sync EN] Document new pgsql functions added in PHP 8.4 (#5351)

### DIFF
--- a/reference/pgsql/functions/pg-change-password.xml
+++ b/reference/pgsql/functions/pg-change-password.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-change-password" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_change_password</refname>
+  <refpurpose>Ändert das Passwort eines PostgreSQL-Benutzers</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>pg_change_password</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>user</parameter></methodparam>
+   <methodparam><type>string</type><parameter>password</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_change_password</function> ändert das Passwort eines
+   PostgreSQL-Benutzers. Diese Funktion verwendet die libpq-Funktion
+   <literal>PQchangePassword</literal>, die die Verschlüsselung des
+   Passworts anhand der Servereinstellungen automatisch übernimmt.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>user</parameter></term>
+    <listitem>
+     <simpara>
+      Der Name des PostgreSQL-Benutzers, dessen Passwort geändert werden soll.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>password</parameter></term>
+    <listitem>
+     <simpara>
+      Das neue Passwort.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.success;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_connect</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-jit.xml
+++ b/reference/pgsql/functions/pg-jit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-jit" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_jit</refname>
+  <refpurpose>Gibt die JIT-Informationen des Servers zurück</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>array</type><methodname>pg_jit</methodname>
+   <methodparam choice="opt"><type class="union"><type>PgSql\Connection</type><type>null</type></type><parameter>connection</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   <function>pg_jit</function> gibt ein Array mit den JIT-Informationen
+   (Just-In-Time-Kompilierung) des PostgreSQL-Servers zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection-with-nullable-default;
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt ein &array; mit den JIT-Informationen des Servers zurück.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_version</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-data.xml
+++ b/reference/pgsql/functions/pg-put-copy-data.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-put-copy-data" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_data</refname>
+  <refpurpose>Sendet während einer COPY-Operation Daten an den Server</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_data</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam><type>string</type><parameter>cmd</parameter></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sendet während einer <literal>COPY FROM STDIN</literal>-Operation Daten
+   an den Server. Vor dem Aufruf dieser Funktion muss über
+   <function>pg_query</function> ein <literal>COPY</literal>-Befehl
+   abgesetzt worden sein.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>cmd</parameter></term>
+    <listitem>
+     <simpara>
+      Die an den Server zu sendenden Daten. Ein abschließender
+      Zeilenumbruch wird automatisch hinzugefügt, falls er nicht
+      vorhanden ist. Die Daten müssen gemäß dem Format des
+      <literal>COPY</literal>-Befehls formatiert sein.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg <literal>1</literal> zurück, <literal>0</literal>, wenn
+   die Daten nicht in die Warteschlange aufgenommen werden konnten (nur im
+   nicht-blockierenden Modus), oder <literal>-1</literal> bei einem Fehler.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_end</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-put-copy-end.xml
+++ b/reference/pgsql/functions/pg-put-copy-end.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-put-copy-end" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_put_copy_end</refname>
+  <refpurpose>Signalisiert dem Server den Abschluss einer COPY-Operation</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_put_copy_end</methodname>
+   <methodparam><type>PgSql\Connection</type><parameter>connection</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>error</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Sendet während einer <literal>COPY FROM STDIN</literal>-Operation eine
+   Anzeige über das Ende der Daten an den Server.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>connection</parameter></term>
+    <listitem>
+     &pgsql.parameter.connection;
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>error</parameter></term>
+    <listitem>
+     <simpara>
+      Ist dieser Parameter nicht &null;, so wird die
+      <literal>COPY</literal>-Operation mit der angegebenen
+      Fehlermeldung zum Scheitern gezwungen.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt bei Erfolg <literal>1</literal> zurück, <literal>0</literal>, wenn
+   die Daten nicht in die Warteschlange aufgenommen werden konnten (nur im
+   nicht-blockierenden Modus), oder <literal>-1</literal> bei einem Fehler.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_put_copy_data</function></member>
+   <member><function>pg_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/pgsql/functions/pg-socket-poll.xml
+++ b/reference/pgsql/functions/pg-socket-poll.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 491bd06bf430a9b0d9117a7b7c2c2b02a46ef84b Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.pg-socket-poll" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>pg_socket_poll</refname>
+  <refpurpose>Prüft einen PostgreSQL-Verbindungssocket auf Lese-/Schreibbereitschaft</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>int</type><methodname>pg_socket_poll</methodname>
+   <methodparam><type>resource</type><parameter>socket</parameter></methodparam>
+   <methodparam><type>int</type><parameter>read</parameter></methodparam>
+   <methodparam><type>int</type><parameter>write</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>timeout</parameter><initializer>-1</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Prüft einen PostgreSQL-Verbindungssocket auf Lese- und/oder
+   Schreibbereitschaft. Der Socket kann mit <function>pg_socket</function>
+   ermittelt werden. Diese Funktion ist nützlich, um nicht-blockierende,
+   asynchrone Abfrageabläufe umzusetzen.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>socket</parameter></term>
+    <listitem>
+     <simpara>
+      Eine mit <function>pg_socket</function> ermittelte Socket-Ressource.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>read</parameter></term>
+    <listitem>
+     <simpara>
+      Ob auf Lesebereitschaft geprüft werden soll. <literal>1</literal>
+      übergeben, um zu prüfen, <literal>0</literal>, um die Prüfung zu
+      überspringen.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>write</parameter></term>
+    <listitem>
+     <simpara>
+      Ob auf Schreibbereitschaft geprüft werden soll. <literal>1</literal>
+      übergeben, um zu prüfen, <literal>0</literal>, um die Prüfung zu
+      überspringen.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>timeout</parameter></term>
+    <listitem>
+     <simpara>
+      Die maximale Anzahl an Millisekunden, die gewartet werden soll.
+      <literal>-1</literal> übergeben, um unbegrenzt zu warten, oder
+      <literal>0</literal>, um überhaupt nicht zu warten.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Gibt einen positiven Wert zurück, wenn der Socket bereit ist,
+   <literal>0</literal>, wenn das Zeitlimit erreicht wurde, oder
+   <literal>-1</literal> bei einem Fehler.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><function>pg_socket</function></member>
+   <member><function>pg_consume_input</function></member>
+   <member><function>pg_send_query</function></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt fünf neue pgsql-Funktionsseiten (PHP 8.4): pg_change_password, pg_jit, pg_put_copy_data, pg_put_copy_end und pg_socket_poll.

Die XML-Struktur spiegelt die englische Vorlage Tag für Tag; nur der Dokumentationstext wurde übersetzt.

Fixes #334