### PR TITLE
[Sync EN] ldap: list LDAP_OPT_X_TLS_PROTOCOL_MAX in get/set option tables

### DIFF
--- a/reference/ldap/functions/ldap-get-option.xml
+++ b/reference/ldap/functions/ldap-get-option.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ -->
-<!-- EN-Revision: aa120f36c5762e99f9ee121d8caf910e0a67121e Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: bc90525a5a5ebcf8412ef34b8355d2de12166fff Reviewer: samesch -->
 <refentry xml:id="function.ldap-get-option" xmlns="http://docbook.org/ns/docbook">
@@ -200,6 +199,11 @@
            <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MIN</constant></entry>
            <entry><type>int</type></entry>
            <entry>7.1</entry>
+          </row>
+          <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>8.4</entry>
           </row>
           <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>

--- a/reference/ldap/functions/ldap-set-option.xml
+++ b/reference/ldap/functions/ldap-set-option.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 85d9a34e16732043af52954a069a020b8c30ec50 Maintainer: nobody Status: ready -->
+<!-- EN-Revision: 5b3a84935252a553528cb81b3dacb88647b57c7b Maintainer: nobody Status: ready -->
 <!-- Reviewed: yes -->
 <!-- Rev-Revision: bc90525a5a5ebcf8412ef34b8355d2de12166fff Reviewer: samesch -->
 <refentry xml:id="function.ldap-set-option" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -180,6 +180,11 @@
            <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MIN</constant></entry>
            <entry><type>int</type></entry>
            <entry>PHP 7.1.0</entry>
+          </row>
+          <row>
+           <entry><constant>LDAP_OPT_X_TLS_PROTOCOL_MAX</constant></entry>
+           <entry><type>int</type></entry>
+           <entry>PHP 8.4.0</entry>
           </row>
           <row>
            <entry><constant>LDAP_OPT_X_TLS_RANDOM_FILE</constant></entry>


### PR DESCRIPTION
Ergänzt die Zeile für `LDAP_OPT_X_TLS_PROTOCOL_MAX` (int, 8.4) in den Optionstabellen von `ldap_get_option` und `ldap_set_option`, synchron mit dem Englischen. Die zugehörigen Konstantendefinitionen werden in einem separaten Sync ergänzt.

Fixes #335