### PR TITLE
[Sync EN] Add PHP 8.4.0 changelog entries for Session and LDAP pages

### DIFF
--- a/reference/ldap/functions/ldap-connect.xml
+++ b/reference/ldap/functions/ldap-connect.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 57c38af2b053068ad0f1dfdead8128b957ccf4f0 Maintainer: simp Status: ready -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: simp Status: ready -->
 <refentry xml:id="function.ldap-connect" xmlns="http://docbook.org/ns/docbook">
  <refnamediv>
   <refname>ldap_connect</refname>
@@ -109,6 +108,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Der Aufruf von <function>ldap_connect</function> mit mehr als
+       zwei Argumenten ist nun veraltet.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>

--- a/reference/session/functions/session-set-save-handler.xml
+++ b/reference/session/functions/session-set-save-handler.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 184f3f7bd45643cb80f828d0bb001991ec3a5fad Maintainer: samesch Status: ready -->
+<!-- EN-Revision: ca23605a1c0e46b9ec85975c6387528c32a7087f Maintainer: samesch Status: ready -->
 <!-- Reviewed: yes Maintainer: samesch -->
 <refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.session-set-save-handler" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -306,6 +305,30 @@
   <para>
    &return.success;
   </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <informaltable>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>&Version;</entry>
+      <entry>&Description;</entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Der Aufruf von <function>session_set_save_handler</function> mit mehr
+       als zwei Argumenten ist nun veraltet.
+       Stattdessen sollte die Signatur mit zwei Argumenten verwendet werden.
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </informaltable>
  </refsect1>
 
  <refsect1 role="examples">


### PR DESCRIPTION
Synchronisiert die Changelog-Tabellen von ldap_connect und session_set_save_handler mit dem englischen Stand.

Beide Funktionen erhalten einen 8.4.0-Eintrag: Der Aufruf mit mehr als zwei Argumenten ist nun veraltet. EN-Revision aktualisiert, toter $Revision$-Marker entfernt.

Fixes #337