### PR TITLE
[Sync EN] Document missing PHP 8.4.0 constants and deprecations

### DIFF
--- a/reference/ldap/constants.xml
+++ b/reference/ldap/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: 26c2246aacfdbf8a40cc2ceccc71c6d878571120 Maintainer: hholzgra Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: hholzgra Status: ready -->
 <appendix xml:id="ldap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  &reftitle.constants;
  &extension.constants;
@@ -386,12 +385,31 @@
    </term>
    <listitem>
     <simpara>
-     Gibt die Mindestprotokolversion an. Entweder
+     Gibt die Mindestprotokollversion an. Entweder
      <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,
      <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>,
      <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>,
-     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant> oder
-     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant>.
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant> oder
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-max">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Gibt die maximale Protokollversion an. Entweder
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL2</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_SSL3</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_0</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_1</constant>,
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_2</constant> oder
+     <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>.
+     Verfügbar ab PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -1202,6 +1220,18 @@
    <listitem>
     <simpara>
      Das TLS-1.2-Protokoll.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.ldap-opt-x-tls-protocol-tls1-3">
+   <term>
+    <constant>LDAP_OPT_X_TLS_PROTOCOL_TLS1_3</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Das TLS-1.3-Protokoll.
+     Verfügbar ab PHP 8.4.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/openssl/constants.xml
+++ b/reference/openssl/constants.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 3b06ef4bb06db8cf2cd8ea8470287f7f43ef9e71 Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: eec6a4a36bf452bf271f116e7b6b9bb09d1181c3 Reviewer: samesch -->
 <appendix xml:id="openssl.constants" xmlns="http://docbook.org/ns/docbook">
@@ -82,6 +82,30 @@
     <listitem>
      <simpara>
 
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.x509-purpose-ocsp-helper">
+    <term>
+     <constant>X509_PURPOSE_OCSP_HELPER</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Prüft das Zertifikat zur Verwendung als OCSP-Responder-Helfer.
+      Verfügbar ab PHP 8.4.0.
+     </simpara>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="constant.x509-purpose-timestamp-sign">
+    <term>
+     <constant>X509_PURPOSE_TIMESTAMP_SIGN</constant>
+     (<type>int</type>)
+    </term>
+    <listitem>
+     <simpara>
+      Prüft das Zertifikat zur Verwendung als vertrauenswürdiger Zeitstempel-Signierer.
+      Verfügbar ab PHP 8.4.0.
      </simpara>
     </listitem>
    </varlistentry>

--- a/reference/session/constants.xml
+++ b/reference/session/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: samesch Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <appendix xml:id="session.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -20,6 +19,11 @@
      dieselbe ID, die auch von <function>session_id</function> zurückgegeben
      wird.
     </simpara>
+    <warning>
+     <simpara>
+      Diese Konstante ist seit PHP 8.4.0 veraltet.
+     </simpara>
+    </warning>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.php-session-disabled">

--- a/reference/soap/constants.xml
+++ b/reference/soap/constants.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: f309e78f9439ae5d063a284cefb4b375233aa785 Maintainer: sammywg Status: ready -->
+<!-- EN-Revision: 7c4e8d8219e9a65553cfc378bb46405bf6b2ed53 Maintainer: sammywg Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: a0ae28d3bc85f927c22649ebd9a590b921534b7d Reviewer: samesch -->
 <appendix xml:id="soap.constants" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -65,7 +64,9 @@
       (<type>int</type>)
      </entry>
      <entry>999</entry>
-     <entry/>
+     <entry>
+      Seit PHP 8.4.0 veraltet.
+     </entry>
     </row>
     <row xml:id="constant.soap-encoded">
      <entry>


### PR DESCRIPTION
Synchronisiert die deutschen Konstanten-Dateien mit dem englischen Stand.

LDAP: neue Konstanten LDAP_OPT_X_TLS_PROTOCOL_MAX und LDAP_OPT_X_TLS_PROTOCOL_TLS1_3, MIN-Eintrag um TLS1_3 ergänzt. OpenSSL: X509_PURPOSE_OCSP_HELPER und X509_PURPOSE_TIMESTAMP_SIGN. Session: Veraltungshinweis für SID. SOAP: Veraltungshinweis für SOAP_FUNCTIONS_ALL.

Fixes #336