### PR TITLE
[Sync EN] reflection: Delete outdated paragraph in hasreturntype.xml

### DIFF
--- a/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
+++ b/reference/reflection/reflectionfunctionabstract/hasreturntype.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: c3485c8f1c57caa8ea0fc2924050a175bbc7686d Maintainer: lacatoire Status: ready -->
+<refentry xml:id="reflectionfunctionabstract.hasreturntype" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>ReflectionFunctionAbstract::hasReturnType</refname>
+  <refpurpose>Prüft, ob die Funktion einen angegebenen Rückgabetyp hat</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis role="ReflectionFunctionAbstract">
+   <modifier>public</modifier> <type>bool</type><methodname>ReflectionFunctionAbstract::hasReturnType</methodname>
+   <void/>
+  </methodsynopsis>
+  <para>
+   Prüft, ob für die untersuchte Funktion ein Rückgabetyp angegeben ist.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Gibt &true; zurück, wenn die Funktion einen angegebenen Rückgabetyp hat,
+   andernfalls &false;.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title><methodname>ReflectionFunctionAbstract::hasReturnType</methodname>-Beispiel</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+function to_int($param): int
+{
+    return (int) $param;
+}
+
+$reflection1 = new ReflectionFunction('to_int');
+var_dump($reflection1->hasReturnType());
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(true)
+]]>
+    </screen>
+   </example>
+
+   <example>
+    <title>Verwendung bei eingebauten Funktionen</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$reflection2 = new ReflectionFunction('array_merge');
+
+var_dump($reflection2->hasReturnType());
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+bool(false)
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><methodname>ReflectionFunctionAbstract::getReturnType</methodname></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Synchronisiert reflectionfunctionabstract/hasreturntype.xml mit dem EN-Stand.
Die deutsche Übersetzung wird neu angelegt: das to_int-Beispiel ist an die
neue Code-Formatierung angepasst und der veraltete Absatz zu eingebauten
Funktionen entfällt.

Fixes #346