### PR TITLE
[Sync EN] Fix changelog row markup in DateInterval::createFromDateString

### DIFF
--- a/reference/datetime/dateinterval/createfromdatestring.xml
+++ b/reference/datetime/dateinterval/createfromdatestring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: c0c9d7721b5a8564a4e27671389a456c1be13e6b Maintainer: cmb Status: ready -->
+<!-- EN-Revision: 82f00c8d4d4f09fa5a363bc0c6f48e0c80eea72d Maintainer: cmb Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: 4586854a24b1ca532b5c9ba2410db1f1eee338ed Reviewer: samesch -->
 <!-- CREDITS: Yannic Schnetz -->
@@ -83,6 +83,13 @@
      </row>
     </thead>
     <tbody>
+     <row>
+      <entry>8.4.0</entry>
+      <entry>
+       Hat nun einen vorläufigen Rückgabetyp von <type>DateInterval</type>.
+       Zuvor war es <type class="union"><type>DateInterval</type><type>false</type></type>.
+      </entry>
+     </row>
      <row>
       <entry>8.3.0</entry>
       <entry>


### PR DESCRIPTION
Synchronisiert die Changelog-Tabelle in DateInterval::createFromDateString mit dem aktuellen EN-Stand.

Der 8.4.0-Eintrag (vorläufiger Rückgabetyp) wird als eigene Zeile ergänzt, getrennt vom 8.3.0-Eintrag, entsprechend dem korrigierten Markup.

Fixes #342