### PR TITLE
[Sync EN] datetime: PHP 8.4 tentative return types and DatePeriod::__construct deprecation

### DIFF
--- a/reference/datetime/dateperiod/construct.xml
+++ b/reference/datetime/dateperiod/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 0cf48a5a4869bd8b42f84e7032076756cde6a474 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: e2c7b3635d5353c05c248c29038bf9d5b7133d6e Reviewer: samesch -->
 
@@ -35,9 +35,8 @@
     <methodparam choice="opt"><type>int</type><parameter>options</parameter><initializer>0</initializer></methodparam>
    </constructorsynopsis>
    <simpara>
-    Stattdessen sollte
-    <methodname>DatePeriod::createFromISO8601String</methodname> verwendet
-    werden.
+    Diese Konstruktorvariante ist seit PHP 8.4.0 veraltet; stattdessen sollte
+    <methodname>DatePeriod::createFromISO8601String</methodname> verwendet werden.
    </simpara>
   </warning>
   <para>
@@ -170,6 +169,14 @@
       </row>
      </thead>
      <tbody>
+      <row>
+       <entry>8.4.0</entry>
+       <entry>
+        Die Signatur mit <parameter>isostr</parameter> ist veraltet, stattdessen
+        sollte <methodname>DatePeriod::createFromISO8601String</methodname>
+        verwendet werden.
+       </entry>
+      </row>
       <row>
        <entry>8.3.0</entry>
        <entry>

--- a/reference/datetime/datetime/modify.xml
+++ b/reference/datetime/datetime/modify.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3a8c3e77df070a046c9d5b56b68926ca2d7e5ee3 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 9eb962113cadccc164d196003062ff5d893de3a5 Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: bbfdc364de79d739aeccc611ef82111e7f15b4da Reviewer: samesch -->
 <!-- CREDITS: Stefan Schenke -->
@@ -70,6 +70,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Hat nun einen vorläufigen Rückgabetyp von <type>DateTime</type>.
+       Zuvor war es <type class="union"><type>DateTime</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
Synchronisiert die Änderungen aus ext/date für PHP 8.4.

Ergänzt die vorläufigen Rückgabetypen für DateInterval::createFromDateString, DateTime::modify und DateTimeImmutable::modify sowie die Veraltung der isostr-Signatur von DatePeriod::__construct.

Fixes #341