### PR TITLE
[Sync EN] ReturnTypeWillChange: Add warning about future strict return type

### DIFF
--- a/language/predefined/attributes/returntypewillchange.xml
+++ b/language/predefined/attributes/returntypewillchange.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 77325b622f91355b118e8f3bc9ff940e8201f55d Maintainer: samesch Status: ready -->
+<!-- EN-Revision: 0019a7e201442447fd746c2852d28ba839ed15ae Maintainer: samesch Status: ready -->
 <!-- Reviewed: no -->
 <reference xml:id="class.returntypewillchange" role="class" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
  <title>Das Attribut ReturnTypeWillChange</title>
@@ -9,16 +9,33 @@
 
   <section xml:id="returntypewillchange.intro">
    &reftitle.intro;
-   <para>
+   <simpara>
     Bei den meisten nicht-finalen internen Methoden müssen überschreibende
     Methoden nun einen kompatiblen Rückgabetyp deklarieren, andernfalls wird
     bei der Validierung der Vererbung ein entsprechender Hinweis auf eine
-    veraltete Verwendung (DEPRECATED) ausgegeben. Für den Fall, dass der
-    Rückgabetyp aufgrund von Kompatibilitätsproblemen mit anderen
-    PHP-Versionen für eine überschreibende Methode nicht deklariert werden
-    kann, kann das Attribut <code>#[\ReturnTypeWillChange]</code> hinzugefügt
-    werden, um den Warnhinweis über die veraltete Technik zu unterdrücken.
-   </para>
+    veraltete Verwendung (DEPRECATED) ausgegeben. Dadurch wird eine Phase mit
+    vorläufigem Rückgabetyp eingeführt: Die Engine gibt einen
+    Veraltungshinweis statt eines schwerwiegenden Fehlers aus, wenn die
+    Rückgabetypen inkompatibel sind, bevor diese in einer zukünftigen Version
+    erzwungen werden. Für den Fall, dass der Rückgabetyp aufgrund von
+    Kompatibilitätsproblemen mit anderen PHP-Versionen für eine
+    überschreibende Methode nicht deklariert werden kann, kann das Attribut
+    <code>#[\ReturnTypeWillChange]</code> hinzugefügt werden, um den
+    Warnhinweis über die veraltete Technik zu unterdrücken.
+   </simpara>
+
+   <warning>
+    <simpara>
+     Das Attribut <classname>ReturnTypeWillChange</classname> unterdrückt
+     Veraltungswarnungen <emphasis>nur</emphasis> während der Phase mit
+     vorläufigem Rückgabetyp. Es hat keine Wirkung beim Überschreiben von
+     Methoden, die in benutzerdefinierten Klassen definiert sind. Sobald
+     interne Methoden strikte Typen übernehmen, führen Abweichungen in den
+     Signaturen überschreibender Methoden zu einem schwerwiegenden Fehler,
+     und dieses Attribut hat dann keine Wirkung mehr.
+    </simpara>
+   </warning>
+
   </section>
 
   <section xml:id="returntypewillchange.synopsis">


### PR DESCRIPTION
Ergänzt die Warnung zum künftigen strikten Rückgabetyp und wandelt den Einleitungsabsatz in simpara um, synchron mit dem Englischen.

Fixes #344