### PR TITLE
[Sync EN] Document missing file mode element for descriptors (#5079)

### DIFF
--- a/reference/exec/functions/proc-open.xml
+++ b/reference/exec/functions/proc-open.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 6667724b8a42ba501172bc874dd1644a6744be0f Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: f50098447455250c9f92eed119248aaa30920100 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: c1f8c2ea33c70f59557175e1a43af7153b1df565 Reviewer: samesch -->
 <refentry xml:id="function.proc-open" xmlns="http://docbook.org/ns/docbook">
@@ -105,14 +104,15 @@
        <simplelist>
         <member>
          Ein Array, das die Pipe beschreibt, die an den Prozess übergeben
-         wird. Das erste Element ist der Descriptortyp, das zweite Element ist
-         eine Option für den angegebenen Typ. Gültige Typen sind
+         wird. Das erste Element ist der Descriptortyp, die folgenden Elemente
+         sind Optionen für den angegebenen Typ. Gültige Typen sind
          <literal>pipe</literal> (das zweite Element ist entweder
          <literal>r</literal>, um das Ende des Leseprozesses der Pipe an den
          Prozess zu übergeben, oder <literal>w</literal>, um das Ende des
          Schreibprozesses zu übergeben) und <literal>file</literal> (das
-         zweite Element ist ein Dateiname). Es ist zu beachten, dass alles
-         außer w wie r behandelt wird.
+         zweite Element ist ein Dateiname und das dritte Element ist der
+         Dateimodus, genau wie bei <function>fopen</function>). Es ist zu
+         beachten, dass alles außer w wie r behandelt wird.
         </member>
         <member>
          Eine Streamressource, die einen echten Filedescriptor repräsentiert


### PR DESCRIPTION
Synchronisierung mit dem Englischen in `reference/exec/functions/proc-open.xml`: Die Beschreibung des `file`-Descriptors erwähnt nun das dritte Element (den Dateimodus, wie bei fopen) und dass die folgenden Elemente Optionen sind.

Fixes #330