### PR TITLE
[Sync EN] Document IntlDateFormatter::parseToCalendar and Spoofchecker::setAllowedChars (PHP 8.4)

### DIFF
--- a/reference/intl/dateformatter/parsetocalendar.xml
+++ b/reference/intl/dateformatter/parsetocalendar.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="intldateformatter.parsetocalendar" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>IntlDateFormatter::parseToCalendar</refname>
+  <refpurpose>Analysiert eine Zeichenkette zu einem Zeitstempel und aktualisiert einen offenen Kalender</refpurpose>
+ </refnamediv>
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="IntlDateFormatter">
+   <modifier>public</modifier> <type class="union"><type>int</type><type>float</type><type>false</type></type><methodname>IntlDateFormatter::parseToCalendar</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter role="reference">offset</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Wandelt <parameter>string</parameter> in einen inkrementellen Zeitwert um, beginnend bei
+   <parameter>offset</parameter>, und verbraucht dabei so viel von der Eingabe wie möglich.
+  </simpara>
+  <simpara>
+   Diese Methode verhält sich wie <methodname>IntlDateFormatter::parse</methodname>, mit dem
+   Unterschied, dass die Zeitzone des Formatierers entsprechend den Zeitzonen-Informationen
+   aktualisiert wird, die in der analysierten Zeichenkette <parameter>string</parameter> enthalten sind.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>string</parameter></term>
+    <listitem>
+     <simpara>
+      Die in eine Zeit umzuwandelnde Zeichenkette.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>offset</parameter></term>
+    <listitem>
+     <simpara>
+      Die Position in <parameter>string</parameter>, an der die Analyse beginnen soll (nullbasiert).
+      Tritt kein Fehler auf, bevor <parameter>string</parameter> vollständig verbraucht wurde,
+      enthält <parameter>offset</parameter> den Wert -1, andernfalls die Position, an der die
+      Analyse endete (und der Fehler auftrat).
+      Diese Variable enthält die Endposition, wenn die Analyse fehlschlägt.
+      Wenn <parameter>offset</parameter> &gt; <code>strlen($string)</code> ist, schlägt die Analyse sofort fehl.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   Den Zeitstempel des analysierten Werts oder &false;, wenn der Wert nicht analysiert werden kann.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <methodname>IntlDateFormatter::parseToCalendar</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$fmt = new IntlDateFormatter(
+    'en_US',
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    'America/Los_Angeles',
+    IntlDateFormatter::GREGORIAN
+);
+echo $fmt->parseToCalendar('Wednesday, December 20, 1989 at 4:00:00 PM Pacific Standard Time');
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+630201600
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>IntlDateFormatter::parse</methodname></member>
+   <member><methodname>IntlDateFormatter::format</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorCode</methodname></member>
+   <member><methodname>IntlDateFormatter::getErrorMessage</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/intl/spoofchecker/setallowedchars.xml
+++ b/reference/intl/spoofchecker/setallowedchars.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 20687bf9c58232244e41272d118b98ef4af16a69 Maintainer: lacatoire Status: ready -->
+<refentry xml:id="spoofchecker.setallowedchars" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>Spoofchecker::setAllowedChars</refname>
+  <refpurpose>Legt die Menge der bei Prüfungen erlaubten Zeichen fest</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="Spoofchecker">
+   <modifier>public</modifier> <type>void</type><methodname>Spoofchecker::setAllowedChars</methodname>
+   <methodparam><type>string</type><parameter>pattern</parameter></methodparam>
+   <methodparam choice="opt"><type>int</type><parameter>patternOptions</parameter><initializer>0</initializer></methodparam>
+  </methodsynopsis>
+  <simpara>
+   Beschränkt die Zeichen, die bei nachfolgenden Prüfungen als zulässig gelten, auf die
+   durch <parameter>pattern</parameter> beschriebene Menge. Jedes Zeichen außerhalb dieser
+   Menge führt dazu, dass <methodname>Spoofchecker::isSuspicious</methodname> ein Ergebnis meldet.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <variablelist>
+   <varlistentry>
+    <term><parameter>pattern</parameter></term>
+    <listitem>
+     <simpara>
+      Eine als <literal>UnicodeSet</literal>-Muster beschriebene Zeichenmenge, also eine
+      Zeichenklasse im Stil eines regulären Ausdrucks. Sie muss mit <literal>[</literal>
+      beginnen und mit <literal>]</literal> enden, zum Beispiel <literal>[a-z0-9]</literal>.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>patternOptions</parameter></term>
+    <listitem>
+     <simpara>
+      Eine Bitmaske, die steuert, wie <parameter>pattern</parameter> interpretiert wird. Sie muss
+      <literal>0</literal> oder <constant>Spoofchecker::IGNORE_SPACE</constant> für sich allein
+      oder kombiniert mit genau einer der Konstanten <constant>Spoofchecker::CASE_INSENSITIVE</constant>,
+      <constant>Spoofchecker::ADD_CASE_MAPPINGS</constant> oder
+      <constant>Spoofchecker::SIMPLE_CASE_INSENSITIVE</constant> sein.
+     </simpara>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <simpara>
+   &return.void;
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simpara>
+   Löst einen <exceptionname>ValueError</exceptionname> aus, wenn <parameter>pattern</parameter>
+   kein gültiges Zeichenmengen-Muster ist oder wenn <parameter>patternOptions</parameter> keine
+   gültige Kombination von Optionen ist.
+  </simpara>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <example>
+   <title>Beispiel für <methodname>Spoofchecker::setAllowedChars</methodname></title>
+   <programlisting role="php">
+<![CDATA[
+<?php
+$checker = new Spoofchecker();
+$checker->setAllowedChars('[a-z0-9]');
+
+var_dump($checker->isSuspicious('hello'));
+var_dump($checker->isSuspicious('héllo'));
+?>
+]]>
+   </programlisting>
+   &example.outputs;
+   <screen>
+<![CDATA[
+bool(false)
+bool(true)
+]]>
+   </screen>
+  </example>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>Spoofchecker::setAllowedLocales</methodname></member>
+   <member><methodname>Spoofchecker::isSuspicious</methodname></member>
+  </simplelist>
+ </refsect1>
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Übersetzt die beiden neuen EN-Seiten für PHP 8.4 ins Deutsche.

Neu angelegt: `reference/intl/dateformatter/parsetocalendar.xml` und `reference/intl/spoofchecker/setallowedchars.xml`, jeweils als Spiegelung der EN-Struktur Tag für Tag.

Fixes #338